### PR TITLE
GH#30021: cache routine enrich actor

### DIFF
--- a/.agents/scripts/issue-sync-helper-enrich.sh
+++ b/.agents/scripts/issue-sync-helper-enrich.sh
@@ -398,8 +398,7 @@ _enrich_check_active_claim() {
 		# GH#19922: resolve runner login so the assignment guard can apply the self-login
 		# exemption — without it the runner blocks its own enrichment when it is
 		# also an assignee (e.g. single-user setups).
-		local _user="${AIDEVOPS_SESSION_USER:-}"
-		[[ -z "$_user" ]] && _user=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
+		local _user="${AIDEVOPS_ENRICH_ACTOR:-${AIDEVOPS_SESSION_USER:-}}"
 		local _dedup_result=""
 		# GH#19922: pass pre-fetched JSON via ISSUE_META_JSON env var to avoid
 		# a redundant metadata read. GH#28498: inspection must never invoke stale
@@ -413,6 +412,17 @@ _enrich_check_active_claim() {
 	return 1
 }
 
+_enrich_resolve_actor() {
+	[[ "${AIDEVOPS_ENRICH_ACTOR_RESOLVED:-}" == "1" ]] && return 0
+	AIDEVOPS_ENRICH_ACTOR="${AIDEVOPS_SESSION_USER:-}"
+	if [[ -z "$AIDEVOPS_ENRICH_ACTOR" ]]; then
+		AIDEVOPS_ENRICH_ACTOR=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
+	fi
+	AIDEVOPS_ENRICH_ACTOR_RESOLVED=1
+	export AIDEVOPS_ENRICH_ACTOR AIDEVOPS_ENRICH_ACTOR_RESOLVED
+	return 0
+}
+
 # =============================================================================
 # cmd_enrich
 # =============================================================================
@@ -421,6 +431,9 @@ cmd_enrich() {
 	local target_task="${1:-}"
 	_init_cmd || return 1
 	local repo="$_CMD_REPO" todo_file="$_CMD_TODO" project_root="$_CMD_ROOT"
+	# Keep the actor cache scoped to this command invocation, even when callers
+	# source the helper and invoke cmd_enrich more than once in the same shell.
+	unset AIDEVOPS_ENRICH_ACTOR AIDEVOPS_ENRICH_ACTOR_RESOLVED
 
 	local tasks=()
 	while IFS= read -r tid; do
@@ -444,6 +457,10 @@ cmd_enrich() {
 	if [[ -z "$target_task" ]] && _enrich_check_rate_limit; then
 		return 0
 	fi
+
+	# Resolve identity once for the invocation. Per-task processing occurs in
+	# command substitutions, so export the bounded result for every child.
+	_enrich_resolve_actor
 
 	# GH#20129 Approach A: batch prefetch — issue ONE gh issue list call for all
 	# open issues instead of per-task gh issue view calls. The prefetch JSON is

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -365,15 +365,6 @@ _enrich_process_task() {
 		print_error "Skipping enrich for $task_id — empty description; fix TODO entry before retrying (t2377)"
 		return 0
 	fi
-	local body
-	local _compose_rc=0
-	body=$(compose_issue_body "$task_id" "$project_root") || _compose_rc=$?
-	# Layer 1 (t2377): composition failure = no authoritative body available.
-	if [[ $_compose_rc -ne 0 || -z "$body" ]]; then
-		print_error "Skipping enrich for $task_id — compose_issue_body failed (rc=$_compose_rc). Task ID is not in TODO.md; fix the TODO entry or remove the brief file (t2377)."
-		return 0
-	fi
-
 	if [[ "$DRY_RUN" == "true" ]]; then
 		local _dry_tier_msg=""
 		[[ -n "$tier_label" ]] && _dry_tier_msg=" tier=${tier_label}(replace)"
@@ -404,6 +395,16 @@ _enrich_process_task() {
 	# GH#19856: cross-runner dedup guard — abort if another runner holds
 	# an active claim.
 	if _enrich_check_active_claim "$num" "$repo" "$task_id" "$_state_json"; then
+		return 0
+	fi
+
+	# Compose the authoritative body only after prefetched metadata and the
+	# active-claim guard prove that this task is eligible for mutation.
+	local body
+	local _compose_rc=0
+	body=$(compose_issue_body "$task_id" "$project_root") || _compose_rc=$?
+	if [[ $_compose_rc -ne 0 || -z "$body" ]]; then
+		print_error "Skipping enrich for $task_id — compose_issue_body failed (rc=$_compose_rc). Task ID is not in TODO.md; fix the TODO entry or remove the brief file (t2377)."
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-enrich-batch-prefetch.sh
+++ b/.agents/scripts/tests/test-enrich-batch-prefetch.sh
@@ -80,6 +80,34 @@ else
 	print_result "_enrich_prefetch_issues_map function exists (GH#20129)" 1 "(function not found)"
 fi
 
+if declare -f _enrich_resolve_actor >/dev/null 2>&1; then
+	print_result "_enrich_resolve_actor function exists (GH#30021)" 0
+else
+	print_result "_enrich_resolve_actor function exists (GH#30021)" 1 "(function not found)"
+fi
+
+# A bulk invocation may consult the resolver repeatedly, but authentication
+# identity must be fetched at most once and then exported to task subprocesses.
+ACTOR_LOOKUP_LOG="${TEST_ROOT}/actor-lookups.log"
+gh() {
+	printf 'lookup\n' >>"$ACTOR_LOOKUP_LOG"
+	printf 'fixture-user\n'
+	return 0
+}
+unset AIDEVOPS_SESSION_USER AIDEVOPS_ENRICH_ACTOR AIDEVOPS_ENRICH_ACTOR_RESOLVED
+for _actor_fixture in $(seq 1 60); do
+	_enrich_resolve_actor
+done
+ACTOR_LOOKUPS=$(wc -l <"$ACTOR_LOOKUP_LOG" | tr -d ' ')
+if [[ "$ACTOR_LOOKUPS" -eq 1 && "$AIDEVOPS_ENRICH_ACTOR" == "fixture-user" ]]; then
+	print_result "60-task actor resolution performs one authenticated lookup" 0
+else
+	print_result "60-task actor resolution performs one authenticated lookup" 1 \
+		"(lookups=${ACTOR_LOOKUPS}, actor=${AIDEVOPS_ENRICH_ACTOR:-unset})"
+fi
+unset -f gh
+unset AIDEVOPS_ENRICH_ACTOR AIDEVOPS_ENRICH_ACTOR_RESOLVED
+
 # Verify cmd_enrich calls both helpers (use grep on the actual file path)
 if grep -q '_enrich_check_rate_limit' "${TEST_SCRIPTS_DIR}/../issue-sync-helper-enrich.sh"; then
 	print_result "cmd_enrich calls _enrich_check_rate_limit" 0

--- a/.agents/scripts/tests/test-enrich-dedup-guard.sh
+++ b/.agents/scripts/tests/test-enrich-dedup-guard.sh
@@ -203,6 +203,31 @@ else
 	print_result "enrich guard blocks active interactive claim with zero GitHub writes" 1 "(guard passed or emitted a write)"
 fi
 
+# A structurally blocked task must return before authoritative body composition.
+# This keeps broad no-op sweeps on their prefetched, read-only path (GH#30021).
+TODO_FIXTURE="${TEST_ROOT}/TODO.md"
+mkdir -p "${TEST_ROOT}/todo/tasks"
+printf '%s\n' '- [ ] t30021: Blocked fixture #bug ref:GH#123' >"$TODO_FIXTURE"
+compose_issue_body() {
+	printf 'compose\n' >>"${TEST_ROOT}/compose-calls.log"
+	printf 'unexpected body\n'
+	return 0
+}
+require_task_issue_mapping() {
+	return 0
+}
+: >"${TEST_ROOT}/compose-calls.log"
+ENRICH_PREFETCH_FILE="${TEST_ROOT}/prefetch.json"
+printf '%s\n' "[$active_claim_json]" >"$ENRICH_PREFETCH_FILE"
+if _enrich_process_task "t30021" "test/repo" "$TODO_FIXTURE" "$TEST_ROOT" \
+	'- [ ] t30021: Blocked fixture #bug ref:GH#123' >/dev/null 2>&1 &&
+	[[ ! -s "${TEST_ROOT}/compose-calls.log" ]]; then
+	print_result "blocked enrich task returns before authoritative body composition" 0
+else
+	print_result "blocked enrich task returns before authoritative body composition" 1 "(compose_issue_body was called)"
+fi
+unset ENRICH_PREFETCH_FILE
+
 # Metadata uncertainty must also fail closed without trying recovery writes.
 : >"$GH_WRITE_LOG"
 write_stub_gh '{}' true

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -287,6 +287,9 @@ jobs:
           bash __aidevops/.agents/scripts/issue-sync-helper.sh enrich --verbose || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Resolve the trusted human actor once at workflow scope; bot actors
+          # retain the command's authenticated-login fallback.
+          AIDEVOPS_SESSION_USER: ${{ endsWith(github.actor, '[bot]') && '' || github.actor }}
           # Push/release runs share a 20-minute budget with close/push/pull and
           # TODO.md push. Keep routine enrichment bounded; manual dispatch still
           # runs full `enrich` because these env vars are not set there.


### PR DESCRIPTION
## Summary

Resolve enrich actor identity once per command, propagate trusted workflow actor context, and defer body composition until claim eligibility is established.

## Files Changed

.agents/scripts/issue-sync-helper-enrich.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/tests/test-enrich-batch-prefetch.sh, .agents/scripts/tests/test-enrich-dedup-guard.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; local changed-file linters; enrich bounds 7/7; claim guard 37/37; assignment safety 25/25; actor lookup assertion passes (broad batch-prefetch script retains two unrelated REST fallback failures).

Resolves #30021


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 2h 36m and 1,708,975 tokens on this with the user in an interactive session.