### PR TITLE
GH#30024: fix: exclude OAuth auth-error providers from routing

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -133,8 +133,9 @@ _probe_format_cooldown_until() {
 	return 0
 }
 
-# Check OAuth pool cooldowns before cached health can mask them.
-# Returns: 0=no blocking cooldown, 2=all usable OAuth pool accounts cooling.
+# Check OAuth pool availability before cached health can mask it.
+# Returns: 0=not blocked, 2=all pool accounts cooling, 3=all pool accounts
+# have authentication errors.
 _probe_oauth_pool_cooldown_gate() {
 	local provider="$1"
 	local quiet="${2:-false}"
@@ -173,6 +174,12 @@ _probe_oauth_pool_cooldown_gate() {
 		[[ "$quiet" != "true" ]] && print_warning "$provider: rate-limited until $until_text"
 		_record_health "$provider" "rate_limited" 429 0 "OAuth pool cooldown active until $until_text" 0
 		return 2
+	fi
+
+	if [[ "${total:-0}" -gt 0 && "${available:--1}" -eq 0 && "${_auth_errors:-0}" -gt 0 ]]; then
+		[[ "$quiet" != "true" ]] && print_warning "$provider: all OAuth pool accounts have authentication errors"
+		_record_health "$provider" "key_invalid" 401 0 "All OAuth pool accounts have authentication errors" 0
+		return 3
 	fi
 
 	return 0
@@ -729,8 +736,8 @@ probe_provider() {
 
 	local oauth_pool_exit=0
 	_probe_oauth_pool_cooldown_gate "$provider" "$quiet" || oauth_pool_exit=$?
-	if [[ "$oauth_pool_exit" -eq 2 ]]; then
-		return 2
+	if [[ "$oauth_pool_exit" -ne 0 ]]; then
+		return "$oauth_pool_exit"
 	fi
 
 	# Return cached result when still valid (unless forced)

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -257,7 +257,7 @@ for provider in local ollama; do
 	esac
 done
 
-section "OAuth Pool Cooldown Gate (GH#26465)"
+section "OAuth Pool Availability Gate (GH#26465, GH#30024)"
 
 cooldown_home=$(mktemp -d "$TEST_DB_DIR/home-cooldown.XXXXXX")
 future_ms=$((($(date +%s) + 900) * 1000))
@@ -274,6 +274,18 @@ else
 		"exit=${cooldown_exit}, output=${cooldown_output}"
 fi
 
+auth_error_home=$(mktemp -d "$TEST_DB_DIR/home-auth-error.XXXXXX")
+write_oauth_auth_json "$auth_error_home"
+write_oauth_pool_json "$auth_error_home" '{"openai":[{"email":"one@example.test","status":"auth-error"}]}'
+auth_error_exit=0
+auth_error_output=$(run_with_timeout 10 env HOME="$auth_error_home" PATH="$NO_GOPASS_BIN:$PATH" OPENAI_API_KEY= JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai 2>&1) || auth_error_exit=$?
+if [[ "$auth_error_exit" -eq 3 && "$auth_error_output" == *"all OAuth pool accounts have authentication errors"* ]]; then
+	pass "all OAuth pool auth errors override cached and auth.json availability (GH#30024)"
+else
+	fail "all OAuth pool auth errors override cached and auth.json availability (GH#30024)" \
+		"exit=${auth_error_exit}, output=${auth_error_output}"
+fi
+
 partial_home=$(mktemp -d "$TEST_DB_DIR/home-partial.XXXXXX")
 write_oauth_auth_json "$partial_home"
 write_oauth_pool_json "$partial_home" "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${future_ms}},{\"email\":\"two@example.test\",\"status\":\"idle\",\"cooldownUntil\":0}]}"
@@ -283,6 +295,17 @@ if [[ "$partial_exit" -eq 0 ]]; then
 	pass "partial OAuth pool with one usable account remains available"
 else
 	fail "partial OAuth pool with one usable account remains available" "exit=${partial_exit}"
+fi
+
+mixed_auth_error_home=$(mktemp -d "$TEST_DB_DIR/home-mixed-auth-error.XXXXXX")
+write_oauth_auth_json "$mixed_auth_error_home"
+write_oauth_pool_json "$mixed_auth_error_home" '{"openai":[{"email":"one@example.test","status":"auth-error"},{"email":"two@example.test","status":"idle"}]}'
+mixed_auth_error_exit=0
+run_with_timeout 10 env HOME="$mixed_auth_error_home" PATH="$NO_GOPASS_BIN:$PATH" OPENAI_API_KEY= JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai --quiet >/dev/null 2>&1 || mixed_auth_error_exit=$?
+if [[ "$mixed_auth_error_exit" -eq 0 ]]; then
+	pass "mixed OAuth pool with usable account remains available after auth error (GH#30024)"
+else
+	fail "mixed OAuth pool with usable account remains available after auth error (GH#30024)" "exit=${mixed_auth_error_exit}"
 fi
 
 expired_home=$(mktemp -d "$TEST_DB_DIR/home-expired.XXXXXX")
@@ -308,6 +331,20 @@ if [[ "$static_exit" -eq 0 ]]; then
 	pass "static API key path bypasses OAuth pool cooldown and can use cached health"
 else
 	fail "static API key path bypasses OAuth pool cooldown and can use cached health" "exit=${static_exit}"
+fi
+
+static_auth_error_home=$(mktemp -d "$TEST_DB_DIR/home-static-auth-error.XXXXXX")
+write_oauth_auth_json "$static_auth_error_home"
+write_oauth_pool_json "$static_auth_error_home" '{"openai":[{"email":"one@example.test","status":"auth-error"}]}'
+run_with_timeout 10 env HOME="$static_auth_error_home" JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" status >/dev/null 2>&1 || true
+sqlite3 "$static_auth_error_home/.aidevops/.agent-workspace/model-availability.db" \
+	"INSERT OR REPLACE INTO provider_health (provider,status,http_code,response_ms,error_message,models_count,checked_at,ttl_seconds) VALUES ('openai','healthy',200,0,'test cached healthy',1,strftime('%Y-%m-%dT%H:%M:%SZ','now'),300);" >/dev/null 2>&1
+static_auth_error_exit=0
+run_with_timeout 10 env HOME="$static_auth_error_home" OPENAI_API_KEY="test-static-key" JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai --quiet >/dev/null 2>&1 || static_auth_error_exit=$?
+if [[ "$static_auth_error_exit" -eq 0 ]]; then
+	pass "static API key bypasses OAuth pool auth errors (GH#30024)"
+else
+	fail "static API key bypasses OAuth pool auth errors (GH#30024)" "exit=${static_auth_error_exit}"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

Prevent configured OAuth pools with no usable accounts because every account is auth-error from passing cached health; static API-key authentication remains independent.

## Files Changed

.agents/scripts/model-availability-probe-lib.sh, tests/test-model-availability.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash tests/test-model-availability.sh exercised model-availability-helper.sh against isolated OAuth-pool fixtures (44 passed, 18 skipped). Static checks: bash -n .agents/scripts/model-availability-probe-lib.sh; bash -n tests/test-model-availability.sh; shellcheck .agents/scripts/model-availability-probe-lib.sh tests/test-model-availability.sh.

Resolves #30024


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 10m and 91,554 tokens on this as a headless worker.