### PR TITLE
GH#30106: fix: preserve health dashboard refresh budget

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -463,6 +463,32 @@ _refresh_priority_health_issue() {
 }
 
 #######################################
+# Skip the optional cross-repository dashboard pass when the primary
+# dashboard update has already consumed most of the wrapper's time budget.
+# This preserves the next scheduler interval for the primary health surface
+# instead of turning a slow, non-critical repository into a timeout.
+# Arguments:
+#   $1 - stats refresh start epoch
+# Returns: 0 to continue optional work, 1 to skip it
+#######################################
+_health_dashboard_optional_work_has_budget() {
+	local refresh_start_epoch="$1"
+	local timeout_seconds="${STATS_TIMEOUT:-600}"
+	local optional_reserve_seconds="${STATS_OPTIONAL_WORK_RESERVE_SECONDS:-120}"
+	local now_epoch elapsed_seconds latest_start_epoch
+
+	[[ "$refresh_start_epoch" =~ ^[0-9]+$ ]] || return 1
+	[[ "$timeout_seconds" =~ ^[0-9]+$ ]] || timeout_seconds="600"
+	[[ "$optional_reserve_seconds" =~ ^[0-9]+$ ]] || optional_reserve_seconds="120"
+	latest_start_epoch=$((timeout_seconds - optional_reserve_seconds))
+	[[ "$latest_start_epoch" -gt 0 ]] || return 1
+	now_epoch=$(date +%s)
+	elapsed_seconds=$((now_epoch - refresh_start_epoch))
+	[[ "$elapsed_seconds" -lt "$latest_start_epoch" ]]
+	return $?
+}
+
+#######################################
 # Build optional cross-repository dashboard sections once per refresh cycle.
 # Arguments:
 #   $1 - priority-ordered newline-delimited slug|path entries
@@ -545,8 +571,14 @@ update_health_issues() {
 	fi
 	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
 
+	local refresh_start_epoch
+	refresh_start_epoch=$(date +%s)
 	local priority_slug=""
 	priority_slug=$(_refresh_priority_health_issue "$repo_entries") || return 1
+	if ! _health_dashboard_optional_work_has_budget "$refresh_start_epoch"; then
+		echo "[stats] Health dashboard optional cross-repo work skipped after priority refresh exhausted its time budget" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -252,6 +252,24 @@ test_priority_dashboard_precedes_optional_cross_repo_work() {
 	return 0
 }
 
+test_slow_priority_dashboard_skips_optional_cross_repo_work() {
+	local dashboard_script production_snippet
+	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
+	production_snippet=$(awk '
+		/^update_health_issues\(\) \{/ { in_production=1 }
+		in_production { print }
+		in_production && /^}$/ { exit }
+	' "$dashboard_script")
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*if ! _health_dashboard_optional_work_has_budget "[$]refresh_start_epoch"; then' &&
+		printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*return 0[[:space:]]*$'; then
+		print_result "slow priority dashboard skips optional cross-repo work" 0
+		return 0
+	fi
+	print_result "slow priority dashboard skips optional cross-repo work" 1 \
+		"Expected update_health_issues to return after the priority refresh consumes the optional-work budget"
+	return 0
+}
+
 # Test 8: dashboard refresh failures must not be blindly swallowed by the wrapper.
 # The wrapper may intentionally defer EX_TEMPFAIL/rate-limit exits, but ordinary
 # dashboard failures must still flow through _stats_wrapper_run_health_update so
@@ -322,6 +340,7 @@ main_test() {
 	test_health_update_precedes_quality_sweep
 	test_health_update_survives_slow_quality_sweep
 	test_priority_dashboard_precedes_optional_cross_repo_work
+	test_slow_priority_dashboard_skips_optional_cross_repo_work
 	test_dashboard_update_failure_not_swallowed
 	test_transient_dashboard_tempfail_is_deferred
 	test_dashboard_body_edit_failure_returns_nonzero


### PR DESCRIPTION
## Summary

Refreshes the priority dashboard first, then skips optional cross-repository work when that refresh leaves insufficient time before the stats wrapper timeout. Adds regression coverage for the guard.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-wrapper-headless-export.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-dashboard-freshness-check.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; bash .agents/scripts/tests/test-stats-functions-characterization.sh; bash .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh; bash .agents/scripts/tests/test-gh-public-privacy-guard.sh; bash .agents/scripts/stats-wrapper.sh --self-check; bash .agents/scripts/stats-wrapper.sh --dry-run; complexity-regression-helper.sh check --base origin/main --working-tree --metric function-complexity; complexity-regression-helper.sh check --base origin/main --working-tree --metric nesting-depth; complexity-regression-helper.sh check --base origin/main --working-tree --metric bash32-compat

Resolves #30106


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 10m and 132,247 tokens on this as a headless worker.