### PR TITLE
GH#30093: isolate runtime-audit drift evidence

### DIFF
--- a/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
+++ b/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
@@ -22,7 +22,10 @@
 
 # shellcheck shell=bash
 
-runtime_audit_id() { printf 'deployed-vs-source-mtime-drift\n'; return 0; }
+runtime_audit_id() {
+	printf 'deployed-vs-source-mtime-drift\n'
+	return 0
+}
 
 _runtime_audit_sha256() {
 	local path="$1"
@@ -107,7 +110,8 @@ runtime_audit_check() {
 	local evidence_rendered
 	evidence_rendered="$evidence_table"
 	local body
-	body=$(cat <<MARKDOWN
+	body=$(
+		cat <<MARKDOWN
 ## Task
 
 The pulse executes a deployed runtime copy, while the repository remains the source of truth. The trusted audit compared both copies before dispatch. The files below have a source-newer-than-deployed delta exceeding ${drift}s (${drift_hours}h).
@@ -146,7 +150,7 @@ Re-run the audit; the cited files should no longer appear:
 
 <!-- aidevops:generator=runtime-audit detector=deployed-vs-source-mtime-drift -->
 MARKDOWN
-)
+	)
 
 	jq -n --arg id "deployed-vs-source-mtime-drift" --arg title "$title" --arg body "$body" \
 		'{id: $id, title: $title, body: $body}'

--- a/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
+++ b/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
@@ -24,6 +24,34 @@
 
 runtime_audit_id() { printf 'deployed-vs-source-mtime-drift\n'; return 0; }
 
+_runtime_audit_sha256() {
+	local path="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$path" | cut -d ' ' -f 1
+		return $?
+	fi
+	shasum -a 256 "$path" | cut -d ' ' -f 1
+	return $?
+}
+
+_runtime_audit_bounded_diff() {
+	local deployed_path="$1"
+	local source_path="$2"
+	local name="$3"
+	local deployed_dir="$4"
+	local source_dir="$5"
+	local rendered=""
+
+	rendered=$(diff -u --label "deployed/${name}" --label "source/${name}" \
+		"$deployed_path" "$source_path" 2>/dev/null | sed -n '1,80p') || true
+	# Source files can themselves mention either checkout. Redact those literals so
+	# generated worker instructions never require or disclose host-only paths.
+	rendered=${rendered//"$deployed_dir"/<deployed-dir>}
+	rendered=${rendered//"$source_dir"/<source-dir>}
+	printf '%s\n' "$rendered"
+	return 0
+}
+
 runtime_audit_check() {
 	local deployed_dir="${AIDEVOPS_DEPLOYED_DIR:-${HOME}/.aidevops/agents/scripts}"
 	local source_dir="${AIDEVOPS_SOURCE_DIR:-${HOME}/Git/aidevops/.agents/scripts}"
@@ -58,11 +86,16 @@ runtime_audit_check() {
 		return 0
 	fi
 
-	local evidence_table="| File | Drift | Deployed mtime | Source mtime |"$'\n'"| --- | --- | --- | --- |"
-	local entry name d_str dm sm
+	local evidence_table="| File | Drift | Deployed mtime | Source mtime | Deployed SHA-256 | Source SHA-256 |"$'\n'"| --- | --- | --- | --- | --- | --- |"
+	local comparison_evidence=""
+	local entry name d_str dm sm deployed_sha source_sha bounded_diff
 	for entry in "${drifted[@]}"; do
 		IFS='|' read -r name d_str dm sm <<<"$entry"
-		evidence_table+=$'\n'"| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$sm") |"
+		deployed_sha=$(_runtime_audit_sha256 "${deployed_dir}/${name}" 2>/dev/null || printf 'unavailable')
+		source_sha=$(_runtime_audit_sha256 "${source_dir}/${name}" 2>/dev/null || printf 'unavailable')
+		evidence_table+=$'\n'"| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$sm") | \`${deployed_sha}\` | \`${source_sha}\` |"
+		bounded_diff=$(_runtime_audit_bounded_diff "${deployed_dir}/${name}" "${source_dir}/${name}" "$name" "$deployed_dir" "$source_dir")
+		comparison_evidence+=$'\n'"### \`${name}\`"$'\n\n'"~~~~diff"$'\n'"${bounded_diff}"$'\n'"~~~~"$'\n'
 	done
 
 	local first_file
@@ -77,11 +110,15 @@ runtime_audit_check() {
 	body=$(cat <<MARKDOWN
 ## Task
 
-The pulse executes scripts from \`${deployed_dir}/\`, but the source of truth is \`${source_dir}/\`. The files below have a source-newer-than-deployed delta exceeding ${drift}s (${drift_hours}h).
+The pulse executes a deployed runtime copy, while the repository remains the source of truth. The trusted audit compared both copies before dispatch. The files below have a source-newer-than-deployed delta exceeding ${drift}s (${drift_hours}h).
 
 ## Evidence
 
 ${evidence_rendered}
+
+The following sanitized comparison was captured by the audit. Each diff is limited to its first 80 lines; host-only checkout paths are replaced with placeholders.
+
+${comparison_evidence}
 
 ## Why
 
@@ -89,8 +126,8 @@ This is the canonical t2036 footgun — debugging a runtime symptom by reading s
 
 ## How
 
-1. Compare the diff: \`diff <(cat ${deployed_dir}/<file>) <(cat ${source_dir}/<file>)\` for each drifted file.
-2. If the source-side change is desired live: run \`aidevops update\` (or \`setup.sh --non-interactive\` from the source repo).
+1. Review the embedded hashes and bounded diff; do not read the host's canonical checkout.
+2. If the source-side change is desired live, run \`aidevops update\` from the worker's normal project boundary.
 3. Restart pulse if pulse-* files were touched: \`pulse-lifecycle-helper.sh restart-if-running\`.
 4. If the source-side change should NOT be deployed yet (work-in-progress): note that here and close. The drift will resolve when the work merges and a deploy fires.
 

--- a/.agents/scripts/tests/test-runtime-audit-detectors.sh
+++ b/.agents/scripts/tests/test-runtime-audit-detectors.sh
@@ -53,6 +53,19 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected not to find: $(printf '%q' "$needle")"
+	else
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	fi
+	return 0
+}
+
 assert_empty() {
 	local label="$1" value="$2"
 	TESTS_RUN=$((TESTS_RUN + 1))
@@ -274,6 +287,11 @@ assert_rc "3.1 firing fixture returns 1" "1" "$rc"
 assert_contains "3.2 firing body has correct id" '"id": "deployed-vs-source-mtime-drift"' "$out"
 assert_contains "3.3 firing references file" "pulse-wrapper.sh" "$out"
 assert_contains "3.4 firing body has marker" 'detector=deployed-vs-source-mtime-drift' "$out"
+assert_contains "3.5 firing body embeds bounded comparison evidence" "-deployed-content" "$out"
+assert_contains "3.6 firing body embeds source-side comparison evidence" "+source-content" "$out"
+assert_contains "3.7 firing body embeds SHA-256 evidence" "Deployed SHA-256" "$out"
+assert_not_contains "3.8 worker brief omits canonical source directory" "$DRIFT_SOURCE" "$out"
+assert_not_contains "3.9 worker brief omits trusted deployed directory" "$DRIFT_DEPLOYED" "$out"
 
 # Clean fixture: same mtime on both sides
 DRIFT_DEPLOYED2="$TMPDIR_TEST/deployed2"
@@ -289,14 +307,14 @@ out=$(_run_detector "$RULES_DIR/deployed-vs-source-mtime-drift.sh" \
 	"AIDEVOPS_SOURCE_DIR=$DRIFT_SOURCE2" \
 	"DRIFT_SECONDS=3600" \
 	"WATCHED_FILES=pulse-wrapper.sh") && rc=0 || rc=$?
-assert_rc "3.5 same-mtime fixture returns 0" "0" "$rc"
-assert_empty "3.6 same-mtime emits no output" "$out"
+assert_rc "3.10 same-mtime fixture returns 0" "0" "$rc"
+assert_empty "3.11 same-mtime emits no output" "$out"
 
 # Missing dirs → no-op
 out=$(_run_detector "$RULES_DIR/deployed-vs-source-mtime-drift.sh" \
 	"AIDEVOPS_DEPLOYED_DIR=/nonexistent/x" \
 	"AIDEVOPS_SOURCE_DIR=/nonexistent/y") && rc=0 || rc=$?
-assert_rc "3.7 missing dirs returns 0" "0" "$rc"
+assert_rc "3.12 missing dirs returns 0" "0" "$rc"
 
 # ---------------------------------------------------------------------------
 # Test 4: log-pattern-novelty

--- a/.agents/scripts/tests/test-runtime-audit-detectors.sh
+++ b/.agents/scripts/tests/test-runtime-audit-detectors.sh
@@ -103,7 +103,8 @@ trap 'rm -rf "$TMPDIR_TEST"' EXIT
 # Helper: run a detector in a clean subshell with an env block, capture
 # stdout and rc.
 _run_detector() {
-	local detector_file="$1"; shift
+	local detector_file="$1"
+	shift
 	local out
 	local rc=0
 	# shellcheck disable=SC2068  # passing through env assignments
@@ -266,8 +267,8 @@ mkdir -p "$DRIFT_DEPLOYED" "$DRIFT_SOURCE"
 
 # pulse-wrapper.sh: deployed touched 3 days ago, source touched 1 minute ago
 # → drift = ~3 days = 259200 > DRIFT_SECONDS (3600 in this test)
-echo "deployed-content" > "$DRIFT_DEPLOYED/pulse-wrapper.sh"
-echo "source-content"   > "$DRIFT_SOURCE/pulse-wrapper.sh"
+echo "deployed-content" >"$DRIFT_DEPLOYED/pulse-wrapper.sh"
+echo "source-content" >"$DRIFT_SOURCE/pulse-wrapper.sh"
 
 # Use touch -t to set deployed mtime in the past
 # Format: [[CC]YY]MMDDhhmm[.SS]
@@ -297,8 +298,8 @@ assert_not_contains "3.9 worker brief omits trusted deployed directory" "$DRIFT_
 DRIFT_DEPLOYED2="$TMPDIR_TEST/deployed2"
 DRIFT_SOURCE2="$TMPDIR_TEST/source2"
 mkdir -p "$DRIFT_DEPLOYED2" "$DRIFT_SOURCE2"
-echo "x" > "$DRIFT_DEPLOYED2/pulse-wrapper.sh"
-echo "x" > "$DRIFT_SOURCE2/pulse-wrapper.sh"
+echo "x" >"$DRIFT_DEPLOYED2/pulse-wrapper.sh"
+echo "x" >"$DRIFT_SOURCE2/pulse-wrapper.sh"
 # Touch both with same reference — touch -r preserves mtime exactly.
 touch -r "$DRIFT_DEPLOYED2/pulse-wrapper.sh" "$DRIFT_SOURCE2/pulse-wrapper.sh"
 
@@ -339,7 +340,7 @@ LOG_FIRING="$TMPDIR_TEST/log-firing.log"
 	for i in $(seq 1 50); do
 		printf '2026-04-30T00:00:00Z OTHER recent line padding iteration %d\n' "$i"
 	done
-} > "$LOG_FIRING"
+} >"$LOG_FIRING"
 
 out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
 	"LOG_FILE=$LOG_FIRING" \
@@ -362,7 +363,7 @@ LOG_PID_STABLE="$TMPDIR_TEST/log-pid-stable.log"
 	for _ in $(seq 1 100); do
 		printf 'Acquired lock (PID 1220368, age 5s, holder: pulse-instance-lock.sh)\n'
 	done
-} > "$LOG_PID_STABLE"
+} >"$LOG_PID_STABLE"
 
 out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
 	"LOG_FILE=$LOG_PID_STABLE" \
@@ -376,7 +377,7 @@ assert_empty "4.7 equivalent PID templates emit no finding" "$out"
 LOG_SHORT="$TMPDIR_TEST/log-short.log"
 for i in $(seq 1 50); do
 	printf 'short line %d\n' "$i"
-done > "$LOG_SHORT"
+done >"$LOG_SHORT"
 
 out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
 	"LOG_FILE=$LOG_SHORT" \
@@ -395,7 +396,7 @@ echo ""
 echo "--- Section 5: idle-state-stuck ---"
 
 PID_FIRING="$TMPDIR_TEST/pid-firing.pid"
-echo "SETUP:99999" > "$PID_FIRING"
+echo "SETUP:99999" >"$PID_FIRING"
 
 # Fake "PID dead" callable
 FAKE_DEAD="$TMPDIR_TEST/pid-dead.sh"
@@ -429,7 +430,7 @@ assert_empty "5.6 alive-PID emits no output" "$out"
 
 # No SETUP marker → no-op
 PID_CLEAN="$TMPDIR_TEST/pid-clean.pid"
-echo "12345" > "$PID_CLEAN"
+echo "12345" >"$PID_CLEAN"
 out=$(_run_detector "$RULES_DIR/idle-state-stuck.sh" \
 	"PID_FILE=$PID_CLEAN") && rc=0 || rc=$?
 assert_rc "5.7 no-SETUP-marker returns 0" "0" "$rc"


### PR DESCRIPTION
## Summary

- capture SHA-256 hashes and an 80-line sanitized source/deployed diff inside the trusted runtime audit
- stop generated worker briefs from naming host-only source or deployed directories
- retain source-versus-deployed drift semantics without broadening external-directory access

## Verification

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-runtime-audit-detectors.sh` (62 passed)
- `bash .agents/scripts/tests/test-approval-helper-content-binding.sh` (43 passed)

Resolves #30093

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol
