### PR TITLE
GH#30108: fix Linux Tabby config discovery

### DIFF
--- a/.agents/scripts/setup/modules/post-setup.sh
+++ b/.agents/scripts/setup/modules/post-setup.sh
@@ -201,20 +201,16 @@ setup_tabby() {
 	local tabby_helper="$HOME/.aidevops/agents/scripts/tabby-helper.sh"
 	local tabby_config
 
-	# Platform-aware config path
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		tabby_config="$HOME/Library/Application Support/tabby/config.yaml"
-	else
-		tabby_config="$HOME/.config/tabby-terminal/config.yaml"
-	fi
-
-	# Skip if Tabby not installed
-	if [[ ! -f "$tabby_config" ]]; then
+	# Skip if helper not deployed yet
+	if [[ ! -x "$tabby_helper" ]]; then
 		return 0
 	fi
 
-	# Skip if helper not deployed yet
-	if [[ ! -x "$tabby_helper" ]]; then
+	# Keep setup and the standalone helper on one config-resolution contract.
+	tabby_config="$(bash "$tabby_helper" config-path)"
+
+	# Skip if Tabby not installed
+	if [[ ! -f "$tabby_config" ]]; then
 		return 0
 	fi
 

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -18,7 +18,7 @@
 #
 # Requires: python3 (ships with macOS), repos.json
 # Tabby config: ~/Library/Application Support/tabby/config.yaml (macOS)
-#               ~/.config/tabby-terminal/config.yaml (Linux)
+#               ${XDG_CONFIG_HOME:-~/.config}/tabby/config.yaml (Linux)
 
 set -euo pipefail
 
@@ -27,15 +27,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+TABBY_CONFIG_OVERRIDE="${TABBY_CONFIG:-}"
 
-# Tabby config path (platform-aware, unless caller provided an override)
-if [[ -z "${TABBY_CONFIG:-}" ]]; then
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		TABBY_CONFIG="${HOME}/Library/Application Support/tabby/config.yaml"
+_resolve_tabby_config() {
+	local platform="${1:-$(uname -s)}"
+
+	if [[ -n "$TABBY_CONFIG_OVERRIDE" ]]; then
+		printf '%s\n' "$TABBY_CONFIG_OVERRIDE"
+	elif [[ -n "${TABBY_CONFIG_DIRECTORY:-}" ]]; then
+		printf '%s/config.yaml\n' "${TABBY_CONFIG_DIRECTORY%/}"
+	elif [[ "$platform" == "Darwin" ]]; then
+		printf '%s/Library/Application Support/tabby/config.yaml\n' "$HOME"
 	else
-		TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
+		printf '%s/tabby/config.yaml\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
 	fi
-fi
+	return 0
+}
+
+TABBY_CONFIG="$(_resolve_tabby_config)"
 
 _info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 _success() { echo -e "${GREEN}[OK]${NC} $1"; }
@@ -346,6 +355,12 @@ cmd_help() {
 	return 0
 }
 
+cmd_config_path() {
+	local platform="${1:-$(uname -s)}"
+	_resolve_tabby_config "$platform"
+	return 0
+}
+
 # --- Main ---
 main() {
 	local cmd="${1:-sync}"
@@ -355,6 +370,7 @@ main() {
 	status) cmd_status ;;
 	zshrc) cmd_zshrc ;;
 	fix-shell) cmd_fix_shell ;;
+	config-path) cmd_config_path "${2:-}" ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		_error "Unknown command: $cmd"

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
 HELPER="${REPO_ROOT}/.agents/scripts/tabby-profile-sync.py"
+TABBY_HELPER="${REPO_ROOT}/.agents/scripts/tabby-helper.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -261,6 +262,23 @@ if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -
 else
 	_fail "sync did not repair existing profile: ${sync_output}"
 fi
+
+_info "Test 11: Tabby config path precedence matches active platform configuration"
+config_home="${tmp_root}/xdg"
+runtime_dir="${tmp_root}/runtime-tabby"
+explicit_config="${tmp_root}/explicit.yaml"
+
+resolved=$(HOME="${tmp_root}" XDG_CONFIG_HOME="${config_home}" TABBY_CONFIG='' TABBY_CONFIG_DIRECTORY='' bash "${TABBY_HELPER}" config-path Linux)
+[[ "$resolved" == "${config_home}/tabby/config.yaml" ]] && _pass "Linux XDG default resolved" || _fail "Linux XDG default mismatch: ${resolved}"
+
+resolved=$(HOME="${tmp_root}" XDG_CONFIG_HOME="${config_home}" TABBY_CONFIG='' TABBY_CONFIG_DIRECTORY="${runtime_dir}/" bash "${TABBY_HELPER}" config-path Linux)
+[[ "$resolved" == "${runtime_dir}/config.yaml" ]] && _pass "runtime directory override resolved" || _fail "runtime directory override mismatch: ${resolved}"
+
+resolved=$(HOME="${tmp_root}" XDG_CONFIG_HOME="${config_home}" TABBY_CONFIG="${explicit_config}" TABBY_CONFIG_DIRECTORY="${runtime_dir}" bash "${TABBY_HELPER}" config-path Linux)
+[[ "$resolved" == "${explicit_config}" ]] && _pass "explicit file override resolved" || _fail "explicit file override mismatch: ${resolved}"
+
+resolved=$(HOME="${tmp_root}" TABBY_CONFIG='' TABBY_CONFIG_DIRECTORY='' bash "${TABBY_HELPER}" config-path Darwin)
+[[ "$resolved" == "${tmp_root}/Library/Application Support/tabby/config.yaml" ]] && _pass "macOS default preserved" || _fail "macOS default mismatch: ${resolved}"
 
 echo ""
 if ((fail_count == 0)); then


### PR DESCRIPTION
## Summary

Centralize Tabby config resolution across setup and the standalone helper, honoring explicit, runtime-directory, XDG Linux, and macOS paths.

## Files Changed

.agents/scripts/setup/modules/post-setup.sh, .agents/scripts/tabby-helper.sh, .agents/scripts/tests/test-tabby-profile-sync.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test-tabby-profile-sync.sh; test-setup-scoped-dispatch.sh; ShellCheck; review bundle dc2077952f91de4c645d34fa63fbbf72a1c3841aa3d823b7bb9fb7ca02c1e78b

Resolves #30108


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 1h 5m and 208,039 tokens on this with the user in an interactive session.