### PR TITLE
GH#30097: fix: prioritize supervisor dashboard refresh

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -41,6 +41,7 @@ _STATS_HEALTH_DASHBOARD_LOADED=1
 readonly _HEALTH_QUERY_FAILED_SENTINEL="__QUERY_FAILED__"
 readonly _HEALTH_CROSS_REPO_MAX_REPOS=30
 readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=43200
+readonly _HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT=180
 readonly _HEALTH_ACTIVITY_STATE_ACTIVE="active"
 readonly _HEALTH_ACTIVITY_STATE_IDLE="idle"
 
@@ -192,6 +193,70 @@ _record_health_issue_refresh_state() {
 		|| "$activity_state" == "$_HEALTH_ACTIVITY_STATE_IDLE" ]] \
 		|| activity_state="$_HEALTH_ACTIVITY_STATE_ACTIVE"
 	printf '%s|%s\n' "$activity_state" "$(date +%s)" >"${health_issue_file}.refresh-state"
+	return 0
+}
+
+#######################################
+# Resolve the maximum time reserved for the first configured dashboard.
+# This priority refresh protects the primary local supervisor dashboard from
+# becoming stale when remaining repositories consume the scheduler ceiling.
+# Arguments:
+#   $1 - wrapper timeout ceiling in seconds
+# Output: bounded timeout in seconds
+#######################################
+_health_priority_repo_refresh_timeout() {
+	local wrapper_timeout="$1"
+	local priority_timeout="${HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT:-$_HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT}"
+	[[ "$wrapper_timeout" =~ ^[0-9]+$ ]] || wrapper_timeout="$_HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT"
+	[[ "$priority_timeout" =~ ^[0-9]+$ ]] || priority_timeout="$_HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT"
+	[[ "$priority_timeout" -gt 0 ]] || priority_timeout="$_HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT"
+	if [[ "$priority_timeout" -gt "$wrapper_timeout" ]]; then
+		priority_timeout="$wrapper_timeout"
+	fi
+	printf '%s\n' "$priority_timeout"
+	return 0
+}
+
+#######################################
+# Refresh the first configured eligible repository before aggregate work.
+# Arguments:
+#   $1 - newline-delimited eligible slug|path entries
+# Returns: 0 when the priority refresh completes or safely skips, 1 on failure
+#######################################
+_refresh_priority_health_issue() {
+	local repo_entries="$1"
+	local priority_entry="" priority_slug="" priority_path="" priority_pid=""
+	local priority_start="" priority_now="" priority_elapsed="" priority_ec=0
+	priority_entry=$(printf '%s\n' "$repo_entries" | awk 'NF { print; exit }')
+	[[ -n "$priority_entry" ]] || return 0
+	IFS='|' read -r priority_slug priority_path <<<"$priority_entry"
+	[[ -n "$priority_slug" ]] || return 0
+
+	local priority_timeout="${STATS_TIMEOUT:-$_HEALTH_PRIORITY_REPO_REFRESH_TIMEOUT_DEFAULT}"
+	priority_timeout=$(_health_priority_repo_refresh_timeout "$priority_timeout")
+	priority_start=$(date +%s)
+	_update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" "" &
+	priority_pid=$!
+	while kill -0 "$priority_pid" 2>/dev/null; do
+		priority_now=$(date +%s)
+		priority_elapsed=$((priority_now - priority_start))
+		if [[ "$priority_elapsed" -ge "$priority_timeout" ]]; then
+			_kill_tree "$priority_pid" || true
+			sleep 2
+			if kill -0 "$priority_pid" 2>/dev/null; then
+				_force_kill_tree "$priority_pid" || true
+			fi
+			wait "$priority_pid" 2>/dev/null || true
+			echo "[stats] Priority health dashboard refresh timed out for ${priority_slug} after ${priority_timeout}s" >>"$LOGFILE"
+			return 124
+		fi
+		sleep 1
+	done
+	wait "$priority_pid" || priority_ec=$?
+	if [[ "$priority_ec" -ne 0 ]]; then
+		echo "[stats] Priority health dashboard refresh failed for ${priority_slug} (rc=${priority_ec})" >>"$LOGFILE"
+		return "$priority_ec"
+	fi
 	return 0
 }
 
