### PR TITLE
GH#30129: fix: publish dashboard freshness before maintenance

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -355,22 +355,6 @@ _update_health_issue_for_repo() {
 	[[ -z "$health_issue_number" ]] && return 0
 	[[ "$health_issue_number" == "$_HEALTH_QUERY_FAILED_SENTINEL" ]] && return 0
 
-	# t2687: periodic dedup scan (at most once per HEALTH_DEDUP_INTERVAL
-	# seconds per repo+runner+role, default 1h). Closes duplicates that
-	# slipped in during past GraphQL rate-limit windows when the cache
-	# was valid so the label-scan inside _find_health_issue never ran.
-	_periodic_health_issue_dedup \
-		"$repo_slug" "$runner_user" "$runner_role" \
-		"$role_label" "$role_display" "$health_issue_number" \
-		"$canonical_identity" "$identity_aliases"
-	_normalize_health_issue_labels \
-		"$health_issue_number" "$repo_slug" "$runner_user" \
-		"$runner_role" "$canonical_identity"
-
-	if [[ "$runner_role" == "supervisor" ]]; then
-		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
-	fi
-
 	_cache_health_issue_number "$health_issue_number" "$health_issue_file"
 
 	local now_iso
@@ -387,6 +371,27 @@ _update_health_issue_for_repo() {
 	_refresh_health_issue_title_from_body \
 		"$health_issue_number" "$repo_slug" "$runner_prefix" "$body" "$now_iso"
 	_record_health_issue_refresh_state "$health_issue_file" "$activity_state"
+
+	# Publish the freshness marker before periodic maintenance. The latter can
+	# consume multiple GitHub requests (dedup, label normalization, pinning),
+	# and must not leave the primary operator dashboard stale when the bounded
+	# stats-wrapper run reaches its deadline.
+	#
+	# t2687: periodic dedup scan (at most once per HEALTH_DEDUP_INTERVAL
+	# seconds per repo+runner+role, default 1h). Closes duplicates that
+	# slipped in during past GraphQL rate-limit windows when the cache
+	# was valid so the label-scan inside _find_health_issue never ran.
+	_periodic_health_issue_dedup \
+		"$repo_slug" "$runner_user" "$runner_role" \
+		"$role_label" "$role_display" "$health_issue_number" \
+		"$canonical_identity" "$identity_aliases"
+	_normalize_health_issue_labels \
+		"$health_issue_number" "$repo_slug" "$runner_user" \
+		"$runner_role" "$canonical_identity"
+
+	if [[ "$runner_role" == "supervisor" ]]; then
+		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
+	fi
 
 	return 0
 }

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -270,6 +270,25 @@ test_slow_priority_dashboard_skips_optional_cross_repo_work() {
 	return 0
 }
 
+test_dashboard_freshness_precedes_maintenance() {
+	local dashboard_script production_snippet update_line maintenance_line
+	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
+	production_snippet=$(awk '
+		/^_update_health_issue_for_repo\(\) \{/ { in_production=1 }
+		in_production { print }
+		in_production && /^}$/ { exit }
+	' "$dashboard_script")
+	update_line=$(printf '%s\n' "$production_snippet" | grep -nE '^[[:space:]]*_update_health_issue_body_or_fail ' | head -1 | cut -d: -f1)
+	maintenance_line=$(printf '%s\n' "$production_snippet" | grep -nE '^[[:space:]]*(_periodic_health_issue_dedup|_normalize_health_issue_labels|_ensure_health_issue_pinned)' | head -1 | cut -d: -f1)
+	if [[ -n "$update_line" && -n "$maintenance_line" && "$update_line" -lt "$maintenance_line" ]]; then
+		print_result "dashboard freshness publishes before lifecycle maintenance" 0
+		return 0
+	fi
+	print_result "dashboard freshness publishes before lifecycle maintenance" 1 \
+		"Expected body update before maintenance; update_line=${update_line:-<missing>} maintenance_line=${maintenance_line:-<missing>}"
+	return 0
+}
+
 # Test 8: dashboard refresh failures must not be blindly swallowed by the wrapper.
 # The wrapper may intentionally defer EX_TEMPFAIL/rate-limit exits, but ordinary
 # dashboard failures must still flow through _stats_wrapper_run_health_update so
@@ -341,6 +360,7 @@ main_test() {
 	test_health_update_survives_slow_quality_sweep
 	test_priority_dashboard_precedes_optional_cross_repo_work
 	test_slow_priority_dashboard_skips_optional_cross_repo_work
+	test_dashboard_freshness_precedes_maintenance
 	test_dashboard_update_failure_not_swallowed
 	test_transient_dashboard_tempfail_is_deferred
 	test_dashboard_body_edit_failure_returns_nonzero


### PR DESCRIPTION
## Summary

Refreshes each health dashboard body and records its freshness marker before periodic deduplication, label normalization, and pinning can consume the bounded stats scheduler budget. Adds a regression test for the ordering contract.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-wrapper-headless-export.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh; bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; bash .agents/scripts/stats-wrapper.sh --self-check; bash .agents/scripts/stats-wrapper.sh --dry-run; shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh

Resolves #30129


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.253 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-terra spent 10m and 106,458 tokens on this as a headless worker.