### PR TITLE
GH#30019: fix(issue-sync): prioritize planning publication

### DIFF
--- a/.agents/scripts/tests/test-planning-publication-reconcile.sh
+++ b/.agents/scripts/tests/test-planning-publication-reconcile.sh
@@ -39,5 +39,14 @@ remove_line=$(grep -n -- "$REMOVE_PATTERN" "$RECONCILER" | cut -d: -f1)
 verify_line=$(grep -n -m1 -- "$VERIFY_PATTERN" "$RECONCILER" | cut -d: -f1)
 [[ "$remove_line" -gt "$verify_line" ]]
 
+awk '
+	/name: Reconcile pending planning publication/ { publication_line = NR }
+	/name: Reconcile issue relationships/ { relationship_line = NR }
+	/name: Enrich plan-linked issues/ { enrichment_line = NR }
+	END {
+		exit !(publication_line > 0 && publication_line < relationship_line && publication_line < enrichment_line)
+	}
+' "$WORKFLOW"
+
 printf 'PASS exact-SHA mapping validation precedes blocker removal\n'
-printf 'PASS default-branch workflow invokes bounded reconciliation\n'
+printf 'PASS default-branch workflow reconciles publication before maintenance\n'

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -263,6 +263,19 @@ jobs:
           AIDEVOPS_SESSION_ORIGIN: ${{ endsWith(github.actor, '[bot]') && 'worker' || 'interactive' }}
           AIDEVOPS_SESSION_USER: ${{ endsWith(github.actor, '[bot]') && '' || github.actor }}
 
+      # Complete the exact-SHA publication transition while the task snapshot
+      # created above is current. Relationship and enrichment maintenance are
+      # deliberately best-effort and must not queue dispatchable work.
+      - name: Reconcile pending planning publication
+        if: steps.check-author.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLICATION_SHA: ${{ github.sha }}
+          PUBLICATION_REPO: ${{ github.repository }}
+        run: |
+          bash __aidevops/.agents/scripts/planning-publication-reconcile.sh reconcile \
+            --repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"
+
       - name: Reconcile issue relationships
         id: relationship-sync
         if: steps.check-author.outputs.skip != 'true'
@@ -295,16 +308,6 @@ jobs:
           # runs full `enrich` because these env vars are not set there.
           AIDEVOPS_ENRICH_MAX_ISSUES: '75'
           AIDEVOPS_ENRICH_MAX_SECONDS: '300'
-
-      - name: Reconcile pending planning publication
-        if: steps.check-author.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLICATION_SHA: ${{ github.sha }}
-          PUBLICATION_REPO: ${{ github.repository }}
-        run: |
-          bash __aidevops/.agents/scripts/planning-publication-reconcile.sh reconcile \
-            --repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"
 
       - name: Pull any missing refs back to TODO.md
         if: steps.check-author.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Moves exact-SHA planning-publication reconciliation directly after task issue creation, ahead of relationship and enrichment maintenance, and adds a workflow-order regression check.

## Files Changed

.agents/scripts/tests/test-planning-publication-reconcile.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-planning-publication-reconcile.sh; bash .agents/scripts/tests/test-planning-publication-lifecycle.sh; bash .agents/scripts/tests/test-issue-sync-push-failures.sh; actionlint .github/workflows/issue-sync-reusable.yml; shellcheck .agents/scripts/tests/test-planning-publication-reconcile.sh

Resolves #30019


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 4m and 48,781 tokens on this as a headless worker.