### PR TITLE
GH#30101: fix: refresh priority dashboard before cache work

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -442,6 +442,67 @@ _prioritize_health_repo_entries() {
 }
 
 #######################################
+# Refresh the first priority dashboard before optional aggregate work.
+# Arguments:
+#   $1 - priority-ordered newline-delimited slug|path entries
+# Output: refreshed priority slug, or empty when no entry exists
+#######################################
+_refresh_priority_health_issue() {
+	local repo_entries="$1"
+	local priority_entry="" priority_slug="" priority_path=""
+
+	priority_entry=$(printf '%s\n' "$repo_entries" | awk 'NR == 1 { print; exit }')
+	[[ -z "$priority_entry" ]] && return 0
+	IFS='|' read -r priority_slug priority_path <<<"$priority_entry"
+	if ! _update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" ""; then
+		echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
+		return 1
+	fi
+	printf '%s\n' "$priority_slug"
+	return 0
+}
+
+#######################################
+# Build optional cross-repository dashboard sections once per refresh cycle.
+# Arguments:
+#   $1 - priority-ordered newline-delimited slug|path entries
+#   $2-$4 - output variable names for activity, session, and person stats
+#######################################
+_build_cross_repo_health_summaries() {
+	local repo_entries="$1"
+	local activity_var="$2" session_var="$3" person_stats_var="$4"
+	local cross_repo_md="" cross_repo_session_time_md="" cross_repo_person_stats_md=""
+	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
+	if [[ -x "$activity_helper" ]]; then
+		local all_repo_paths
+		all_repo_paths=$(printf '%s\n' "$repo_entries" | awk -F'|' 'NF >= 2 && $2 != "" { print $2 }')
+		if [[ -n "$all_repo_paths" ]]; then
+			local -a cross_args=()
+			while IFS= read -r rp; do
+				[[ -n "$rp" ]] && cross_args+=("$rp")
+			done <<<"$all_repo_paths"
+			if [[ ${#cross_args[@]} -gt 1 && ${#cross_args[@]} -le $_HEALTH_CROSS_REPO_MAX_REPOS ]]; then
+				cross_repo_md=$(timeout 120 bash "$activity_helper" cross-repo-summary "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo data unavailable._")
+				cross_repo_session_time_md=$(timeout 120 bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period all --format markdown || echo "_Cross-repo session data unavailable._")
+			elif [[ ${#cross_args[@]} -gt $_HEALTH_CROSS_REPO_MAX_REPOS ]]; then
+				local cross_repo_skip_message="Cross-repo summary skipped: ${#cross_args[@]} repositories exceeds limit ${_HEALTH_CROSS_REPO_MAX_REPOS}."
+				echo "[stats] ${cross_repo_skip_message}" >>"${LOGFILE:-/dev/null}"
+				cross_repo_md="_${cross_repo_skip_message}_"
+				cross_repo_session_time_md="_${cross_repo_skip_message}_"
+			fi
+		fi
+	fi
+	local cross_repo_cache="${PERSON_STATS_CACHE_DIR}/person-stats-cache-cross-repo.md"
+	if [[ -f "$cross_repo_cache" ]]; then
+		cross_repo_person_stats_md=$(_read_person_stats_cache "cross-repo")
+	fi
+	printf -v "$activity_var" '%s' "$cross_repo_md"
+	printf -v "$session_var" '%s' "$cross_repo_session_time_md"
+	printf -v "$person_stats_var" '%s' "$cross_repo_person_stats_md"
+	return 0
+}
+
+#######################################
 # Update health issues for ALL pulse-enabled repos
 #
 # Iterates repos.json and calls _update_health_issue_for_repo for each
@@ -484,59 +545,17 @@ update_health_issues() {
 	fi
 	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
 
-	# The primary framework dashboard is the operator health surface. Publish it
-	# before optional cache and cross-repository work, each of which can consume
-	# most of the wrapper's bounded wall-clock budget. The regular loop below
-	# skips it afterwards, preventing a duplicate update in the same cycle.
-	local priority_entry=""
 	local priority_slug=""
-	priority_entry=$(printf '%s\n' "$repo_entries" | awk 'NR == 1 { print; exit }')
-	if [[ -n "$priority_entry" ]]; then
-		local priority_path
-		IFS='|' read -r priority_slug priority_path <<<"$priority_entry"
-		if ! _update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" ""; then
-			echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
-			return 1
-		fi
-	fi
+	priority_slug=$(_refresh_priority_health_issue "$repo_entries") || return 1
 
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true
 
-	# Pre-compute cross-repo summaries ONCE for all health issues.
-	# This avoids N×N git log walks (one cross-repo scan per repo dashboard)
-	# and redundant DB queries for session time.
-	# Person stats read from cache (refreshed hourly by _refresh_person_stats_cache).
-	# Skip the optional cross-repo summaries above _HEALTH_CROSS_REPO_MAX_REPOS;
-	# the contributor activity helper can time out at that scale and stall the
-	# dashboard refresh.
 	local cross_repo_md=""
 	local cross_repo_session_time_md=""
 	local cross_repo_person_stats_md=""
-	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
-	if [[ -x "$activity_helper" ]]; then
-		local all_repo_paths
-		all_repo_paths=$(printf '%s\n' "$repo_entries" | awk -F'|' 'NF >= 2 && $2 != "" { print $2 }')
-		if [[ -n "$all_repo_paths" ]]; then
-			local -a cross_args=()
-			while IFS= read -r rp; do
-				[[ -n "$rp" ]] && cross_args+=("$rp")
-			done <<<"$all_repo_paths"
-			if [[ ${#cross_args[@]} -gt 1 && ${#cross_args[@]} -le $_HEALTH_CROSS_REPO_MAX_REPOS ]]; then
-				cross_repo_md=$(timeout 120 bash "$activity_helper" cross-repo-summary "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo data unavailable._")
-				cross_repo_session_time_md=$(timeout 120 bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period all --format markdown || echo "_Cross-repo session data unavailable._")
-			elif [[ ${#cross_args[@]} -gt $_HEALTH_CROSS_REPO_MAX_REPOS ]]; then
-				local cross_repo_skip_message="Cross-repo summary skipped: ${#cross_args[@]} repositories exceeds limit ${_HEALTH_CROSS_REPO_MAX_REPOS}."
-				echo "[stats] ${cross_repo_skip_message}" >>"${LOGFILE:-/dev/null}"
-				cross_repo_md="_${cross_repo_skip_message}_"
-				cross_repo_session_time_md="_${cross_repo_skip_message}_"
-			fi
-		fi
-	fi
-	local cross_repo_cache="${PERSON_STATS_CACHE_DIR}/person-stats-cache-cross-repo.md"
-	if [[ -f "$cross_repo_cache" ]]; then
-		cross_repo_person_stats_md=$(_read_person_stats_cache "cross-repo")
-	fi
+	_build_cross_repo_health_summaries "$repo_entries" \
+		cross_repo_md cross_repo_session_time_md cross_repo_person_stats_md
 
 	local updated=0
 	local failed=0
@@ -551,7 +570,7 @@ update_health_issues() {
 		updated=$((updated + 1))
 	done <<<"$repo_entries"
 
-	[[ -n "$priority_entry" ]] && updated=$((updated + 1))
+	[[ -n "$priority_slug" ]] && updated=$((updated + 1))
 	if [[ "$updated" -gt 0 ]]; then
 		echo "[stats] Health issues: updated $updated repo(s)" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -484,6 +484,22 @@ update_health_issues() {
 	fi
 	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
 
+	# The primary framework dashboard is the operator health surface. Publish it
+	# before optional cache and cross-repository work, each of which can consume
+	# most of the wrapper's bounded wall-clock budget. The regular loop below
+	# skips it afterwards, preventing a duplicate update in the same cycle.
+	local priority_entry=""
+	local priority_slug=""
+	priority_entry=$(printf '%s\n' "$repo_entries" | awk 'NR == 1 { print; exit }')
+	if [[ -n "$priority_entry" ]]; then
+		local priority_path
+		IFS='|' read -r priority_slug priority_path <<<"$priority_entry"
+		if ! _update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" ""; then
+			echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true
 
@@ -526,6 +542,7 @@ update_health_issues() {
 	local failed=0
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
+		[[ "$slug" == "${priority_slug:-}" ]] && continue
 		if ! _update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md"; then
 			echo "[stats] Health issue update failed for ${slug}" >>"$LOGFILE"
 			failed=$((failed + 1))
@@ -534,6 +551,7 @@ update_health_issues() {
 		updated=$((updated + 1))
 	done <<<"$repo_entries"
 
+	[[ -n "$priority_entry" ]] && updated=$((updated + 1))
 	if [[ "$updated" -gt 0 ]]; then
 		echo "[stats] Health issues: updated $updated repo(s)" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -235,7 +235,24 @@ MOCK_STATS_FUNCTIONS
 	return 0
 }
 
-# Test 7: dashboard refresh failures must not be blindly swallowed by the wrapper.
+# Test 7: priority dashboard selection must be followed immediately by its
+# update, before optional cross-repository summaries can consume the wrapper
+# timeout. Static ordering keeps this focused on the scheduler safety contract.
+test_priority_dashboard_precedes_optional_cross_repo_work() {
+	local dashboard_script priority_line cache_line
+	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
+	priority_line=$(grep -nE "^[[:space:]]*if ! _update_health_issue_for_repo \"[\$]priority_slug\"" "$dashboard_script" | head -1 | cut -d: -f1)
+	cache_line=$(grep -nE '^[[:space:]]*_refresh_person_stats_cache \|\| true' "$dashboard_script" | head -1 | cut -d: -f1)
+	if [[ -n "$priority_line" && -n "$cache_line" && "$priority_line" -lt "$cache_line" ]]; then
+		print_result "priority dashboard refresh precedes optional cross-repo work" 0
+		return 0
+	fi
+	print_result "priority dashboard refresh precedes optional cross-repo work" 1 \
+		"Expected priority update before person-stats refresh; priority_line=${priority_line:-<missing>} cache_line=${cache_line:-<missing>}"
+	return 0
+}
+
+# Test 8: dashboard refresh failures must not be blindly swallowed by the wrapper.
 # The wrapper may intentionally defer EX_TEMPFAIL/rate-limit exits, but ordinary
 # dashboard failures must still flow through _stats_wrapper_run_health_update so
 # the EXIT trap can emit HEALTH-DASHBOARD-FAIL.
@@ -278,7 +295,7 @@ test_transient_dashboard_tempfail_is_deferred() {
 	return 0
 }
 
-# Test 8: the dashboard updater itself must return non-zero when the body edit
+# Test 9: the dashboard updater itself must return non-zero when the body edit
 # fails, otherwise the wrapper's direct update_health_issues call still exits 0
 # and the HEALTH-DASHBOARD-FAIL trap never fires.
 test_dashboard_body_edit_failure_returns_nonzero() {
@@ -304,6 +321,7 @@ main_test() {
 	test_export_before_self_check
 	test_health_update_precedes_quality_sweep
 	test_health_update_survives_slow_quality_sweep
+	test_priority_dashboard_precedes_optional_cross_repo_work
 	test_dashboard_update_failure_not_swallowed
 	test_transient_dashboard_tempfail_is_deferred
 	test_dashboard_body_edit_failure_returns_nonzero

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -241,7 +241,7 @@ MOCK_STATS_FUNCTIONS
 test_priority_dashboard_precedes_optional_cross_repo_work() {
 	local dashboard_script priority_line cache_line
 	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
-	priority_line=$(grep -nE "^[[:space:]]*if ! _update_health_issue_for_repo \"[\$]priority_slug\"" "$dashboard_script" | head -1 | cut -d: -f1)
+	priority_line=$(grep -nE "^[[:space:]]*priority_slug=[\$]\(_refresh_priority_health_issue \"[\$]repo_entries\"\)" "$dashboard_script" | head -1 | cut -d: -f1)
 	cache_line=$(grep -nE '^[[:space:]]*_refresh_person_stats_cache \|\| true' "$dashboard_script" | head -1 | cut -d: -f1)
 	if [[ -n "$priority_line" && -n "$cache_line" && "$priority_line" -lt "$cache_line" ]]; then
 		print_result "priority dashboard refresh precedes optional cross-repo work" 0


### PR DESCRIPTION
## Summary

Refresh the prioritized framework health dashboard before optional person-stat cache and cross-repository summaries, then skip duplicate processing in the same cycle. This ensures the dashboard freshness marker is published even when optional work reaches the wrapper timeout.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-wrapper-headless-export.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; bash .agents/scripts/stats-wrapper.sh --self-check; bash .agents/scripts/stats-wrapper.sh --dry-run

Resolves #30101


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 16m and 138,242 tokens on this as a headless worker.