### PR TITLE
GH#29973: allow read-only hash-object in canonical checkouts

### DIFF
--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -91,10 +91,47 @@ def _bundle_is_read_only(args: list[str]) -> bool:
     return len(paths) == 1 and not paths[0].startswith("-")
 
 
+def _hash_object_is_read_only(args: list[str]) -> bool:
+    """Allow hashing inputs while rejecting object database writes."""
+    value_options = {"-t"}
+    read_only_options = {
+        "--literally",
+        "--no-filters",
+        "--stdin",
+        "--stdin-paths",
+    }
+    expect_value = False
+    options_ended = False
+
+    for arg in args:
+        if options_ended:
+            continue
+        if expect_value:
+            expect_value = False
+            continue
+        if arg == "--":
+            options_ended = True
+            continue
+        if arg == "-w" or (
+            arg.startswith("-") and not arg.startswith("--") and "w" in arg[1:]
+        ):
+            return False
+        if arg in value_options:
+            expect_value = True
+            continue
+        if arg in read_only_options or arg.startswith("--path="):
+            continue
+        if arg.startswith("-"):
+            return False
+
+    return not expect_value
+
+
 CANONICAL_CHECKS: dict[str, Callable[[list[str]], bool]] = {
     "branch": _branch_is_read_only,
     "bundle": _bundle_is_read_only,
     "config": _config_is_read_only,
     "clean": _clean_is_read_only,
+    "hash-object": _hash_object_is_read_only,
     **REF_QUERY_CHECKS,
 }

--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -97,36 +97,39 @@ def _is_hash_object_write_flag(arg: str) -> bool:
     )
 
 
-def _hash_object_is_read_only(args: list[str]) -> bool:
-    """Allow hashing inputs while rejecting object database writes."""
+def _hash_object_options(args: list[str]) -> list[str]:
+    try:
+        return args[: args.index("--")]
+    except ValueError:
+        return args
+
+
+def _is_unknown_hash_object_option(arg: str) -> bool:
     read_only_options = {
         "--literally",
         "--no-filters",
         "--stdin",
         "--stdin-paths",
     }
-    expect_value = False
-    options_ended = False
+    return (
+        arg.startswith("-")
+        and arg not in read_only_options
+        and not arg.startswith("--path=")
+    )
 
-    for arg in args:
-        if options_ended:
-            continue
+
+def _hash_object_is_read_only(args: list[str]) -> bool:
+    """Allow hashing inputs while rejecting object database writes."""
+    expect_value = False
+
+    for arg in _hash_object_options(args):
         if expect_value:
             expect_value = False
             continue
-        if arg == "--":
-            options_ended = True
-            continue
-        if _is_hash_object_write_flag(arg):
-            return False
         if arg == "-t":
             expect_value = True
             continue
-        if (
-            arg.startswith("-")
-            and arg not in read_only_options
-            and not arg.startswith("--path=")
-        ):
+        if _is_hash_object_write_flag(arg) or _is_unknown_hash_object_option(arg):
             return False
 
     return not expect_value

--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -91,9 +91,14 @@ def _bundle_is_read_only(args: list[str]) -> bool:
     return len(paths) == 1 and not paths[0].startswith("-")
 
 
+def _is_hash_object_write_flag(arg: str) -> bool:
+    return arg == "-w" or (
+        arg.startswith("-") and not arg.startswith("--") and "w" in arg[1:]
+    )
+
+
 def _hash_object_is_read_only(args: list[str]) -> bool:
     """Allow hashing inputs while rejecting object database writes."""