@@ -451,6 +516,7 @@ update_health_issues() {
 	if [[ -z "$repo_entries" ]]; then
 		return 0
 	fi
+	_refresh_priority_health_issue "$repo_entries" || return $?
 
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -297,6 +297,46 @@ test_dashboard_body_edit_failure_returns_nonzero() {
 	return 0
 }
 
+# Test 9: the configured primary repo must refresh before the optional person
+# stats and cross-repo summaries. A slow aggregate stage must not consume the
+# whole scheduler tick before it reaches the primary supervisor dashboard.
+test_priority_dashboard_refresh_precedes_aggregate_work() {
+	local priority_line person_stats_line cross_repo_line priority_call
+	priority_call="_refresh_priority_health_issue \"\$repo_entries\" || return \$?"
+	priority_line=$(grep -nF "$priority_call" "$HEALTH_DASHBOARD_SCRIPT" | cut -d: -f1)
+	person_stats_line=$(grep -nF '_refresh_person_stats_cache || true' "$HEALTH_DASHBOARD_SCRIPT" | cut -d: -f1)
+	cross_repo_line=$(grep -nF 'Pre-compute cross-repo summaries ONCE' "$HEALTH_DASHBOARD_SCRIPT" | cut -d: -f1)
+	if [[ -n "$priority_line" && -n "$person_stats_line" && -n "$cross_repo_line" \
+		&& "$priority_line" -lt "$person_stats_line" && "$priority_line" -lt "$cross_repo_line" ]]; then
+		print_result "priority dashboard refresh precedes aggregate work" 0
+		return 0
+	fi
+	print_result "priority dashboard refresh precedes aggregate work" 1 \
+		"Expected priority=$priority_line before person_stats=$person_stats_line and cross_repo=$cross_repo_line"
+	return 0
+}
+
+# Test 10: the priority refresh must use a bounded timeout derived from the
+# scheduler ceiling so an individual repository cannot consume the entire run.
+test_priority_dashboard_refresh_is_bounded() {
+	local priority_snippet child_call timeout_check
+	priority_snippet=$(awk '
+		/^_refresh_priority_health_issue\(\) \{/ { in_helper=1 }
+		in_helper { print }
+		in_helper && /^[[:space:]]*}$/ { exit }
+	' "$HEALTH_DASHBOARD_SCRIPT")
+	child_call="_update_health_issue_for_repo \"\$priority_slug\" \"\$priority_path\" \"\" \"\" \"\" &"
+	timeout_check="if [[ \"\$priority_elapsed\" -ge \"\$priority_timeout\" ]]"
+	if printf '%s' "$priority_snippet" | grep -qF "$child_call" \
+		&& printf '%s' "$priority_snippet" | grep -qF "$timeout_check"; then
+		print_result "priority dashboard refresh uses bounded timeout" 0
+		return 0
+	fi
+	print_result "priority dashboard refresh uses bounded timeout" 1 \
+		"Expected bounded child process around _update_health_issue_for_repo"
+	return 0
+}
+
 main_test() {
 	test_export_line_present_at_top_of_main
 	test_detect_session_origin_returns_worker_when_headless
@@ -307,6 +347,8 @@ main_test() {
 	test_dashboard_update_failure_not_swallowed
 	test_transient_dashboard_tempfail_is_deferred
 	test_dashboard_body_edit_failure_returns_nonzero
+	test_priority_dashboard_refresh_precedes_aggregate_work
+	test_priority_dashboard_refresh_is_bounded
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Refresh the first configured eligible dashboard before aggregate summaries, with a bounded child-process budget so remaining repositories cannot starve the primary health surface.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-wrapper-headless-export.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; bash .agents/scripts/stats-wrapper.sh --self-check

Resolves #30097


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 9m and 97,306 tokens on this as a headless worker.