### PR TITLE
GH#30068: classify terminal infrastructure outcomes

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -947,7 +947,7 @@ _hrff_retry_class_for_reason() {
 		worker_noop_zero_output | crash_during_startup | access_denied | rate_limit* | provider_error | \
 		startup_no_model_activity | service_interruption_exhausted | worker_runtime_not_invoked | \
 		worker_sensitive_temp_preflight_failed | worker_ownership_lost | worker_ledger_ready_failed | \
-		worker_claim_ready_transition_failed)
+		worker_claim_ready_transition_failed | signal_terminated_continue | watchdog_stall_killed)
 		printf '%s\n' "$_HRFF_RETRY_CLASS_INFRASTRUCTURE"
 		;;
 	permission_required | awaiting_maintainer_permission | worker_signing_unavailable)

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -186,6 +186,14 @@ assert_eq "access denied is retryable infrastructure without provider rotation" 
 	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "0")"
 assert_eq "access denied remains infrastructure after session creation" \
 	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "1")"
+assert_eq "terminated worker remains retryable infrastructure after session creation" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "signal_terminated_continue" "1")"
+assert_eq "watchdog hard kill remains retryable infrastructure after session creation" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "watchdog_stall_killed" "1")"
+assert_eq "permission request remains a maintainer gate" \
+	"$_HRFF_RETRY_CLASS_MAINTAINER_GATE" "$(_hrff_retry_class_for_reason "permission_required" "1")"
+assert_eq "unknown session-bearing failure remains remediation" \
+	"$_HRFF_RETRY_CLASS_REMEDIATION" "$(_hrff_retry_class_for_reason "context_exhausted" "1")"
 
 write_retry_fixture() {
 	local name="$1"


### PR DESCRIPTION
## Summary

Implementation for issue #30068.

## Files Changed

.agents/scripts/headless-runtime-failure.sh, .agents/scripts/tests/test-headless-runtime-failure-classification.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30068


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 15h 7m and 2,990,168 tokens on this with the user in an interactive session.