### PR TITLE
GH#30088: fix configured worktree permissions and approval continuity

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -24,6 +24,7 @@ import {
   enforceTeamInterfaceConversationIsolation,
   enforceTeamInterfaceRemoteInteractiveSelection,
   ensureAgentGuard,
+  managedExternalDirectories,
   registerManagedDirectoryPermissions,
 } from "./config-safety-guards.mjs";
 import {
@@ -39,6 +40,7 @@ export {
   enforcePublicTriageIsolation,
   enforceTeamInterfaceConversationIsolation,
   enforceTeamInterfaceRemoteInteractiveSelection,
+  managedExternalDirectories,
   registerManagedDirectoryPermissions,
   registerResearchOnlyAgent,
 };

--- a/.agents/plugins/opencode-aidevops/config-safety-guards.mjs
+++ b/.agents/plugins/opencode-aidevops/config-safety-guards.mjs
@@ -38,7 +38,7 @@ if (process.platform === "darwin") {
   }
 }
 
-const MANAGED_EXTERNAL_DIRECTORIES = [
+const STABLE_MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.aidevops",
   "~/.aidevops/**",
   "~/.config/aidevops",
@@ -47,12 +47,24 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.config/opencode/command/**",
   "~/.config/opencode/skills",
   "~/.config/opencode/skills/**",
-  "~/Git/_worktrees",
-  "~/Git/_worktrees/**",
-  ...[...tempDirectories].sort().flatMap((path) => [path, `${path}/**`]),
 ];
 
-function addManagedDirectoryRules(target) {
+export function managedExternalDirectories(env = process.env) {
+  const isConfigured = Object.hasOwn(env, "AIDEVOPS_WORKTREE_BASE_DIR");
+  const configured = env.AIDEVOPS_WORKTREE_BASE_DIR;
+  const worktreeBase = isConfigured ? configured.replace(/\/+$/, "") : "~/Git/_worktrees";
+  if (isConfigured && (!worktreeBase.startsWith("/") || worktreeBase === "/")) {
+    throw new TypeError("AIDEVOPS_WORKTREE_BASE_DIR must be a non-root absolute path");
+  }
+  return [
+    ...STABLE_MANAGED_EXTERNAL_DIRECTORIES,
+    worktreeBase,
+    `${worktreeBase}/**`,
+    ...[...tempDirectories].sort().flatMap((path) => [path, `${path}/**`]),
+  ];
+}
+
+function addManagedDirectoryRules(target, env) {
   if (typeof target.permission === "string") {
     const defaultPermission = target.permission;
     target.permission = {
@@ -69,8 +81,13 @@ function addManagedDirectoryRules(target) {
   const rules = typeof existing === "string"
     ? { "*": existing }
     : { ...existing };
+  const configuredWorktreeBase = managedExternalDirectories(env)[STABLE_MANAGED_EXTERNAL_DIRECTORIES.length];
+  if (configuredWorktreeBase !== "~/Git/_worktrees") {
+    delete rules["~/Git/_worktrees"];
+    delete rules["~/Git/_worktrees/**"];
+  }
   let count = 0;
-  for (const path of MANAGED_EXTERNAL_DIRECTORIES) {
+  for (const path of managedExternalDirectories(env)) {
     if (rules[path] !== "allow") count++;
     // OpenCode uses the last matching rule, so managed exceptions must follow
     // broad user defaults such as `"*": "ask"`.
@@ -81,10 +98,10 @@ function addManagedDirectoryRules(target) {
   return count;
 }
 
-export function registerManagedDirectoryPermissions(config) {
-  let count = addManagedDirectoryRules(config);
+export function registerManagedDirectoryPermissions(config, env = process.env) {
+  let count = addManagedDirectoryRules(config, env);
   for (const agent of Object.values(config.agent || {})) {
-    count += addManagedDirectoryRules(agent);
+    count += addManagedDirectoryRules(agent, env);
   }
   return count;
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 
-import { registerManagedDirectoryPermissions } from "../config-hook.mjs";
+import { managedExternalDirectories, registerManagedDirectoryPermissions } from "../config-hook.mjs";
 
 const tempDirectories = new Set();
 function addTempDirectory(path) {
@@ -20,23 +20,44 @@ if (process.platform === "darwin") {
   const darwinTemp = execFileSync("/usr/bin/getconf", ["DARWIN_USER_TEMP_DIR"], { encoding: "utf8" }).trim();
   addTempDirectory(darwinTemp);
 }
-const managedRules = {
-  "~/.aidevops": "allow",
-  "~/.aidevops/**": "allow",
-  "~/.config/aidevops": "allow",
-  "~/.config/aidevops/**": "allow",
-  "~/.config/opencode/command": "allow",
-  "~/.config/opencode/command/**": "allow",
-  "~/.config/opencode/skills": "allow",
-  "~/.config/opencode/skills/**": "allow",
-  "~/Git/_worktrees": "allow",
-  "~/Git/_worktrees/**": "allow",
-  ...Object.fromEntries([...tempDirectories].sort().flatMap((path) => [
-    [path, "allow"],
-    [`${path}/**`, "allow"],
-  ])),
-};
+const managedRules = Object.fromEntries(
+  managedExternalDirectories({}).map((path) => [path, "allow"]),
+);
 const managedRuleCount = Object.keys(managedRules).length;
+const defaultManagedEnvironment = {};
+
+test("uses the configured worktree base instead of hardcoding ~/Git", () => {
+  assert.deepEqual(
+    managedExternalDirectories({ AIDEVOPS_WORKTREE_BASE_DIR: "/Users/test/Projects/.worktrees/" })
+      .filter((path) => path.includes("worktrees")),
+    ["/Users/test/Projects/.worktrees", "/Users/test/Projects/.worktrees/**"],
+  );
+});
+
+test("rejects unsafe configured worktree bases", () => {
+  for (const value of ["", "/", "///", "relative/worktrees", "~"]) {
+    assert.throws(
+      () => managedExternalDirectories({ AIDEVOPS_WORKTREE_BASE_DIR: value }),
+      /must be a non-root absolute path/,
+    );
+  }
+});
+
+test("registers the configured worktree base for global and agent permissions", () => {
+  const config = {
+    permission: { external_directory: { "*": "ask", "~/Git/_worktrees": "allow", "~/Git/_worktrees/**": "allow" } },
+    agent: { "Build+": { permission: { external_directory: "ask" } } },
+  };
+  const env = { AIDEVOPS_WORKTREE_BASE_DIR: "/Users/test/Projects/.worktrees" };
+
+  assert.ok(registerManagedDirectoryPermissions(config, env) > 0);
+  for (const target of [config, config.agent["Build+"]]) {
+    assert.equal(target.permission.external_directory["/Users/test/Projects/.worktrees"], "allow");
+    assert.equal(target.permission.external_directory["/Users/test/Projects/.worktrees/**"], "allow");
+    assert.equal(target.permission.external_directory["~/Git/_worktrees"], undefined);
+    assert.equal(target.permission.external_directory["~/Git/_worktrees/**"], undefined);
+  }
+});
 
 test("adds narrow managed-directory exceptions after a broad ask rule", () => {
   const config = {
@@ -48,7 +69,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), managedRuleCount);
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
     "~/Documents/**": "deny",
@@ -61,7 +82,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
 test("converts a top-level default without allowing unrelated directories", () => {
   const config = { permission: "ask" };
 
-  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), managedRuleCount);
   assert.equal(config.permission["*"], "ask");
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
@@ -72,15 +93,15 @@ test("converts a top-level default without allowing unrelated directories", () =
 test("leaves an existing global external-directory allow unchanged", () => {
   const config = { permission: { external_directory: "allow", read: "ask" } };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 0);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), 0);
   assert.deepEqual(config.permission, { external_directory: "allow", read: "ask" });
 });
 
 test("is idempotent and keeps managed rules last", () => {
   const config = { permission: { external_directory: { "*": "ask" } } };
 
-  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
-  assert.equal(registerManagedDirectoryPermissions(config), 0);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), managedRuleCount);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), 0);
   assert.deepEqual(Object.keys(config.permission.external_directory).slice(-managedRuleCount), Object.keys(managedRules));
 });
 
@@ -93,7 +114,7 @@ test("adds managed rules to per-agent permissions that override top-level defaul
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount * 3);
+  assert.equal(registerManagedDirectoryPermissions(config, defaultManagedEnvironment), managedRuleCount * 3);
   assert.deepEqual(config.agent["Build+"].permission.external_directory, {
     "*": "ask",
     ...managedRules,

--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -104,6 +104,10 @@ def _persist_managed_external_directories(config):
         return
     rules = {'*': existing} if isinstance(existing, str) else dict(existing or {})
     managed_paths = managed_external_directories()
+    worktree_base = managed_paths[6]
+    if worktree_base != '~/Git/_worktrees':
+        rules.pop('~/Git/_worktrees', None)
+        rules.pop('~/Git/_worktrees/**', None)
     for path in managed_paths:
         rules.pop(path, None)
         rules[path] = 'allow'

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1003,13 +1003,15 @@ _approval_verify_locked_issue_continuity() {
 	if ! jq -e --argjson signed "$signed_lifecycle" '
 		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:in-review" or . == "status:in-progress";
 		.lifecycle as $current |
+		($current.labels | map(.name)) as $current_labels |
+		($signed.labels | map(.name)) as $signed_labels |
 		$current.state == $signed.state
 		and $current.state_reason == $signed.state_reason
 		and $current.locked == $signed.locked
 		and $current.active_lock_reason == $signed.active_lock_reason
 		and $current.milestone == $signed.milestone
 		and $current.lock_anchor == $signed.lock_anchor
-		and ([(($current.labels + $signed.labels)[] | .name)] | unique | all(allowed_label))
+		and ([($current_labels - $signed_labels)[], ($signed_labels - $current_labels)[]] | unique | all(allowed_label))
 		and ($current.assignees != $signed.assignees or $current.labels != $signed.labels)
 	' <<<"$current_snapshot" >/dev/null 2>&1; then
 		return 1

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -248,6 +248,17 @@ _write_permissive_stub() {
 	local extra_tools="$4"
 	local quoted_desc
 	quoted_desc=$(_yaml_quote_scalar "$src_desc")
+	local worktree_base="${HOME}/Git/_worktrees"
+	if [[ -n "${AIDEVOPS_WORKTREE_BASE_DIR+x}" ]]; then
+		worktree_base="$AIDEVOPS_WORKTREE_BASE_DIR"
+	fi
+	while [[ "$worktree_base" == */ ]]; do
+		worktree_base="${worktree_base%/}"
+	done
+	if [[ "$worktree_base" != /* || "$worktree_base" == "/" ]]; then
+		printf 'AIDEVOPS_WORKTREE_BASE_DIR must be a non-root absolute path\n' >&2
+		return 1
+	fi
 	{
 		printf '%s\n' \
 			"---" \
@@ -262,8 +273,8 @@ _write_permissive_stub() {
 			'    "~/.config/aidevops/**": allow' \
 			'    "~/.config/opencode/command": allow' \
 			'    "~/.config/opencode/command/**": allow' \
-			'    "~/Git/_worktrees": allow' \
-			'    "~/Git/_worktrees/**": allow' \
+			"    \"${worktree_base}\": allow" \
+			"    \"${worktree_base}/**\": allow" \
 			"tools:" \
 			"  read: true" \
 			"  bash: true"

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -318,6 +318,22 @@ _write_restrictive_subagent_source() {
 # Arguments: $1 - source .md file path
 # Requires: AGENTS_DIR and agent_dir to be set (exported for xargs usage)
 # Outputs: "1" to stdout on success (for counting)
+_validated_worktree_base() {
+	local worktree_base="${HOME}/Git/_worktrees"
+	if [[ -n "${AIDEVOPS_WORKTREE_BASE_DIR+x}" ]]; then
+		worktree_base="$AIDEVOPS_WORKTREE_BASE_DIR"
+	fi
+	while [[ "$worktree_base" == */ ]]; do
+		worktree_base="${worktree_base%/}"
+	done
+	if [[ "$worktree_base" != /* || "$worktree_base" == "/" ]]; then
+		printf 'AIDEVOPS_WORKTREE_BASE_DIR must be a non-root absolute path\n' >&2
+		return 1
+	fi
+	printf '%s\n' "$worktree_base"
+	return 0
+}
+
 _write_subagent_stub() {
 	local f="$1"
 	local name
@@ -381,6 +397,8 @@ _write_subagent_stub() {
 
 	local quoted_desc
 	quoted_desc=$(_yaml_quote_scalar "$src_desc")
+	local worktree_base=""
+	worktree_base=$(_validated_worktree_base) || return 1
 
 	{
 		printf '%s\n' \
@@ -401,8 +419,8 @@ _write_subagent_stub() {
 			'    "~/.config/aidevops/**": allow' \
 			'    "~/.config/opencode/command": allow' \
 			'    "~/.config/opencode/command/**": allow' \
-			'    "~/Git/_worktrees": allow' \
-			'    "~/Git/_worktrees/**": allow' \
+			"    \"${worktree_base}\": allow" \
+			"    \"${worktree_base}/**\": allow" \
 			"tools:" \
 			"  read: true" \
 			"  bash: true"
@@ -514,6 +532,7 @@ _generate_subagents_opencode() {
 	export -f _yaml_quote_scalar 2>/dev/null || true
 	export -f _read_subagent_runtime_guards 2>/dev/null || true
 	export -f _write_restrictive_subagent_source 2>/dev/null || true
+	export -f _validated_worktree_base 2>/dev/null || true
 	export -f _write_subagent_stub 2>/dev/null || true
 	export AGENTS_DIR
 	export agent_dir

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -53,9 +53,13 @@ def managed_external_directories():
         "~/.config/aidevops/**",
         "~/.config/opencode/command",
         "~/.config/opencode/command/**",
-        "~/Git/_worktrees",
-        "~/Git/_worktrees/**",
     ]
+    is_worktree_base_configured = "AIDEVOPS_WORKTREE_BASE_DIR" in os.environ
+    configured_worktree_base = os.environ.get("AIDEVOPS_WORKTREE_BASE_DIR", "")
+    worktree_base = configured_worktree_base.rstrip("/") if is_worktree_base_configured else "~/Git/_worktrees"
+    if is_worktree_base_configured and (not worktree_base.startswith("/") or worktree_base == "/"):
+        raise ValueError("AIDEVOPS_WORKTREE_BASE_DIR must be a non-root absolute path")
+    paths.extend((worktree_base, f"{worktree_base}/**"))
     configured_temp = tempfile.gettempdir().rstrip("/")
     temp_dirs = {configured_temp, os.path.realpath(configured_temp)}
     if sys.platform == "darwin":

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -406,7 +406,7 @@ test_post_approval_linked_references() {
 
 write_locked_issue_fixture() {
 	write_baseline_fixtures
-	jq '.locked = true | .active_lock_reason = "resolved" | .labels = [] | .assignees = []' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	jq '.locked = true | .active_lock_reason = "resolved" | .labels = [{id:6,node_id:"L_6",name:"external-contributor"},{id:7,node_id:"L_7",name:"origin:interactive"},{id:8,node_id:"L_8",name:"review:approve"},{id:9,node_id:"L_9",name:"tier:standard"}] | .assignees = []' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	jq '.[0] += [{id:418,node_id:"EV_418",event:"locked",created_at:"2026-01-01T00:04:00Z",actor:{id:1,node_id:"U_1",login:"maintainer",type:"User"}}]' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
 	append_signed_comment issue 41 "2026-01-01T00:05:00Z" 4199
 	return 0
@@ -420,7 +420,7 @@ append_issue_timeline_event() {
 
 test_locked_issue_continuity() {
 	write_locked_issue_fixture
-	jq '.assignees = [{id:1,node_id:"U_1",login:"maintainer",type:"User"}] | .labels = [{id:7,node_id:"L_7",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	jq '.assignees = [{id:1,node_id:"U_1",login:"maintainer",type:"User"}] | .labels += [{id:10,node_id:"L_10",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	append_issue_timeline_event '{"id":420,"node_id":"EV_420","event":"assigned","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'
 	append_issue_timeline_event '{"id":421,"node_id":"EV_421","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
 	assert_verify "trusted allowlisted mutations preserve continuously locked issue approval" issue 41 VERIFIED 0

--- a/.agents/scripts/tests/test-opencode-subagent-runtime-guards.sh
+++ b/.agents/scripts/tests/test-opencode-subagent-runtime-guards.sh
@@ -86,6 +86,13 @@ source_status=$?
 set -e
 [[ "$source_status" -eq 0 ]]
 
+for unsafe_worktree_base in "" "/" "///" "relative/worktrees" "~"; do
+	if AIDEVOPS_WORKTREE_BASE_DIR="$unsafe_worktree_base" _validated_worktree_base >/dev/null 2>&1; then
+		printf 'FAIL: accepted unsafe configured worktree base %q\n' "$unsafe_worktree_base" >&2
+		exit 1
+	fi
+done
+
 if ! _write_subagent_stub "$AGENTS_DIR/tools/code-review/bounded-review.md" >/dev/null; then
 	printf '%s\n' 'FAIL: could not generate bounded OpenCode subagent' >&2
 	exit 1


### PR DESCRIPTION
## Summary

Honor validated AIDEVOPS_WORKTREE_BASE_DIR permissions across runtime and persisted OpenCode config; reject unsafe bases; preserve locked approval continuity when unchanged stable labels coexist with allowlisted lifecycle transitions. Resolves #30120.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/config-safety-guards.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs, .agents/scripts/agent-discovery.py, .agents/scripts/approval-helper.sh, .agents/scripts/generate-opencode-agents.sh, .agents/scripts/generate-runtime-config-agents.sh, .agents/scripts/lib/agent_config.py, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-opencode-subagent-runtime-guards.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Node managed-directory tests; OpenCode subagent runtime guard test; approval content-binding suite (43 cases); same-session regression; Python compilation; ShellCheck; local linters.

Resolves #30088


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 2h 52m and 586,258 tokens on this with the user in an interactive session.