### PR TITLE
GH#30059: reconcile authorized aggregate release receipts

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -29,6 +29,7 @@ _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RELEASE_SUPERSEDED="superseded"
 _FULL_LOOP_RELEASE_STRICT="strict"
 _FULL_LOOP_RELEASE_RECONCILE_PUBLISHED="published-reconcile"
+_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED="authorized-published-reconcile"
 _FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT="receipt-conflict"
 _FULL_LOOP_RELEASE_ROLE_AGGREGATED="aggregated"
 _FULL_LOOP_SHA40_REGEX='^[0-9a-f]{40}$'
@@ -625,7 +626,8 @@ _full_loop_validate_release_candidates() {
 		'[{pr:.source_pr,merge:.source_merge,role:"source"}]
 		+ [.aggregated_sources[] | {pr,merge,role:$aggregate_role}]
 		| .[] | [.pr,.merge,.role] | @tsv' <<<"$source_json") || return 1
-	if [[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]]; then
+	if [[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+		"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]]; then
 		[[ "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
 	elif [[ "$mode" != "$_FULL_LOOP_RELEASE_STRICT" ]]; then
 		return 1
@@ -638,7 +640,9 @@ _full_loop_validate_release_candidates() {
 		"" | "$_FULL_LOOP_PHASE_FAILED") ;;
 		"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
 			[[ "$mode" == "$_FULL_LOOP_RELEASE_STRICT" ||
-				("$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED") ]] || {
+				(("$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+					"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED") &&
+					"$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED") ]] || {
 				printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
 				return 1
 			}
@@ -650,12 +654,16 @@ _full_loop_validate_release_candidates() {
 			fi
 			;;
 		"$_FULL_LOOP_RELEASE_SUPERSEDED")
-			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED" ]] || return 1
+			[[ ( "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+				"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ) &&
+				"$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED" ]] || return 1
 			_full_loop_release_candidate_evidence_matches "$repo" "$candidate_pr" "$candidate_merge" \
 				"$source_pr" "$source_merge" "$tag_name" "$tag_commit" aggregate || return 1
 			;;
 		"$_FULL_LOOP_RELEASE_PUBLISHED")
-			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "source" ]] || return 1
+			[[ ( "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+				"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ) &&
+				"$candidate_role" == "source" ]] || return 1
 			;;
 		*)
 			printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
@@ -695,7 +703,8 @@ _full_loop_persist_release_success() {
 				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
 			;;
 		"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
-			if [[ "$mode" == "$_FULL_LOOP_RELEASE_STRICT" ]]; then
+			if [[ "$mode" == "$_FULL_LOOP_RELEASE_STRICT" ||
+				"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]]; then
 				_full_loop_write_superseded_release_receipt "$repo" "$aggregated_pr" "$aggregated_merge" \
 					"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
 			else
@@ -704,7 +713,8 @@ _full_loop_persist_release_success() {
 			fi
 			;;
 		"$_FULL_LOOP_RELEASE_SUPERSEDED")
-			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+				"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]] || return 1
 			_full_loop_release_candidate_evidence_matches "$repo" "$aggregated_pr" "$aggregated_merge" \
 				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" aggregate || return 1
 			_full_loop_update_superseded_cleanup_receipt "$repo" "$aggregated_pr" || return 1
@@ -724,7 +734,8 @@ _full_loop_persist_release_success() {
 		full_loop_update_cleanup_release_status "$repo" "$release_source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED" || return 1
 		;;
 	"$_FULL_LOOP_RELEASE_PUBLISHED")
-		[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+		[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ||
+			"$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]] || return 1
 		;;
 	*) return 1 ;;
 	esac

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -789,7 +789,8 @@ _full_loop_release_validate_published_reconciliation_intent() {
 	persisted_sources=$(_full_loop_read_release_authorization "$repo" "$requested_pr") || return 1
 	persisted_json=$(release_authorization_manifest_json "$persisted_sources") || return 1
 	observed_json=$(release_authorization_observed_sources_json "$persisted_json" "$source_json") || return 1
-	observed_sources=$(jq -r 'sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")' <<<"$observed_json") || return 1
+	observed_sources=$(jq -r 'sort_by(.pr) | map([.pr, .merge] | join("@")) | join(",")' \
+		<<<"$observed_json") || return 1
 	release_authorization_compare "$persisted_sources" "$observed_sources" || return 1
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" --arg expected "$persisted_sources" '

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -774,6 +774,33 @@ _full_loop_release_reset_tag_worktree() {
 	return 0
 }
 
+_full_loop_release_validate_published_reconciliation_intent() {
+	local repo="$1"
+	local requested_pr="$2"
+	local tag_name="$3"
+	local source_json="$4"
+	local persisted_sources=""
+	local persisted_json=""
+	local observed_json=""
+	local observed_sources=""
+
+	[[ "$requested_pr" =~ ^[0-9]+$ && "$tag_name" =~ $_FULL_LOOP_RELEASE_VERSION_TAG_REGEX ]] || return 1
+	declare -F release_lane_read >/dev/null 2>&1 || return 1
+	persisted_sources=$(_full_loop_read_release_authorization "$repo" "$requested_pr") || return 1
+	persisted_json=$(release_authorization_manifest_json "$persisted_sources") || return 1
+	observed_json=$(release_authorization_observed_sources_json "$persisted_json" "$source_json") || return 1
+	observed_sources=$(jq -r 'sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")' <<<"$observed_json") || return 1
+	release_authorization_compare "$persisted_sources" "$observed_sources" || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" --arg expected "$persisted_sources" '
+		.active == true and .source_pr == $source_pr and .tag == $tag_name
+		and .expected_sources == $expected
+		and (.phase == "remote-publication" or .phase == "exact-tag-deployment")
+		and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	return 0
+}
+
 _full_loop_release_finalize_reconciliation() {
 	local repo="$1"
 	local requested_pr="$2"
@@ -793,8 +820,10 @@ _full_loop_release_finalize_reconciliation() {
 		'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
 	[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || return 1
 	tag_commit=$(_full_loop_release_resolve_tag_commit "$tag_name") || return 1
+	_full_loop_release_validate_published_reconciliation_intent \
+		"$repo" "$requested_pr" "$tag_name" "$source_json" || return 1
 	_full_loop_validate_release_candidates "$repo" "$source_json" \
-		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" "$tag_name" "$tag_commit" || return 1
+		"$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" "$tag_name" "$tag_commit" || return 1
 	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
 	if declare -F release_lane_update_if_owned >/dev/null 2>&1; then
 		release_lane_update_if_owned "$repo" "$requested_pr" "exact-tag-deployment" "$tag_name" || return 1
@@ -814,7 +843,7 @@ _full_loop_release_finalize_reconciliation() {
 			bash "$version_manager" post-release
 	) || return 1
 	_full_loop_persist_release_success "$repo" "$_FULL_LOOP_RELEASE_PATH" "$source_json" \
-		"$source_pr" "$source_merge" "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED"
+		"$source_pr" "$source_merge" "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -13,12 +13,15 @@ _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RELEASE_SUPERSEDED="superseded"
 _FULL_LOOP_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RELEASE_RECONCILE_PUBLISHED="published-reconcile"
+_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED="authorized-published-reconcile"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/receipts"
 
 # shellcheck source=../full-loop-release-reconcile.sh
 source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
+# shellcheck source=../release-authorization-manifest-helper.sh
+source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 
 stale_publication_jobs_fixture() {
 	local mode="${1:-valid}"
@@ -286,6 +289,18 @@ printf 'PASS historical authorization gaps use idempotent detached production ev
 		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED"
 	cmp -s "$conflict_receipt" "${TEST_ROOT}/receipt-conflict-original.status"
 	cmp -s "$conflict_evidence" "${TEST_ROOT}/receipt-conflict-original.json"
+	_full_loop_validate_release_candidates test/repo "$conflict_source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" v1.2.5 "$conflict_tag_commit"
+	_full_loop_persist_release_success test/repo "$conflict_release_path" "$conflict_source_json" \
+		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED"
+	grep -qx "$_FULL_LOOP_RELEASE_SUPERSEDED" "$conflict_receipt"
+	jq -e --arg tag_commit "$conflict_tag_commit" '
+		.status == "superseded" and .pr_number == 89 and .aggregate_pr == 90
+		and .release_commit == $tag_commit
+	' "${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-89.aggregate.json" >/dev/null
+	_full_loop_persist_release_success test/repo "$conflict_release_path" "$conflict_source_json" \
+		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED"
+	grep -qx "$_FULL_LOOP_RELEASE_SUPERSEDED" "$conflict_receipt"
 	conflicting_source_json=$(jq '.aggregated_sources[0].merge = "5555555555555555555555555555555555555555"' \
 		<<<"$conflict_source_json")
 	if _full_loop_validate_release_candidates test/repo "$conflicting_source_json" \
@@ -294,7 +309,7 @@ printf 'PASS historical authorization gaps use idempotent detached production ev
 		exit 1
 	fi
 )
-printf 'PASS published aggregate reconciliation preserves terminal no-release receipts\n'
+printf 'PASS published aggregate reconciliation repairs only authorization-bound terminal no-release receipts\n'
 
 (
 	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="${TEST_ROOT}/future-release-receipts"
@@ -585,9 +600,22 @@ _full_loop_validate_release_candidates() {
 	local mode="$3"
 	local tag_name="$4"
 	local tag_commit="$5"
-	[[ -n "$repo" && -n "$source_json" && "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+	[[ -n "$repo" && -n "$source_json" && "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]] || return 1
 	[[ "$tag_name" == "v1.2.3" && "$tag_commit" == "3333333333333333333333333333333333333333" ]]
 	return $?
+}
+_full_loop_read_release_authorization() {
+	local repo="$1"
+	local requested_pr="$2"
+	[[ "$repo" == "test/repo" && "$requested_pr" == "90" ]] || return 1
+	printf '%s\n' '90@1111111111111111111111111111111111111111'
+	return 0
+}
+release_lane_read() {
+	local repo="$1"
+	[[ "$repo" == "test/repo" ]] || return 1
+	_AIDEVOPS_RELEASE_LANE_JSON='{"active":true,"source_pr":90,"expected_sources":"90@1111111111111111111111111111111111111111","phase":"remote-publication","tag":"v1.2.3","terminal_receipt":null}'
+	return 0
 }
 _full_loop_release_resolve_tag_commit() {
 	local tag_name="$1"
@@ -602,7 +630,7 @@ _full_loop_persist_release_success() {
 	local source_pr="$4"
 	local source_merge="$5"
 	local mode="$6"
-	[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+	[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED" ]] || return 1
 	printf '%s|%s|%s|%s|%s|%s\n' \
 		"$repo" "$release_path" "$source_json" "$source_pr" "$source_merge" "$mode" \
 		>"$FAKE_PERSIST_LOG"


### PR DESCRIPTION
Resolves #30059

Draft checkpoint: authorization-bound asynchronous receipt reconciliation is implemented; targeted release reconciliation tests pass. Full release suites and linters remain in progress.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.252 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra
