### PR TITLE
GH#30083: fix: sanitize health dashboard publication

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -328,11 +328,51 @@ privacy_redact_public_text() {
 	local entities_file="$2"
 	local class value redacted="$text"
 	[[ -f "$entities_file" ]] || return 1
+	redacted=$(privacy_redact_local_paths "$redacted") || return 1
 	while IFS=$'\t' read -r class value || [[ -n "$class" ]]; do
 		[[ -z "$class" || -z "$value" ]] && continue
 		redacted="${redacted//"$value"/[private-${class}]}"
 	done <"$entities_file"
 	printf '%s' "$redacted"
+	return 0
+}
+
+#######################################
+# Build a public-safe copy of text from the local entity inventory.
+# Arguments: $1=text
+#######################################
+privacy_redact_public_text_from_inventory() {
+	local text="$1"
+	local entities_file redacted
+
+	entities_file=$(mktemp) || return 1
+	if ! privacy_enumerate_private_entities "$entities_file"; then
+		rm -f "$entities_file"
+		return 1
+	fi
+	redacted=$(privacy_redact_public_text "$text" "$entities_file") || {
+		rm -f "$entities_file"
+		return 1
+	}
+	rm -f "$entities_file"
+	printf '%s' "$redacted"
+	return 0
+}
+
+#######################################
+# Replace local filesystem paths before rendering text for a public surface.
+# Mirrors privacy_scan_local_paths() so callers can preserve useful dashboard
+# data without bypassing the public-write privacy guard.
+# Arguments: $1=text
+#######################################
+privacy_redact_local_paths() {
+	local text="$1"
+	# shellcheck disable=SC2016  # sed expressions intentionally use single quotes
+	printf '%s' "$text" | sed -E \
+		-e 's%(^|[[:space:]`"(:=])/Users/[^[:space:]`")]*%\1[local-path]%g' \
+		-e 's%(^|[[:space:]`"(:=])/home/[^[:space:]`")]*%\1[local-path]%g' \
+		-e 's%(^|[[:space:]`"(:=])~/(Git|Projects|Code|src|work|dev)/[^[:space:]`")]*%\1[local-path]%g' \
+		-e 's%(^|[[:space:]`"(:=])file:///(Users|home)/[^[:space:]`")]*%\1[local-path]%g'
 	return 0
 }
 

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -62,6 +62,10 @@ source "${SCRIPT_DIR}/stats-health-dashboard-issue.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/stats-health-dashboard-data.sh"
 
+# shellcheck source=./privacy-guard-helper.sh
+# shellcheck disable=SC1091  # sibling library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/privacy-guard-helper.sh"
+
 # --- Orchestration functions ---
 
 #######################################
