### PR TITLE
GH#30127: fix(approval): preserve canonical claim refresh continuity

### DIFF
--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -66,8 +66,12 @@ _approval_snapshot_v2_comments_json() {
 			and ((.body // $empty) | contains(". Stale recovery tick reset."))
 		) | not)
 		| select((
+			# #aidevops:trust-boundary — only the canonical versioned audit shape
+			# emitted by _isc_post_claim_comment is non-scope-bearing. Keep the
+			# optional worktree qualifier bounded to its backtick-delimited basename;
+			# trusted prose or copied markers must remain approval-significant.
 			((.author_association // $empty) == "OWNER" or (.author_association // $empty) == "MEMBER" or (.author_association // $empty) == "COLLABORATOR")
-			and ((.body // $empty) | test("^<!-- ops:start -->\\n> Interactive session claimed by @[^\\n]+ on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
+			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
 		) | not)
 		| {
 			source: $source,

--- a/.agents/scripts/interactive-session-helper-stamp.sh
+++ b/.agents/scripts/interactive-session-helper-stamp.sh
@@ -22,6 +22,7 @@
 # Include guard
 [[ -n "${_ISC_STAMP_LIB_LOADED:-}" ]] && return 0
 _ISC_STAMP_LIB_LOADED=1
+ISC_CLAIM_AUDIT_SCHEMA="aidevops-interactive-claim/v1"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -365,6 +366,7 @@ _isc_post_claim_comment() {
 	local body
 	body=$(
 		cat <<EOF
+<!-- ${ISC_CLAIM_AUDIT_SCHEMA} -->
 <!-- ops:start -->
 > Interactive session claimed by @${user}${worktree_note} on ${hostname}.
 > Pulse dispatch blocked via \`status:in-review\` + self-assignment.

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -351,7 +351,8 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 	assert_verify "trusted deterministic lifecycle audit comment is excluded" pr 42 VERIFIED 0 "$PR_HEAD"
 
 	reset_and_sign issue 41
-	local claim_marker="<!-- ops:start -->
+	local claim_marker="<!-- aidevops-interactive-claim/v1 -->
+<!-- ops:start -->
 > Interactive session claimed by @maintainer on Linux.
 > Pulse dispatch blocked via \`status:in-review\` + self-assignment.
 <!-- ops:end -->
@@ -359,9 +360,17 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 ---
 [aidevops.sh](https://aidevops.sh) v3.32.175 automated scan."
 	local claim_comments=""
-	claim_comments=$(jq -c --arg body "$claim_marker" '.[0] += [{id:4303,node_id:"IC_4303",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	local worktree_claim_marker="<!-- aidevops-interactive-claim/v1 -->
+<!-- ops:start -->
+> Interactive session claimed by @maintainer in \`linked-worktree\` on Linux.
+> Pulse dispatch blocked via \`status:in-review\` + self-assignment.
+<!-- ops:end -->
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.32.175 automated scan."
+	claim_comments=$(jq -c --arg body "$claim_marker" --arg worktree_body "$worktree_claim_marker" '.[0] += [{id:4303,node_id:"IC_4303",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$body},{id:4306,node_id:"IC_4306",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:01Z",updated_at:"2026-01-01T00:06:01Z",body:$worktree_body}]' "${FIXTURES}/comments-41.json")
 	printf '%s\n' "$claim_comments" >"${FIXTURES}/comments-41.json"
-	assert_verify "trusted interactive claim audit does not stale issue approval" issue 41 VERIFIED 0
+	assert_verify "canonical interactive claim refreshes, including worktree-qualified form, preserve approval" issue 41 VERIFIED 0
 
 	claim_comments=$(jq -c --arg body "$claim_marker" '.[0] += [{id:4304,node_id:"IC_4304",user:{id:105,node_id:"U_105",login:"external-author",type:"User"},author_association:"CONTRIBUTOR",created_at:"2026-01-01T00:07:00Z",updated_at:"2026-01-01T00:07:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
 	printf '%s\n' "$claim_comments" >"${FIXTURES}/comments-41.json"

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -312,6 +312,15 @@ source "$HELPER_PATH" >/dev/null 2>&1
 # Helper sets `set -euo pipefail` — drop -e for negative assertions
 set +e
 
+# Capture the canonical claim audit payload directly without tying its
+# assertions to the implementation details of the GitHub comment wrapper.
+CLAIM_COMMENT_LOG="${TEST_ROOT}/claim-comments.log"
+: >"$CLAIM_COMMENT_LOG"
+gh_issue_comment() {
+	printf '%s\n' "$*" >>"$CLAIM_COMMENT_LOG"
+	return 0
+}
+
 # Persisted runtime cooldowns must not suppress the stubbed write calls this
 # isolated command-shape suite asserts.
 _gh_secondary_cooldown_preflight() {
@@ -381,6 +390,7 @@ fi
 # second claim supplies the linked worktree. Repeating both phases remains
 # idempotent and does not add another ownership comment.
 : >"$STUB_LOG"
+: >"$CLAIM_COMMENT_LOG"
 STAGED_STAMP_FILE="${HOME}/.aidevops/.agent-workspace/interactive-claims/testowner-testrepo-18739.json"
 export STUB_ISSUE_HAS_IN_REVIEW=0
 _isc_cmd_claim 18739 testowner/testrepo --implementing --defer-comment >/dev/null 2>&1
@@ -388,9 +398,11 @@ export STUB_ISSUE_HAS_IN_REVIEW=1
 _isc_cmd_claim 18739 testowner/testrepo --implementing --worktree /tmp/wt-linked >/dev/null 2>&1
 _isc_cmd_claim 18739 testowner/testrepo --implementing --defer-comment >/dev/null 2>&1
 _isc_cmd_claim 18739 testowner/testrepo --implementing --worktree /tmp/wt-linked >/dev/null 2>&1
-staged_comment_count=$(grep -c '^gh issue comment ' "$STUB_LOG" 2>/dev/null || true)
+staged_comment_count=$(grep -Fc '<!-- aidevops-interactive-claim/v1 -->' "$CLAIM_COMMENT_LOG" 2>/dev/null || true)
 staged_worktree=$(jq -r '.worktree_path // empty' "$STAGED_STAMP_FILE" 2>/dev/null)
-if [[ "$staged_comment_count" == "1" && "$staged_worktree" == "/tmp/wt-linked" ]]; then
+if [[ "$staged_comment_count" == "1" && "$staged_worktree" == "/tmp/wt-linked" ]] &&
+	grep -Fq '<!-- aidevops-interactive-claim/v1 -->' "$CLAIM_COMMENT_LOG" &&
+	grep -Fq "> Interactive session claimed by @testuser in \`wt-linked\` on " "$CLAIM_COMMENT_LOG"; then
 	print_result "deferred worktree claim posts one idempotent ownership comment" 0
 else
 	print_result "deferred worktree claim posts one idempotent ownership comment" 1 \


### PR DESCRIPTION
## Summary

Defines a versioned canonical interactive-claim audit marker, accepts only that exact trusted shape including its bounded worktree form in approval snapshots, and covers both forms plus lookalikes.

## Files Changed

.agents/scripts/approval-snapshot-v2.sh, .agents/scripts/interactive-session-helper-stamp.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-interactive-session-claim.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed bash .agents/scripts/tests/test-approval-helper-content-binding.sh (43 passed) and bash .agents/scripts/tests/test-interactive-session-claim.sh (47 passed); .agents/scripts/linters-local.sh passed.

Resolves #30127


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 11m and 112,809 tokens on this as a headless worker.