-    value_options = {"-t"}
     read_only_options = {
         "--literally",
         "--no-filters",
@@ -112,16 +117,16 @@ def _hash_object_is_read_only(args: list[str]) -> bool:
         if arg == "--":
             options_ended = True
             continue
-        if arg == "-w" or (
-            arg.startswith("-") and not arg.startswith("--") and "w" in arg[1:]
-        ):
+        if _is_hash_object_write_flag(arg):
             return False
-        if arg in value_options:
+        if arg == "-t":
             expect_value = True
             continue
-        if arg in read_only_options or arg.startswith("--path="):
-            continue
-        if arg.startswith("-"):
+        if (
+            arg.startswith("-")
+            and arg not in read_only_options
+            and not arg.startswith("--path=")
+        ):
             return False
 
     return not expect_value

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -134,6 +134,8 @@ assert_blocked "blocks chained canonical mutation" "git status && git branch -M 
 assert_blocked "blocks canonical update-ref plumbing" "/usr/bin/git update-ref refs/heads/main HEAD"
 assert_blocked "blocks canonical bundle creation" "git bundle create '$TEST_ROOT/commits.bundle' HEAD"
 assert_blocked "blocks canonical bundle unbundle" "git bundle unbundle '$TEST_ROOT/commits.bundle'"
+assert_blocked "blocks canonical hash-object writes" "git hash-object -w --stdin"
+assert_blocked "blocks combined canonical hash-object write flags" "git hash-object -wt blob --stdin"
 assert_blocked "blocks merge-tree writes in a canonical checkout" \
 	"git merge-tree --write-tree '$INITIAL_HEAD' '$INITIAL_HEAD'"
 assert_blocked "blocks destructive clean with exclude containing n" "git clean --force --exclude=nope"
@@ -201,6 +203,10 @@ assert_allowed "allows reordered canonical symbolic-ref query flags" "$REPO" "gi
 assert_allowed "allows canonical non-recursive symbolic-ref query" "$REPO" "git symbolic-ref --no-recurse refs/remotes/origin/HEAD"
 assert_allowed "allows canonical bundle verification" "$REPO" "git bundle verify '$TEST_ROOT/commits.bundle'"
 assert_allowed "allows quiet canonical bundle verification" "$REPO" "git bundle verify --quiet '$TEST_ROOT/commits.bundle'"
+assert_allowed "allows canonical stdin hashing" "$REPO" "git hash-object --stdin"
+assert_allowed "allows canonical stdin path hashing" "$REPO" "git hash-object --stdin-paths"
+assert_allowed "allows canonical path hashing" "$REPO" "git hash-object README.md"
+assert_allowed "allows canonical option-like path hashing after terminator" "$REPO" "git hash-object -- -w"
 assert_allowed "allows canonical worktree creation" "$REPO" "git worktree add '$LINKED' -b feature/example"
 
 PROSPECTIVE_CONTEXT=$(mktemp -d "${TEST_ROOT}/aidevops-prospective-todo.XXXXXX")
@@ -275,6 +281,28 @@ if (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git status --short >/dev/
 	pass "deployed symlink shim resolves policy engine"
 else
 	fail "deployed symlink shim resolves policy engine"
+fi
+HASH_INPUT="canonical hash-object read-only fixture $RANDOM"
+printf '%s\n' "$HASH_INPUT" >"${REPO}/hash-input.txt"
+EXPECTED_STDIN_HASH=$(printf '%s' "$HASH_INPUT" | /usr/bin/git hash-object --stdin)
+EXPECTED_PATH_HASH=$(/usr/bin/git -C "$REPO" hash-object hash-input.txt)
+COUNT_OUTPUT=$(/usr/bin/git -C "$REPO" count-objects)
+OBJECT_COUNT_BEFORE=${COUNT_OUTPUT%% *}
+SHIM_STDIN_HASH=$(printf '%s' "$HASH_INPUT" | (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git hash-object --stdin))
+SHIM_PATH_HASH=$(cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git hash-object hash-input.txt)
+if [[ "$SHIM_STDIN_HASH" == "$EXPECTED_STDIN_HASH" && "$SHIM_PATH_HASH" == "$EXPECTED_PATH_HASH" ]]; then
+	pass "deployed symlink shim allows read-only content and path hashing"
+else
+	fail "deployed symlink shim preserves native read-only hash-object output"
+fi
+WRITE_OUTPUT=$(printf '%s' "blocked hash-object write $RANDOM" | (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git hash-object -w --stdin) 2>&1)
+WRITE_RC=$?
+COUNT_OUTPUT=$(/usr/bin/git -C "$REPO" count-objects)
+OBJECT_COUNT_AFTER=${COUNT_OUTPUT%% *}
+if [[ "$WRITE_RC" -eq 42 && "$WRITE_OUTPUT" == *"BLOCKED by canonical Git guard"* && "$OBJECT_COUNT_AFTER" == "$OBJECT_COUNT_BEFORE" && "$(git -C "$REPO" rev-parse HEAD)" == "$INITIAL_HEAD" ]]; then
+	pass "deployed symlink shim blocks hash-object writes without changing objects or refs"
+else
+	fail "deployed symlink shim blocks hash-object writes without changing objects or refs (rc=$WRITE_RC objects=${OBJECT_COUNT_BEFORE}->${OBJECT_COUNT_AFTER})"
 fi
 if (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git switch --detach main >/dev/null 2>&1); then
 	fail "deployed symlink shim blocks canonical mutation"


### PR DESCRIPTION
## Summary

Classify hash-object arguments so digest-only forms pass the canonical guard while object-writing forms remain blocked, with policy and deployed-shim regressions.

## Files Changed

.agents/scripts/canonical_git_readonly.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — canonical guard suite (87 tests), relationship resume test, relationship benchmark, Python compile, ShellCheck, and local linters pass

Resolves #29973


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 6m and 50,878 tokens on this with the user in an interactive session.