### PR TITLE
GH#30114: fix: ignore historical supervisor dashboards (#30114)

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -233,17 +233,17 @@ _cadence_gate_ok() {
 
 # Emit "slug issue_number" lines for every known dashboard. Prefer local
 # ~/.aidevops/logs/health-issue-* cache files written by stats-health-dashboard.sh,
-# and include open `source:health-dashboard` issues in configured repos. The
-# GitHub enumeration is intentional even when some caches exist: it covers
-# orphaned historical dashboards after cache migration, identity changes, or
-# fresh hosts where only the stale dashboard's cache is absent.
+# and include the current authenticated supervisor dashboard in configured repos
+# when that repository has no local cache. The authenticated identity constraint
+# keeps retired dashboards for other operators from repeatedly filing stale
+# alerts after a host or supervisor changes.
 # Historical cache names included the role segment
 # (`health-issue-<runner>-supervisor-<slug-dashed>`); current canonical identity
 # caches omit it (`health-issue-<canonical>-<slug-dashed>`). Resolve both by
 # matching the longest repos.json slug suffix instead of parsing a fixed segment
 # position.
 _enumerate_dashboards() {
-	local cache issue slug_raw slug key seen="|" cached_slugs="|" slug_candidates
+	local cache issue slug_raw slug key seen="|" cached_slugs="|" slug_candidates current_user=""
 	slug_candidates="$(_repo_slug_candidates)"
 	shopt -s nullglob
 	for cache in "${HEALTH_ISSUE_CACHE_DIR}"/health-issue-*; do
@@ -262,6 +262,8 @@ _enumerate_dashboards() {
 	done
 	shopt -u nullglob
 	if command -v gh >/dev/null 2>&1 && gh auth status &>/dev/null 2>&1; then
+		current_user=$(_dashboard_scan_current_user)
+		[[ -n "$current_user" ]] || return 0
 		while IFS= read -r slug; do
 			[[ -n "$slug" ]] || continue
 			case "$cached_slugs" in
@@ -275,7 +277,7 @@ _enumerate_dashboards() {
 				esac
 				seen="${seen}${key}|"
 				printf '%s %s\n' "$slug" "$issue"
-			done < <(_github_health_dashboard_issue_numbers "$slug")
+			done < <(_github_health_dashboard_issue_numbers "$slug" "$current_user")
 		done < <(_repo_slugs_for_dashboard_scan)
 	fi
 	return 0
@@ -295,15 +297,28 @@ _repo_slugs_for_dashboard_scan() {
 	return 0
 }
 
-# Emit open supervisor health-dashboard issue numbers for a repo via
-# REST-backed gh api. Contributor dashboards are intentionally excluded: they
-# can be stale when that contributor is offline and are not the operator's
-# primary single-glance health surface.
+# Resolve the authenticated GitHub login once for remote dashboard enumeration.
+# Output: validated GitHub login, or empty when it cannot be safely determined.
+_dashboard_scan_current_user() {
+	local current_user=""
+	current_user=$(gh api user --jq '.login // ""' 2>>"$LOGFILE" || true)
+	[[ "$current_user" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 0
+	printf '%s\n' "$current_user"
+	return 0
+}
+
+# Emit the open supervisor health-dashboard issue number for the authenticated
+# operator in a repo via REST-backed gh api. Contributor dashboards and
+# historical dashboards for other supervisors are intentionally excluded: they
+# can be stale when that operator is offline and are not this host's primary
+# single-glance health surface.
 _github_health_dashboard_issue_numbers() {
 	local slug="$1"
-	[[ -n "$slug" ]] || return 0
+	local current_user="$2"
+	[[ -n "$slug" && "$current_user" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 0
 	gh api --paginate "repos/${slug}/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100" \
-		--jq '.[] | select(.pull_request == null) | .number' 2>>"$LOGFILE" || true
+		--jq ".[] | select(.pull_request == null) | select(any(.labels[]?; .name == \"operator:${current_user}\")) | .number" \
+		2>>"$LOGFILE" || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -27,9 +27,9 @@
 #      closes the recovered missing-marker alert and files a stale alert.
 #  11. open issue list failures are logged instead of silently treated as an
 #      empty dedup result.
-#  12. scan without a local health-issue cache falls back to open
-#      source:health-dashboard issues for configured repos, while a local cache
-#      suppresses historical dashboards for that same repo.
+#  12. scan without a local health-issue cache falls back to the authenticated
+#      operator's open source:health-dashboard issue for configured repos, while
+#      a local cache suppresses historical dashboards for that same repo.
 #  13. source regression: recovered stale and missing-marker alert paths share
 #      the parameterized close helper and accept a pre-fetched open issue list.
 #
@@ -204,7 +204,14 @@ run_scan_stub_script() {
 						return 0
 						;;
 					api)
+						if [[ "$gh_args" == *"user --jq .login // \"\""* ]]; then
+							printf '%s\n' "testrunner"
+							return 0
+						fi
 						if [[ "$gh_args" == *"repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100"* ]]; then
+							if [[ "${DASHBOARD_TITLE:-}" == "[Supervisor:historical] stale" ]]; then
+								return 0
+							fi
 							printf "%s\n" 424242
 							return 0
 						fi
@@ -520,8 +527,9 @@ created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
 [[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
 
 if (( created_count == 1 )) \
-	&& grep -q '^api --paginate repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100 ' "$calls_file"; then
-	pass "missing cache → source:health-dashboard fallback scans dashboard"
+	&& grep -q '^api --paginate repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100 ' "$calls_file" \
+	&& grep -q 'operator:testrunner' "$calls_file"; then
+	pass "missing cache → current supervisor dashboard fallback scans dashboard"
 else
 	fail "source health-dashboard fallback" \
 		"created=$created_count; calls:\n$(cat "$calls_file")"
@@ -547,7 +555,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 12b: contributor health dashboards are ignored
+# Test 12b: a dashboard for a different supervisor is ignored when no local
+# cache exists, preventing stale alerts for inactive historical operators.
+# ---------------------------------------------------------------------------
+echo "Testing: historical supervisor dashboard is ignored"
+rm -f "$HEALTH_CACHE"
+run_scan_with_stubs "$STALE_BODY" 0 "export DASHBOARD_TITLE='[Supervisor:historical] stale'" >/dev/null
+calls_file="${TMP}/gh-calls.log"
+created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
+[[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
+
+if (( created_count == 0 )); then
+	pass "historical supervisor dashboard without operator label → no alert"
+else
+	fail "historical supervisor dashboard ignored" \
+		"created=$created_count; calls:\n$(cat "$calls_file")"
+fi
+printf '%s\n' 424242 >"$HEALTH_CACHE"
+
+# ---------------------------------------------------------------------------
+# Test 12c: contributor health dashboards are ignored
 # ---------------------------------------------------------------------------
 echo "Testing: contributor dashboard is ignored"
 run_scan_with_stubs "$STALE_BODY" 0 "export DASHBOARD_TITLE='[Contributor:testrunner] stale'; export DASHBOARD_ROLE_LABEL=contributor" >/dev/null


### PR DESCRIPTION
## Summary

Restrict remote dashboard freshness fallback to the authenticated operator so retired supervisor dashboards cannot repeatedly create stale alerts after host or supervisor changes.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh, .agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-dashboard-freshness-check.sh; bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/stats-wrapper.sh --self-check; bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-repo-state-guard.sh; bash .agents/scripts/tests/test-repo-maintenance-state.sh; shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh .agents/scripts/stats-wrapper.sh .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh

Resolves #30114


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 12m and 150,959 tokens on this as a headless worker.