### PR TITLE
GH#30118: fix: serialize OpenCode pin repair for worker canaries

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1606,14 +1606,46 @@ _enforce_opencode_version_pin() {
 		return 0
 	fi
 
+	# Multiple Pulse candidates can hit the canary at once. Serialise the repair
+	# path so concurrent workers do not race a global package-manager reinstall
+	# and falsely fail closed while another process is restoring the same pin.
+	local repair_lock_base="${STATE_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+	local repair_lock_dir="${repair_lock_base}/opencode-pin-repair.lock"
+	mkdir -p "$repair_lock_base" 2>/dev/null || true
+	local repair_lock_acquired=0
+	local repair_lock_waited=0
+	while ! mkdir "$repair_lock_dir" 2>/dev/null; do
+		if [[ "$repair_lock_waited" -ge "30" ]]; then
+			print_error "Timed out waiting for OpenCode ${pin} repair lock -- refusing headless launch"
+			return 1
+		fi
+		sleep 1
+		repair_lock_waited=$((repair_lock_waited + 1))
+	done
+	repair_lock_acquired=1
+
+	# Another canary may have repaired the runtime while this process waited.
+	if ! installed=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null); then
+		installed="unknown"
+	fi
+	installed="${installed#v}"
+	installed="${installed%%[[:space:]]*}"
+	[[ "$installed" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || installed="unknown"
+	if [[ "$installed" == "$pin" ]]; then
+		rmdir "$repair_lock_dir" 2>/dev/null || true
+		return 0
+	fi
+
 	print_warning "OpenCode version drift: installed=$installed, pin=$pin -- reinstalling"
 	local repair_cmd=""
 	if ! repair_cmd=$(aidevops_opencode_upgrade_command "$pin"); then
 		print_error "Cannot build OpenCode ${pin} repair command -- refusing headless launch"
+		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
 		return 1
 	fi
 	if ! AIDEVOPS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT" bash -c "$repair_cmd" >/dev/null 2>&1; then
 		print_error "Failed to restore OpenCode to ${pin} -- refusing headless launch"
+		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
 		return 1
 	fi
 
@@ -1626,8 +1658,10 @@ _enforce_opencode_version_pin() {
 	[[ "$restored" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || restored="unknown"
 	if [[ "$restored" != "$pin" ]]; then
 		print_error "OpenCode version mismatch after repair: installed=$restored, pin=$pin -- refusing headless launch"
+		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
 		return 1
 	fi
+	rmdir "$repair_lock_dir" 2>/dev/null || true
 	print_info "OpenCode restored to ${pin}"
 	return 0
 }

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -226,6 +226,39 @@ assert_eq "headless pin repair status" "0" "$guard_rc"
 assert_eq "headless repair uses resolved binary outside PATH" "1.18.16" "$("$SANDBOX/version-guard/runtime/opencode")"
 assert_eq "headless pin reinstall command" "install -g opencode-ai@1.18.16" "$(tr '\n' ';' <"$SANDBOX/version-guard/calls" | sed 's/;$//')"
 
+printf 'Test 4b: concurrent headless version guard waits for repair and avoids duplicate reinstall\n'
+mkdir -p "$SANDBOX/version-guard-lock/runtime" "$SANDBOX/version-guard-lock/bin" "$SANDBOX/version-guard-lock/state"
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/version-guard-lock/runtime/opencode" '#!/usr/bin/env bash
+version=$(<"'"$SANDBOX"'/version-guard-lock/version")
+printf "%s\n" "$version"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/version-guard-lock/bin/npm" '#!/usr/bin/env bash
+printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard-lock/calls"
+printf "1.18.16\n" >"'"$SANDBOX"'/version-guard-lock/version"'
+printf '1.18.7\n' >"$SANDBOX/version-guard-lock/version"
+mkdir "$SANDBOX/version-guard-lock/state/opencode-pin-repair.lock"
+(
+ sleep 1
+ printf '1.18.16\n' >"$SANDBOX/version-guard-lock/version"
+ rmdir "$SANDBOX/version-guard-lock/state/opencode-pin-repair.lock"
+) &
+lock_repair_pid=$!
+guard_rc=0
+(
+	source_extracted
+	STATE_DIR="$SANDBOX/version-guard-lock/state"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard-lock/runtime/opencode"
+	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
+	print_warning() { return 0; }
+	print_info() { return 0; }
+	print_error() { return 0; }
+	PATH="$SANDBOX/version-guard-lock/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
+) || guard_rc=$?
+wait "$lock_repair_pid" 2>/dev/null || true
+assert_eq "headless pin repair lock wait status" "0" "$guard_rc"
+assert_eq "headless pin repair lock avoids duplicate reinstall" "0" "$([[ -f "$SANDBOX/version-guard-lock/calls" ]] && wc -l <"$SANDBOX/version-guard-lock/calls" || printf '0\n')"
+
 printf 'Test 5: headless version guard fails closed when reinstall fails\n'
 mkdir -p "$SANDBOX/version-install-failure"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Serialize OpenCode pinned-version repairs in headless canary preflight with a shared lock.
- Re-check the installed version after waiting so concurrent canaries can succeed when another process already restored the pin.
- Add a regression that simulates an in-progress repair and verifies the waiting guard avoids a duplicate reinstall.

## Evidence

Observed worker pre-runtime logs for #30106 and #30107 both reported:

```
OpenCode version drift: installed=1.18.9, pin=1.18.16 -- reinstalling
Failed to restore OpenCode to 1.18.16 -- refusing headless launch
```

Both attempts recorded `pre_runtime_failure:canary_preflight`; a manual canary later restored/passed at `1.18.16`, indicating repair race/self-heal timing rather than provider auth.

## Verification

- .agents/scripts/tests/test-tool-version-check-opencode.sh
- shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-tool-version-check-opencode.sh
- git diff --check HEAD~1..HEAD
- bun run typecheck

Resolves #30118

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.5
