### PR TITLE
GH#30091: prune closed NMR revalidation state

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -60,6 +60,7 @@ fi
 
 NMR_REVALIDATION_STATE_FILE="${AIDEVOPS_NMR_REVALIDATION_STATE_FILE:-${HOME}/.aidevops/cache/nmr-revalidation-state.json}"
 NMR_TEMPORARY_REVALIDATE_SECONDS="${AIDEVOPS_NMR_TEMPORARY_REVALIDATE_SECONDS:-3600}"
+NMR_STATE_PRUNE_LIMIT="${AIDEVOPS_NMR_STATE_PRUNE_LIMIT:-25}"
 NMR_REASON_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-reason.jq"
 NMR_TRUSTED_RESOLUTION_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-trusted-resolution.jq"
 NMR_STATE_RECORD_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-state-record.jq"
@@ -1083,6 +1084,49 @@ _nmr_record_revalidation_state() {
 	return 0
 }
 
+_nmr_prune_closed_revalidation_state() {
+	[[ -f "$NMR_REVALIDATION_STATE_FILE" ]] || return 0
+	local limit="$NMR_STATE_PRUNE_LIMIT"
+	[[ "$limit" =~ ^[1-9][0-9]*$ ]] || limit=25
+	local current=""
+	current=$(<"$NMR_REVALIDATION_STATE_FILE") || return 0
+	printf '%s' "$current" | jq -e '.entries | type == "object"' >/dev/null 2>&1 || return 0
+	local cursor=""
+	cursor=$(printf '%s' "$current" | jq -r '.prune_cursor // empty' 2>/dev/null) || cursor=""
+
+	local key=""
+	local slug=""
+	local issue_num=""
+	local issue_json=""
+	local state=""
+	local checked=0
+	while IFS= read -r key; do
+		[[ "$checked" -lt "$limit" ]] || break
+		checked=$((checked + 1))
+		cursor="$key"
+		[[ "$key" == *#* ]] || continue
+		slug="${key%#*}"
+		issue_num="${key##*#}"
+		[[ -n "$slug" && "$issue_num" =~ ^[0-9]+$ ]] || continue
+		issue_json=$(gh api "$(_nmr_issue_api_path "$issue_num" "$slug")" 2>/dev/null) || continue
+		state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null) || continue
+		[[ "$state" == "closed" || "$state" == "CLOSED" ]] || continue
+		current=$(printf '%s' "$current" | jq --arg key "$key" 'del(.entries[$key])' 2>/dev/null) || return 0
+	done < <(printf '%s' "$current" | jq -r --arg cursor "$cursor" '
+		.entries | keys as $keys | (($keys | map(select(. > $cursor))) + ($keys | map(select(. <= $cursor))))[]
+	' 2>/dev/null)
+
+	[[ "$checked" -gt 0 ]] || return 0
+	current=$(printf '%s' "$current" | jq --arg cursor "$cursor" '.prune_cursor = $cursor' 2>/dev/null) || return 0
+	local state_dir="${NMR_REVALIDATION_STATE_FILE%/*}"
+	[[ "$state_dir" != "$NMR_REVALIDATION_STATE_FILE" ]] || return 0
+	local tmp_file=""
+	tmp_file=$(mktemp "${state_dir}/.nmr-prune.XXXXXX") || return 0
+	printf '%s\n' "$current" >"$tmp_file" || { rm -f "$tmp_file"; return 0; }
+	mv "$tmp_file" "$NMR_REVALIDATION_STATE_FILE" 2>/dev/null || rm -f "$tmp_file"
+	return 0
+}
+
 _nmr_emit_decision_packet() {
 	local issue_num="$1"
 	local slug="$2"
@@ -2096,6 +2140,7 @@ Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 auto_approve_maintainer_issues() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
+	_nmr_prune_closed_revalidation_state || true
 
 	local total_approved=0
 	local total_normalized=0

--- a/.agents/scripts/tests/test-pulse-nmr-state-pruning.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-state-pruning.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+NMR_SCRIPT="${SCRIPT_DIR}/../pulse-nmr-approval.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export AIDEVOPS_NMR_REVALIDATION_STATE_FILE="${TEST_ROOT}/nmr-state.json"
+export AIDEVOPS_NMR_STATE_PRUNE_LIMIT=2
+export NMR_SCRIPT_DIR="${SCRIPT_DIR}/.."
+export LOGFILE="${TEST_ROOT}/pulse.log"
+
+gh() {
+	local command="$1"
+	local path="$2"
+	[[ "$command" == "api" ]] || return 1
+	case "$path" in
+	repos/owner/repo/issues/1) printf '{"state":"closed"}\n' ;;
+	repos/owner/repo/issues/2) printf '{"state":"open"}\n' ;;
+	repos/owner/repo/issues/3) return 1 ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+# shellcheck source=../pulse-nmr-approval.sh
+source "$NMR_SCRIPT"
+
+cat >"$AIDEVOPS_NMR_REVALIDATION_STATE_FILE" <<'JSON'
+{"entries":{"invalid-key":{"status":"keep"},"owner/repo#1":{"status":"closed"},"owner/repo#2":{"status":"open"},"owner/repo#3":{"status":"unknown"}}}
+JSON
+
+_nmr_prune_closed_revalidation_state
+_nmr_prune_closed_revalidation_state
+
+if ! jq -e '
+  (.entries["owner/repo#1"] == null) and
+  (.entries["owner/repo#2"].status == "open") and
+  (.entries["owner/repo#3"].status == "unknown") and
+  (.entries["invalid-key"].status == "keep") and
+  (.prune_cursor | type == "string")
+' "$AIDEVOPS_NMR_REVALIDATION_STATE_FILE" >/dev/null; then
+	printf 'FAIL: pruning did not remove only authoritatively closed state\n' >&2
+	exit 1
+fi
+
+printf 'PASS: NMR state pruning removes only authoritatively closed entries\n'


### PR DESCRIPTION
## Summary

Bound NMR state reconciliation to 25 rotating entries per pulse cycle and remove only entries whose issue is authoritatively confirmed closed.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh, .agents/scripts/tests/test-pulse-nmr-state-pruning.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test-pulse-nmr-state-pruning.sh; test-pulse-nmr-automation-signature.sh (49 tests); test-pulse-nmr-scanner-label-breaker-trip.sh (11 tests); ShellCheck; review bundle c945f2b8a725bda91be20d5260a21da0873feff29d88dd42a910260c37bb4d1b

Resolves #30091


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 1h 40m and 279,097 tokens on this with the user in an interactive session.