### PR TITLE
GH#30115: fix: bound dashboard activity helpers

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -51,6 +51,12 @@ readonly STATS_HEALTH_EX_PARTIAL="${EX_PARTIAL:-75}"
 # unbounded blocking point when GitHub is slow.
 : "${STATS_HEALTH_PERSON_STATS_RATE_LIMIT_TIMEOUT:=10}"
 
+# The primary dashboard must publish its freshness marker within the enclosing
+# stats-wrapper ceiling. Activity and session-time helpers can walk large local
+# histories, so bound each best-effort section independently rather than let a
+# single slow history scan consume the whole dashboard refresh budget.
+: "${STATS_HEALTH_ACTIVITY_TIMEOUT:=60}"
+
 # --- Functions ---
 
 #######################################
@@ -711,7 +717,7 @@ _gather_activity_stats_for_repo() {
 	local repo_path="$1"
 	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
 	if [[ -x "$activity_helper" ]]; then
-		bash "$activity_helper" summary "$repo_path" --period month --format markdown || echo "_Activity data unavailable._"
+		timeout_sec "$STATS_HEALTH_ACTIVITY_TIMEOUT" bash "$activity_helper" summary "$repo_path" --period month --format markdown || echo "_Activity data unavailable._"
 	else
 		echo "_Activity helper not installed._"
 	fi
@@ -729,7 +735,7 @@ _gather_session_time_for_repo() {
 	local repo_path="$1"
 	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
 	if [[ -x "$activity_helper" ]]; then
-		bash "$activity_helper" session-time "$repo_path" --period all --format markdown || echo "_Session data unavailable._"
+		timeout_sec "$STATS_HEALTH_ACTIVITY_TIMEOUT" bash "$activity_helper" session-time "$repo_path" --period all --format markdown || echo "_Session data unavailable._"
 	else
 		echo "_Activity helper not installed._"
 	fi

--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -183,6 +183,18 @@ test_dashboard_wraps_person_stats_rate_limit_probes() {
 	return 0
 }
 
+test_dashboard_wraps_local_activity_helpers_with_timeout() {
+	local name="dashboard bounds local activity helper calls"
+	local summary_pattern="timeout_sec \"\$STATS_HEALTH_ACTIVITY_TIMEOUT\" bash \"\$activity_helper\" summary"
+	local session_pattern="timeout_sec \"\$STATS_HEALTH_ACTIVITY_TIMEOUT\" bash \"\$activity_helper\" session-time"
+	if grep -Fq "$summary_pattern" "$DASHBOARD_LIB" && grep -Fq "$session_pattern" "$DASHBOARD_LIB"; then
+		pass "$name"
+	else
+		fail "$name" "missing wall-clock timeout around local activity or session-time helper"
+	fi
+	return 0
+}
+
 test_dashboard_preserves_partial_cache() {
 	local name="dashboard caches partial person-stats output and updates marker"
 	local fake_home="${TMP_DIR}/home-partial"
@@ -288,6 +300,7 @@ test_cross_repo_collection_failures_are_partial
 test_legacy_all_zero_cache_is_unavailable
 test_dashboard_wraps_person_stats_with_timeout
 test_dashboard_wraps_person_stats_rate_limit_probes
+test_dashboard_wraps_local_activity_helpers_with_timeout
 test_dashboard_preserves_partial_cache
 test_dashboard_skips_marker_when_all_refreshes_fail
 


### PR DESCRIPTION
## Summary

Bound per-repository activity and session-time collection so a slow local history scan cannot exhaust the stats-wrapper budget before the supervisor dashboard refresh completes.

## Files Changed

.agents/scripts/stats-health-dashboard-data.sh, .agents/scripts/tests/test-contributor-activity-helper-person.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/tests/test-contributor-activity-helper-person.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; bash .agents/scripts/stats-wrapper.sh --self-check; shellcheck .agents/scripts/stats-health-dashboard-data.sh .agents/scripts/tests/test-contributor-activity-helper-person.sh

Resolves #30115


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 11m and 144,640 tokens on this as a headless worker.