### PR TITLE
GH#30149: normalize legacy published release lanes

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -783,6 +783,8 @@ _full_loop_release_validate_published_reconciliation_intent() {
 	local persisted_json=""
 	local observed_json=""
 	local observed_sources=""
+	local lane_sources=""
+	local lane_intent_json=""
 
 	[[ "$requested_pr" =~ ^[0-9]+$ && "$tag_name" =~ $_FULL_LOOP_RELEASE_VERSION_TAG_REGEX ]] || return 1
 	declare -F release_lane_read >/dev/null 2>&1 || return 1
@@ -793,12 +795,20 @@ _full_loop_release_validate_published_reconciliation_intent() {
 		<<<"$observed_json") || return 1
 	release_authorization_compare "$persisted_sources" "$observed_sources" || return 1
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" --arg expected "$persisted_sources" '
+	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" '
 		.active == true and .source_pr == $source_pr and .tag == $tag_name
-		and .expected_sources == $expected
+		and (.expected_sources | type) == "string"
 		and (.phase == "remote-publication" or .phase == "exact-tag-deployment")
 		and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ "$lane_sources" != "$persisted_sources" ]]; then
+		lane_intent_json=$(release_authorization_intent_json "$lane_sources") || return 1
+		jq -e --argjson lane_intent "$lane_intent_json" --argjson persisted "$persisted_json" '
+			all($lane_intent[]; .merge == null)
+			and ([$lane_intent[].pr] | sort) == ([$persisted[].pr] | sort)
+		' <<<"$persisted_json" >/dev/null || return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -611,10 +611,12 @@ _full_loop_read_release_authorization() {
 	printf '%s\n' '90@1111111111111111111111111111111111111111'
 	return 0
 }
+lane_expected_sources='90@1111111111111111111111111111111111111111'
 release_lane_read() {
 	local repo="$1"
 	[[ "$repo" == "test/repo" ]] || return 1
-	_AIDEVOPS_RELEASE_LANE_JSON='{"active":true,"source_pr":90,"expected_sources":"90@1111111111111111111111111111111111111111","phase":"remote-publication","tag":"v1.2.3","terminal_receipt":null}'
+	_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$lane_expected_sources" \
+		'{active:true,source_pr:90,expected_sources:$expected,phase:"remote-publication",tag:"v1.2.3",terminal_receipt:null}') || return 1
 	return 0
 }
 _full_loop_release_resolve_tag_commit() {
@@ -646,9 +648,32 @@ if ! _full_loop_release_finalize_reconciliation test/repo 90 v1.2.3 ||
 	printf 'FAIL reconciliation did not finalize with current hardened runtime against the tag checkout\n'
 	exit 1
 fi
+lane_expected_sources='90'
+if ! _full_loop_release_finalize_reconciliation test/repo 90 v1.2.3; then
+	printf 'FAIL published reconciliation rejected equivalent legacy PR-only lane intent\n'
+	exit 1
+fi
+lane_state_before="$_AIDEVOPS_RELEASE_LANE_JSON"
+if ! _full_loop_release_validate_published_reconciliation_intent test/repo 90 v1.2.3 \
+	'{"source_pr":90,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}' ||
+	[[ "$_AIDEVOPS_RELEASE_LANE_JSON" != "$lane_state_before" ]]; then
+	printf 'FAIL published validation mutated equivalent legacy lane intent\n'
+	exit 1
+fi
+for lane_expected_sources in \
+	'91' \
+	'90,91' \
+	'90,90' \
+	'90@2222222222222222222222222222222222222222'; do
+	if _full_loop_release_finalize_reconciliation test/repo 90 v1.2.3; then
+		printf 'FAIL published reconciliation accepted mismatched lane intent: %s\n' "$lane_expected_sources"
+		exit 1
+	fi
+done
+lane_expected_sources='90@1111111111111111111111111111111111111111'
 SCRIPT_DIR="$saved_script_dir"
 _FULL_LOOP_RELEASE_PATH=""
-printf 'PASS reconciliation uses current hardened runtime against immutable tag content\n'
+printf 'PASS reconciliation uses hardened tag runtime and accepts only equivalent legacy lane intent\n'
 
 cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Accept only exact PR-identity-equivalent legacy release-lane intent during provenance-verified published reconciliation, while retaining canonical SHA, tag, phase, receipt, and CAS gates.

## Files Changed

.agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused release reconciliation regression suite passed; ShellCheck clean; linters-local.sh --changed passed; review evidence 284d5073a993998f48c08ff7a8caf776e9a42be9499bdfe1ba4b9c359060d6f4.

Resolves #30149


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.254 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-sol spent 3h 18m and 1,453,681 tokens on this with the user in an interactive session.