### PR TITLE
GH#30027: preserve capability contract part identity

### DIFF
--- a/.agents/plugins/opencode-aidevops/subagent-effort-escalation.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-effort-escalation.mjs
@@ -65,16 +65,22 @@ export function appendCapabilityEscalationContract(output) {
   const marker = "[AIDEvOps capability escalation contract]";
   const parts = Array.isArray(output?.parts) ? output.parts : [];
   if (parts.some((part) => part?.type === "text" && String(part.text || "").includes(marker))) return;
-  parts.push({
-    type: "text",
-    synthetic: true,
-    text: [
-      marker,
-      "After bounded attempts, emit `BLOCKED: capability limit - <evidence>` only when model capability is the sole blocker.",
-      "Do not use it for permission, authentication, provider, rate-limit, secret, policy, trust-boundary, locality, billing, or side-effect uncertainty.",
-    ].join("\n"),
-  });
-  output.parts = parts;
+  const targetIndex = parts.findIndex((part) => part?.type === "text"
+    && typeof part.id === "string"
+    && typeof part.sessionID === "string"
+    && typeof part.messageID === "string");
+  if (targetIndex < 0) return;
+
+  const contract = [
+    marker,
+    "After bounded attempts, emit `BLOCKED: capability limit - <evidence>` only when model capability is the sole blocker.",
+    "Do not use it for permission, authentication, provider, rate-limit, secret, policy, trust-boundary, locality, billing, or side-effect uncertainty.",
+  ].join("\n");
+  const target = parts[targetIndex];
+  const originalText = String(target.text || "");
+  output.parts = parts.map((part, index) => index === targetIndex
+    ? { ...target, text: originalText ? `${originalText}\n\n${contract}` : contract }
+    : part);
 }
 
 class InteractiveSubagentEscalator {

--- a/.agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs
@@ -11,7 +11,10 @@ import {
   normalizeEffortTier,
   resolveTierReasoning,
 } from "../subagent-effort.mjs";
-import { capabilityEscalationEvidence } from "../subagent-effort-escalation.mjs";
+import {
+  appendCapabilityEscalationContract,
+  capabilityEscalationEvidence,
+} from "../subagent-effort-escalation.mjs";
 import { SubagentLifecycleTracker, eventSessionID } from "../subagent-lifecycle-tracker.mjs";
 
 const TIER_REASONING = {
@@ -543,10 +546,25 @@ test("conversation turns keep one route attempt and capability escalation reuses
 
   const initialOutput = {
     message: { sessionID: "child", agent: "explore" },
-    parts: [{ type: "text", text: "Inspect this bounded implementation detail." }],
+    parts: [{
+      id: "part-initial",
+      sessionID: "child",
+      messageID: "message-initial",
+      type: "text",
+      text: "Inspect this bounded implementation detail.",
+    }],
   };
   await hooks.chatMessage({}, initialOutput);
-  assert.match(initialOutput.parts.at(-1).text, /capability escalation contract/);
+  assert.equal(initialOutput.parts.length, 1);
+  assert.deepEqual(
+    {
+      id: initialOutput.parts[0].id,
+      sessionID: initialOutput.parts[0].sessionID,
+      messageID: initialOutput.parts[0].messageID,
+    },
+    { id: "part-initial", sessionID: "child", messageID: "message-initial" },
+  );
+  assert.match(initialOutput.parts[0].text, /capability escalation contract/);
   for (let turn = 0; turn < 18; turn += 1) {
     await hooks.chatParams({
       provider: { id: "openai" },
@@ -700,4 +718,42 @@ test("non-capability blockers and headless tasks never auto-escalate", async () 
 
   assert.equal(promptCalls, 0);
   assert.equal(taskOutput.metadata.aidevopsRoutingEscalation, undefined);
+});
+
+test("capability contract preserves persisted part identity and fails open", () => {
+  const completeOutput = {
+    parts: [{
+      id: "part-1",
+      sessionID: "session-1",
+      messageID: "message-1",
+      type: "text",
+      text: "Original prompt",
+      synthetic: false,
+    }],
+  };
+
+  appendCapabilityEscalationContract(completeOutput);
+  appendCapabilityEscalationContract(completeOutput);
+
+  assert.equal(completeOutput.parts.length, 1);
+  assert.deepEqual(
+    completeOutput.parts[0],
+    {
+      id: "part-1",
+      sessionID: "session-1",
+      messageID: "message-1",
+      type: "text",
+      text: completeOutput.parts[0].text,
+      synthetic: false,
+    },
+  );
+  assert.equal(
+    completeOutput.parts[0].text.match(/\[AIDEvOps capability escalation contract\]/g)?.length,
+    1,
+  );
+  assert.match(completeOutput.parts[0].text, /^Original prompt\n\n/);
+
+  const incompleteOutput = { parts: [{ type: "text", text: "Incomplete host part" }] };
+  appendCapabilityEscalationContract(incompleteOutput);
+  assert.deepEqual(incompleteOutput, { parts: [{ type: "text", text: "Incomplete host part" }] });
 });


### PR DESCRIPTION
## Summary

Append the capability escalation contract to a persisted identity-bearing text part and fail open when no safe target exists.

## Files Changed

.agents/plugins/opencode-aidevops/subagent-effort-escalation.mjs, .agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified by executing the full OpenCode plugin suite: 634 tests passed, including host-shaped persisted-part identity retention, idempotent contract injection, fail-open handling, and the complete subagent routing hook path; changed-file linters also passed.

Resolves #30027


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 1h 19m and 867,619 tokens on this with the user in an interactive session.