### PR TITLE
GH#30096: fix: prioritize supervisor dashboard refresh

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -43,6 +43,10 @@ readonly _HEALTH_CROSS_REPO_MAX_REPOS=30
 readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=43200
 readonly _HEALTH_ACTIVITY_STATE_ACTIVE="active"
 readonly _HEALTH_ACTIVITY_STATE_IDLE="idle"
+# The framework dashboard is the primary operator health surface. Refresh it
+# before lower-priority managed repositories so a bounded stats run still
+# publishes its freshness marker when a later repository is slow or rate-limited.
+readonly _HEALTH_PRIORITY_REPO_DEFAULT="marcusquinn/aidevops"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -411,6 +415,33 @@ _filter_routine_eligible_repo_entries() {
 }
 
 #######################################
+# Put the primary framework dashboard first without dropping or duplicating
+# configured repositories. Deployments may override the default for forks or
+# an independently managed framework repository.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+# Output: priority entry first (when present), then all other entries in order
+#######################################
+_prioritize_health_repo_entries() {
+	local repo_entries="$1"
+	local priority_repo="${STATS_HEALTH_PRIORITY_REPO:-${AIDEVOPS_HEALTH_PRIORITY_REPO:-$_HEALTH_PRIORITY_REPO_DEFAULT}}"
+	local slug path
+
+	[[ "$priority_repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+		printf '%s\n' "$repo_entries"
+		return 0
+	}
+
+	while IFS='|' read -r slug path; do
+		[[ "$slug" == "$priority_repo" ]] && printf '%s|%s\n' "$slug" "$path"
+	done <<<"$repo_entries"
+	while IFS='|' read -r slug path; do
+		[[ -n "$slug" && "$slug" != "$priority_repo" ]] && printf '%s|%s\n' "$slug" "$path"
+	done <<<"$repo_entries"
+	return 0
+}
+
+#######################################
 # Update health issues for ALL pulse-enabled repos
 #
 # Iterates repos.json and calls _update_health_issue_for_repo for each
@@ -451,6 +482,7 @@ update_health_issues() {
 	if [[ -z "$repo_entries" ]]; then
 		return 0
 	fi
+	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
 
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -432,6 +432,23 @@ fi
 unset HEALTH_FIXTURE
 
 : >"$GH_CALLS"
+priority_entries=$(_prioritize_health_repo_entries $'owner/slow|/repo/slow\nmarcusquinn/aidevops|/repo/framework\nowner/other|/repo/other')
+if [[ "$priority_entries" == $'marcusquinn/aidevops|/repo/framework\nowner/slow|/repo/slow\nowner/other|/repo/other' ]]; then
+	pass "health dashboard prioritizes the framework repository without dropping entries"
+else
+	fail "health dashboard prioritizes the framework repository without dropping entries" "entries=${priority_entries}"
+fi
+
+STATS_HEALTH_PRIORITY_REPO="owner/other"
+priority_entries=$(_prioritize_health_repo_entries $'owner/slow|/repo/slow\nmarcusquinn/aidevops|/repo/framework\nowner/other|/repo/other')
+unset STATS_HEALTH_PRIORITY_REPO
+if [[ "$priority_entries" == $'owner/other|/repo/other\nowner/slow|/repo/slow\nmarcusquinn/aidevops|/repo/framework' ]]; then
+	pass "health dashboard supports an explicit priority repository override"
+else
+	fail "health dashboard supports an explicit priority repository override" "entries=${priority_entries}"
+fi
+
+: >"$GH_CALLS"
 export HEALTH_FIXTURE=label_hygiene
 gh() {
 	local call="$*"


### PR DESCRIPTION
## Summary

Prioritized the framework health dashboard before lower-priority managed repositories so the freshness marker refreshes before bounded runs can time out.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/stats-wrapper.sh --self-check; bash .agents/scripts/stats-wrapper.sh --dry-run; shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh

Resolves #30096


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 7m and 151,525 tokens on this as a headless worker.