### PR TITLE
GH#30020: persist hosted relationship progress

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -296,6 +296,7 @@ _relationship_print_summary() {
 	local created already_present failed deferred first_incomplete
 	local mapping_calls snapshot_calls mutation_calls verify_calls status_calls other_calls
 	local mapping_seconds snapshot_seconds mutation_class_seconds verify_seconds status_seconds
+	local timed_seconds unaccounted_seconds
 	created=$(_relationship_outcome_count "$_REL_OUTCOME_CREATED")
 	already_present=$(_relationship_outcome_count "$_REL_OUTCOME_ALREADY_PRESENT")
 	failed=$(_relationship_outcome_count "failed")
@@ -312,6 +313,9 @@ _relationship_print_summary() {
 	mutation_class_seconds=$(_relationship_operation_seconds mutation)
 	verify_seconds=$(_relationship_operation_seconds verify)
 	status_seconds=$(_relationship_operation_seconds status)
+	timed_seconds=$((mapping_seconds + snapshot_seconds + mutation_class_seconds + verify_seconds + status_seconds))
+	unaccounted_seconds=$((mutation_seconds - timed_seconds))
+	[[ "$unaccounted_seconds" -ge 0 ]] || unaccounted_seconds=0
 	printf '\n=== Relationships Sync ===\nEdges: created=%d already-present=%d failed=%d deferred=%d\n' \
 		"$created" "$already_present" "$failed" "$deferred"
 	printf 'Tasks: attempted=%d complete=%d/%d | Retryable: %d | Deadline exhausted: %s\n' \
@@ -324,6 +328,8 @@ _relationship_print_summary() {
 		"$mapping_calls" "$snapshot_calls" "$mutation_calls" "$verify_calls" "$status_calls" "$other_calls"
 	printf 'Operation timing: mapping=%ss snapshot=%ss mutation=%ss verify=%ss status=%ss\n' \
 		"$mapping_seconds" "$snapshot_seconds" "$mutation_class_seconds" "$verify_seconds" "$status_seconds"
+	printf 'Timing coverage: operations=%ss unaccounted=%ss\n' \
+		"$timed_seconds" "$unaccounted_seconds"
 	printf 'Failure: %s\n' "$first_incomplete"
 	[[ "$retryable_total" -eq 0 ]] || printf 'Recovery: rerun .agents/scripts/issue-sync-helper.sh relationships\n'
 	return 0
@@ -1148,7 +1154,10 @@ _relationship_prepare_workset() {
 	local todo_file="$2"
 	local repo="$3"
 	local revision_input="" seen_list=$'\n' line="" tid="" dominated=false task=""
-	local todo_line_re='^[[:space:]]*-[[:space:]]+\[[[:space:]x>-]\][[:space:]]+(t[0-9]+(\.[0-9]+)*)[[:space:]]'
+	# Broad reconciliation only needs active work. Explicit single-task sync still
+	# repairs completed tasks after publication, but unchanged historical rows do
+	# not consume every hosted default-branch pass.
+	local todo_line_re='^[[:space:]]*-[[:space:]]+\[[[:space:]>-]\][[:space:]]+(t[0-9]+(\.[0-9]+)*)[[:space:]]'
 	local tasks=() unique_tasks=()
 	_RELATIONSHIP_WORK_TASKS=()
 	_RELATIONSHIP_CANDIDATE_TOTAL=0
@@ -1253,6 +1262,19 @@ cmd_relationships() {
 		attempted=$((attempted + 1))
 		task_retryable=0
 		_relationship_print_progress "$attempted" "$total"
+		# All nested paths must respect the same absolute deadline. Mapping and
+		# hierarchy helpers otherwise perform local work after a transport call
+		# has consumed the final second of the aggregate budget.
+		if _relationship_deadline_expired; then
+			deadline_exhausted=true
+			_relationship_record_outcome "$_REL_OUTCOME_DEFERRED_DEADLINE"
+			retryable_total=$((retryable_total + 1))
+			pending_tasks+=("$current_task")
+			for ((remaining_index = index + 1; remaining_index < total; remaining_index++)); do
+				pending_tasks+=("${_RELATIONSHIP_WORK_TASKS[remaining_index]}")
+			done
+			break
+		fi
 
 		# Blocked-by / blocks
 		result=$(_sync_blocked_by_for_task "$current_task" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -1204,6 +1204,29 @@ _relationship_prepare_workset() {
 	return 0
 }
 
+#######################################
+# Persist and report a completed bulk relationship pass. Bash dynamic scope
+# supplies the command-local timing, workset, and pending-task variables while
+# keeping cmd_relationships focused on orchestration.
+#######################################
+_relationship_finalize_command() {
+	[[ $total -gt 25 ]] && printf "\n" >&2
+	mutation_finished=$(date +%s 2>/dev/null || printf '%s' "$mutation_started")
+	backend_calls=$(_relationship_backend_call_count)
+	if [[ -z "$target_task" ]]; then
+		if [[ ${#pending_tasks[@]} -gt 0 ]]; then
+			_relationship_write_resume_state "$_RELATIONSHIP_STATE_FILE" "$_RELATIONSHIP_INPUT_REVISION" "${pending_tasks[@]}" || \
+				print_warning "Relationship progress could not be persisted; the next run will restart safely"
+		else
+			rm -f "$_RELATIONSHIP_STATE_FILE"
+		fi
+	fi
+	_relationship_print_summary "$attempted" "$complete" "$pending_before" "$retryable_total" "$deadline_exhausted" \
+		"$candidate_total" "${#pending_tasks[@]}" "$_RELATIONSHIP_RESUME_STATUS" \
+		"$((parse_finished - parse_started))" "$((mutation_finished - mutation_started))" "$backend_calls"
+	return 0
+}
+
 # Bulk relationship sync command.
 # Scans TODO.md for tasks with relationship metadata or subtask patterns,
 # resolves to GitHub node IDs, and sets relationships via GraphQL.
@@ -1304,20 +1327,7 @@ cmd_relationships() {
 			pending_tasks+=("$current_task")
 		fi
 	done
-	[[ $total -gt 25 ]] && printf "\n" >&2
-	mutation_finished=$(date +%s 2>/dev/null || printf '%s' "$mutation_started")
-	backend_calls=$(_relationship_backend_call_count)
-	if [[ -z "$target_task" ]]; then
-		if [[ ${#pending_tasks[@]} -gt 0 ]]; then
-			_relationship_write_resume_state "$_RELATIONSHIP_STATE_FILE" "$_RELATIONSHIP_INPUT_REVISION" "${pending_tasks[@]}" || \
-				print_warning "Relationship progress could not be persisted; the next run will restart safely"
-		else
-			rm -f "$_RELATIONSHIP_STATE_FILE"
-		fi
-	fi
-	_relationship_print_summary "$attempted" "$complete" "$pending_before" "$retryable_total" "$deadline_exhausted" \
-		"$candidate_total" "${#pending_tasks[@]}" "$_RELATIONSHIP_RESUME_STATUS" \
-		"$((parse_finished - parse_started))" "$((mutation_finished - mutation_started))" "$backend_calls"
+	_relationship_finalize_command
 	[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 	[[ "$retryable_total" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -125,6 +125,9 @@ expired_result=$(_sync_declared_blocked_by_edges t1 "${TMP_DIR}/TODO.md" example
 pass "edge loop stops with retryable state after aggregate exhaustion"
 
 : >"$_RELATIONSHIP_RESULT_FILE"
+# The preceding edge-loop assertion intentionally expires the aggregate scope.
+# Start a fresh fixture scope before exercising bounded mutation behavior.
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 30 ))
 MUTATION_FIXTURE=""
 _gh_with_timeout() {
 	local operation="$1"

--- a/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
@@ -14,7 +14,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-export AIDEVOPS_RELATIONSHIP_STATE_DIR="${TMP_DIR}/state"
+HOSTED_ARTIFACT_DIR="${TMP_DIR}/hosted-artifact"
+export AIDEVOPS_RELATIONSHIP_STATE_DIR="${TMP_DIR}/hosted-runner-one/state"
 TODO_FILE="${TMP_DIR}/TODO.md"
 ATTEMPT_LOG="${TMP_DIR}/attempts.log"
 DEADLINE_FLAG="${TMP_DIR}/deadline"
@@ -84,6 +85,12 @@ for ((task_number = 1; task_number <= 800; task_number++)); do
 	printf -- '- [ ] t%d Task %d blocked-by:t900 ref:GH#%d\n' \
 		"$task_number" "$task_number" "$task_number" >>"$TODO_FILE"
 done
+# A large historical completed set must not consume recurring broad hosted
+# reconciliation. Targeted relationship sync remains available for repairs.
+for ((task_number = 1001; task_number <= 1141; task_number++)); do
+	printf -- '- [x] t%d Completed task %d blocked-by:t900 ref:GH#%d\n' \
+		"$task_number" "$task_number" "$task_number" >>"$TODO_FILE"
+done
 : >"$ATTEMPT_LOG"
 
 first_rc=0
@@ -98,7 +105,16 @@ first_pending=$(grep -c '^pending=' "$state_file" || true)
 if [[ "${AIDEVOPS_BENCHMARK_OUTPUT:-0}" == "1" ]]; then
 	printf '%s\n' "$first_output"
 fi
-pass "800-task reconciliation persists bounded first-pass progress"
+pass "800 active-task reconciliation persists bounded first-pass progress"
+
+# Hosted runners are ephemeral. Simulate the workflow handoff by copying only
+# the persisted state into a fresh runner state directory before the next pass.
+mkdir -p "$HOSTED_ARTIFACT_DIR"
+cp "$state_file" "$HOSTED_ARTIFACT_DIR/example_repo.state"
+export AIDEVOPS_RELATIONSHIP_STATE_DIR="${TMP_DIR}/hosted-runner-two/state"
+mkdir -p "$AIDEVOPS_RELATIONSHIP_STATE_DIR"
+cp "$HOSTED_ARTIFACT_DIR/example_repo.state" "$AIDEVOPS_RELATIONSHIP_STATE_DIR/example_repo.state"
+state_file=$(_relationship_resume_state_file "example/repo")
 
 : >"$ATTEMPT_LOG"
 rm -f "$DEADLINE_FLAG"

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -224,6 +224,19 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Restore durable relationship progress
+        id: relationship-state-restore
+        if: steps.check-author.outputs.skip != 'true'
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ runner.temp }}/aidevops-relationship-state
+          key: issue-sync-relationships-${{ github.repository_id }}-${{ hashFiles('TODO.md') }}-restore
+          # A prior revision can restore safely: the state file embeds the
+          # relationship-input revision and invalidates itself before use.
+          restore-keys: |
+            issue-sync-relationships-${{ github.repository_id }}-${{ hashFiles('TODO.md') }}-
+            issue-sync-relationships-${{ github.repository_id }}-
+
       - name: Configure Git
         if: steps.check-author.outputs.skip != 'true'
         run: |
@@ -292,6 +305,16 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AIDEVOPS_RELATIONSHIP_STATE_DIR: ${{ runner.temp }}/aidevops-relationship-state
+
+      - name: Persist durable relationship progress
+        if: always() && steps.relationship-sync.outputs.pending == 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ runner.temp }}/aidevops-relationship-state
+          # Cache entries are immutable, so each run writes a new revision-keyed
+          # checkpoint and the next run restores the newest matching entry.
+          key: issue-sync-relationships-${{ github.repository_id }}-${{ hashFiles('TODO.md') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Enrich plan-linked issues
         if: steps.check-author.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Persist relationship reconciliation checkpoints across hosted runs, exclude unchanged completed tasks from broad passes, and report operation timing coverage.

## Files Changed

.agents/scripts/issue-sync-relationships.sh, .agents/scripts/tests/test-issue-sync-relationship-deadline.sh, .agents/scripts/tests/test-issue-sync-relationship-resume.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — actionlint; ShellCheck; relationship deadline, resume, benchmark, and dependency-readiness tests

Resolves #30020


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 32m and 298,790 tokens on this as a headless worker.