@@ -219,7 +223,17 @@ _update_health_issue_body_or_fail() {
 	local health_issue_number="$1"
 	local repo_slug="$2"
 	local body="$3"
-	local body_edit_stderr
+	local body_edit_stderr sanitized_body=""
+
+	# Health dashboards aggregate helper output from many local repositories.
+	# Sanitize that output before the public write rather than letting one local
+	# path prevent the entire dashboard—including its freshness marker—from
+	# updating. The write wrapper independently scans the final body.
+	sanitized_body=$(privacy_redact_public_text_from_inventory "$body") || {
+		echo "[stats] Health issue: could not sanitize public body for #${health_issue_number}" \
+			>>"${LOGFILE:-/dev/null}"
+		return 1
+	}
 
 	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback
 	# in shared-gh-wrappers-safe-edit.sh fires when GraphQL is rate-limited.
@@ -227,7 +241,7 @@ _update_health_issue_body_or_fail() {
 	# update when the 5000/hr GraphQL budget is exhausted, leaving the
 	# dashboard stale until the budget resets (up to 1h). GH#33.
 	body_edit_stderr=$(_gh_with_timeout write gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
-		--body "$body" 2>&1 >/dev/null) || {
+		--body "$sanitized_body" 2>&1 >/dev/null) || {
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
 			>>"${LOGFILE:-/dev/null}"
 		return 1

--- a/.agents/scripts/tests/test-gh-public-privacy-guard.sh
+++ b/.agents/scripts/tests/test-gh-public-privacy-guard.sh
@@ -63,6 +63,20 @@ else
 	fail "private entity inventory redacts generic placeholders"
 fi
 
+redacted=$(privacy_redact_public_text 'Local source: /Users/example/Git/private-project' "$entities_file")
+if [[ "$redacted" == 'Local source: [local-path]' ]]; then
+	pass "public text redacts local filesystem paths"
+else
+	fail "public text redacts local filesystem paths" "redacted=$redacted"
+fi
+
+redacted=$(privacy_redact_public_text_from_inventory 'Synthetic Private Person at /Users/example/Git/private-project')
+if [[ "$redacted" == '[private-person] at [local-path]' ]]; then
+	pass "public text inventory helper redacts before publication"
+else
+	fail "public text inventory helper redacts before publication" "redacted=$redacted"
+fi
+
 out=$(privacy_scan_public_text 'Synthetic Private Person' "$entities_file")
 rc=$?
 if [[ "$rc" -eq 1 && "$out" == '[private-person]' ]]; then

--- a/.agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh
+++ b/.agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh
@@ -130,15 +130,33 @@ _assemble_health_issue_body() {
 }
 
 # shellcheck disable=SC2317
-_gh_with_timeout() {
-	record_call "gh_with_timeout"
-	return 1
-}
-
-# shellcheck disable=SC2317
 _update_health_issue_title() {
 	record_call "title"
 	return 0
+}
+
+# shellcheck disable=SC2317
+privacy_redact_public_text_from_inventory() {
+	local body="$1"
+	record_call "sanitize"
+	printf '%s' "${body//\/Users\/example\/Git\/private-project/[local-path]}"
+	return 0
+}
+
+# shellcheck disable=SC2317
+gh_issue_edit_safe() {
+	local health_issue_number="$1"
+	shift
+	record_call "edit:${health_issue_number}:$*"
+	return 0
+}
+
+# shellcheck disable=SC2317
+_gh_with_timeout() {
+	local mode="$1"
+	shift
+	"$@"
+	return $?
 }
 
 cache_file="${HOME}/.aidevops/logs/health-issue-alice-owner-repo"
@@ -157,6 +175,15 @@ if [[ "$(<"$CALLS_FILE")" == "resolve" ]]; then
 	pass "abstains immediately after resolver sentinel"
 else
 	fail "abstains immediately after resolver sentinel" "expected only 'resolve', but got: $(tr '\n' ' ' <"$CALLS_FILE")"
+fi
+
+: >"$CALLS_FILE"
+_update_health_issue_body_or_fail "42" "owner/repo" "Local source: /Users/example/Git/private-project"
+calls=$(<"$CALLS_FILE")
+if [[ "$calls" == *"sanitize"* && "$calls" == *"--body Local source: [local-path]"* && "$calls" != *"private-project"* ]]; then
+	pass "sanitizes dashboard body before public issue edit"
+else
+	fail "sanitizes dashboard body before public issue edit" "calls=${calls}"
 fi
 
 if ((TESTS_FAILED > 0)); then


### PR DESCRIPTION
## Summary

Sanitize local paths and configured private entities before public dashboard edits so the health dashboard refresh can update its freshness marker without bypassing privacy protections.

## Files Changed

.agents/scripts/privacy-guard-helper.sh, .agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-gh-public-privacy-guard.sh, .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and ShellCheck for changed shell files; test-gh-public-privacy-guard.sh; test-health-dashboard-sentinel-abstain.sh; test-health-dashboard-identity-aliases.sh; test-stats-wrapper-headless-export.sh; test-stats-wrapper-timeout.sh

Resolves #30083


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 14m and 194,517 tokens on this as a headless worker.