### PR TITLE
t18234: feat: add campaign production manifests

### DIFF
--- a/.agents/configs/campaign-channel-specs.json
+++ b/.agents/configs/campaign-channel-specs.json
@@ -2,6 +2,8 @@
   "version": 1,
   "channels": {
     "facebook": {
+      "canonical_id": "facebook",
+      "fanout_aliases": ["facebook"],
       "display_name": "Facebook",
       "max_words": 250,
       "format": "short-form",
@@ -10,6 +12,8 @@
       "guidelines": "Conversational tone. Lead with a hook (question or bold claim). 1-3 short paragraphs. End with a clear CTA. Emojis sparingly. Hashtags optional (2-3 max)."
     },
     "instagram": {
+      "canonical_id": "instagram",
+      "fanout_aliases": ["short-form"],
       "display_name": "Instagram",
       "max_words": 200,
       "format": "caption",
@@ -18,6 +22,8 @@
       "guidelines": "Visual-first platform. Caption supports the image/video. Lead with a hook. Line breaks for readability. CTA directs to link in bio. 5-15 relevant hashtags at end."
     },
     "linkedin": {
+      "canonical_id": "linkedin",
+      "fanout_aliases": ["social-linkedin"],
       "display_name": "LinkedIn",
       "max_words": 500,
       "format": "thought-leadership",
@@ -26,6 +32,8 @@
       "guidelines": "Professional tone. Open with a surprising insight or counter-intuitive claim. Use line breaks generously (mobile-first). End with a question to drive comments. No hashtags in body; 3-5 at end. Avoid hard-sell CTAs."
     },
     "twitter": {
+      "canonical_id": "twitter",
+      "fanout_aliases": ["social-x"],
       "display_name": "Twitter / X",
       "max_words": 50,
       "format": "micro",
@@ -34,6 +42,8 @@
       "guidelines": "280 characters max. Punchy, direct. One clear idea per post. Thread-friendly: first post must stand alone. Links shorten to 23 chars. 1-2 hashtags max."
     },
     "email": {
+      "canonical_id": "email",
+      "fanout_aliases": ["email"],
       "display_name": "Email",
       "max_words": 800,
       "format": "long-form",
@@ -42,6 +52,8 @@
       "guidelines": "Subject line: 6-10 words, curiosity or benefit-driven. Preview text: extends subject, not repeats it. Body: scannable with subheadings. Single primary CTA button. P.S. line for secondary offer. Mobile-first formatting."
     },
     "blog": {
+      "canonical_id": "blog",
+      "fanout_aliases": ["blog"],
       "display_name": "Blog Post",
       "max_words": 1500,
       "format": "article",

--- a/.agents/content.md
+++ b/.agents/content.md
@@ -132,6 +132,11 @@ All subagent paths relative to `content/`.
 
 `content-fanout-helper.sh` automates the diamond pipeline from brief to channel-specific outputs.
 
+For campaign work, create the evidence-linked creative brief and provider-neutral
+job first: `campaign-helper.sh production create <id> --channel <channel>`. The
+manifest remains `brief_ready` until a production owner records verified output;
+fan-out prompt preparation remains `prompts_ready`, never generated or published.
+
 ```bash
 content-fanout-helper.sh template default   # Brief template
 content-fanout-helper.sh plan ~/brief.md    # Generate fan-out plan

--- a/.agents/content/media-generation-providers.md
+++ b/.agents/content/media-generation-providers.md
@@ -68,6 +68,11 @@ retention, and support when accessed through a gateway.
   and the user has authorized the cost.
 - **Do not hide asynchronous state.** A submitted task is not a completed asset;
   return task IDs and make timeout recovery explicit.
+- **Consume campaign jobs as requirements, not provider selections.** A
+  schema-v1 production manifest names asset class, format, rights, disclosure,
+  and fallback. Verify current capability evidence before setting its provider
+  route; an unavailable capability stays `blocked` rather than silently
+  switching providers.
 - **Do not preserve stale capability tables.** Update this file when a new
   provider changes routing; keep provider agents focused on their own contract.
 

--- a/.agents/schemas/campaign-creative-brief.schema.json
+++ b/.agents/schemas/campaign-creative-brief.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Campaign Creative Brief v1",
+  "description": "Versioned, evidence-linked creative strategy. A brief is planning evidence, never evidence that an asset was generated or published.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "brief_id", "campaign_id", "revision", "source_snapshot_sha256", "objective", "audience_insight", "message", "creative", "brand_references", "claims", "authenticity", "review", "lifecycle"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "brief_id": {"type": "string", "pattern": "^brief:[a-z0-9][a-z0-9-]{0,159}$"},
+    "campaign_id": {"type": "string", "minLength": 1, "maxLength": 160},
+    "revision": {"type": "integer", "minimum": 1},
+    "source_snapshot_sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "objective": {"type": "object", "additionalProperties": false, "required": ["metric", "target"], "properties": {"metric": {"type": "string", "minLength": 1}, "target": {"type": "string", "minLength": 1}}},
+    "audience_insight": {"type": "object", "additionalProperties": false, "required": ["segment", "pain", "outcome"], "properties": {"segment": {"type": "string", "minLength": 1}, "pain": {"type": "string", "minLength": 1}, "outcome": {"type": "string", "minLength": 1}}},
+    "message": {"type": "object", "additionalProperties": false, "required": ["positioning", "hook", "story", "cta"], "properties": {"positioning": {"type": "string", "minLength": 1}, "hook": {"type": "string", "minLength": 1}, "story": {"type": "string", "minLength": 1}, "cta": {"type": "string", "minLength": 1}}},
+    "creative": {"type": "object", "additionalProperties": false, "required": ["copy_direction", "script_direction", "shot_direction", "visual_direction", "audio_direction"], "properties": {"copy_direction": {"type": "string"}, "script_direction": {"type": "string"}, "shot_direction": {"type": "string"}, "visual_direction": {"type": "string"}, "audio_direction": {"type": "string"}}},
+    "brand_references": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "claims": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["claim", "evidence_reference", "approval_status"], "properties": {"claim": {"type": "string", "minLength": 1}, "evidence_reference": {"type": "string", "minLength": 1}, "approval_status": {"enum": ["approved", "pending", "rejected"]}}}},
+    "authenticity": {"type": "object", "additionalProperties": false, "required": ["synthetic_people_or_voice", "testimonial_or_ugc_style", "source_requirements", "consent_requirements", "disclosure_requirements"], "properties": {"synthetic_people_or_voice": {"type": "boolean"}, "testimonial_or_ugc_style": {"type": "boolean"}, "source_requirements": {"type": "array", "items": {"type": "string"}}, "consent_requirements": {"type": "array", "items": {"type": "string"}}, "disclosure_requirements": {"type": "array", "items": {"type": "string"}}}},
+    "review": {"type": "object", "additionalProperties": false, "required": ["criteria", "owner", "status"], "properties": {"criteria": {"type": "array", "minItems": 1, "items": {"type": "string"}}, "owner": {"type": "string", "minLength": 1}, "status": {"enum": ["required", "pending", "approved", "rejected"]}}},
+    "lifecycle": {"type": "object", "additionalProperties": false, "required": ["status", "asset_evidence"], "properties": {"status": {"const": "brief_ready"}, "asset_evidence": {"type": "array", "maxItems": 0}}}
+  }
+}

--- a/.agents/schemas/content-production-manifest.schema.json
+++ b/.agents/schemas/content-production-manifest.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Content Production Manifest v1",
+  "description": "A channel-native production job. Status describes verified work only; prompts are not generated assets.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "job_id", "campaign_id", "brief_id", "channel", "variant_id", "revision", "input_snapshot_sha256", "format", "asset_inputs", "execution", "authenticity", "review", "experiment", "lifecycle", "outputs"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "job_id": {"type": "string", "pattern": "^job:[a-z0-9][a-z0-9:-]{0,240}$"},
+    "campaign_id": {"type": "string", "minLength": 1},
+    "brief_id": {"type": "string", "minLength": 1},
+    "channel": {"enum": ["facebook", "instagram", "linkedin", "twitter", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"]},
+    "variant_id": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+    "revision": {"type": "integer", "minimum": 1},
+    "input_snapshot_sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "format": {"type": "object", "additionalProperties": false, "required": ["asset_class", "dimensions", "duration_seconds"], "properties": {"asset_class": {"enum": ["writing", "image", "video", "audio", "editor"]}, "dimensions": {"type": "string", "minLength": 1}, "duration_seconds": {"type": ["integer", "null"], "minimum": 1}}},
+    "asset_inputs": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["reference", "required"], "properties": {"reference": {"type": "string", "minLength": 1}, "required": {"type": "boolean"}}}},
+    "execution": {"type": "object", "additionalProperties": false, "required": ["owner", "provider_route", "capability", "fallback", "status"], "properties": {"owner": {"type": "string", "minLength": 1}, "provider_route": {"type": ["string", "null"]}, "capability": {"type": "string", "minLength": 1}, "fallback": {"type": ["string", "null"]}, "status": {"enum": ["capability_required", "blocked", "ready"]}}},
+    "authenticity": {"type": "object", "additionalProperties": false, "required": ["disclosure_requirements", "rights_requirements"], "properties": {"disclosure_requirements": {"type": "array", "items": {"type": "string"}}, "rights_requirements": {"type": "array", "items": {"type": "string"}}}},
+    "review": {"type": "object", "additionalProperties": false, "required": ["criteria", "status"], "properties": {"criteria": {"type": "array", "minItems": 1, "items": {"type": "string"}}, "status": {"enum": ["required", "pending", "approved", "rejected"]}}},
+    "experiment": {"type": "object", "additionalProperties": false, "required": ["experiment_id", "hypothesis"], "properties": {"experiment_id": {"type": "string", "minLength": 1}, "hypothesis": {"type": "string", "minLength": 1}}},
+    "lifecycle": {"type": "object", "additionalProperties": false, "required": ["status", "status_evidence"], "properties": {"status": {"enum": ["brief_ready", "prompts_ready", "queued", "running", "generated", "edited", "review_required", "approved", "rejected", "failed", "blocked"]}, "status_evidence": {"type": "array", "items": {"type": "string"}}}},
+    "outputs": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["path", "sha256", "media_type"], "properties": {"path": {"type": "string", "minLength": 1}, "sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"}, "media_type": {"type": "string", "minLength": 1}}}}
+  }
+}

--- a/.agents/scripts/campaign-helper.sh
+++ b/.agents/scripts/campaign-helper.sh
@@ -62,6 +62,7 @@ readonly CAMPAIGNS_INTAKE_FILE="intake.json"
 readonly CAMPAIGNS_CHANNEL_SPECS="${SCRIPT_DIR}/../configs/campaign-channel-specs.json"
 readonly CAMPAIGNS_VALID_CHANNELS="facebook instagram linkedin twitter email blog"
 readonly CAMPAIGN_RESEARCH_HELPER="${SCRIPT_DIR}/campaign-research-helper.py"
+readonly CAMPAIGN_PRODUCTION_HELPER="${SCRIPT_DIR}/campaign-production-helper.py"
 
 # ---------------------------------------------------------------------------
 # Error helpers — centralise repeated messages to satisfy string-literal ratchet
@@ -1313,7 +1314,15 @@ P5 Commands (AI creative agent):
       Tone defaults to 'professional'. Variant defaults to 1.
       Model defaults to 'standard' (simple|standard|thinking).
       Output: _campaigns/active/<id>/drafts/<channel>-v<N>.md
-      Human-gated: drafts require manual review before promotion to creative/.
+       Human-gated: drafts require manual review before promotion to creative/.
+
+  production create <id> --channel <ch> [--variant N] [--asset-class writing|image|video|audio|editor] [--capability <class>] [--repo <path>]
+      Create a schema-v1 creative brief and a truthful, provider-neutral production job.
+      Jobs remain brief_ready or blocked until a downstream owner records verified evidence.
+  production list <id> [--repo <path>]
+      List schema-v1 production jobs and their verified lifecycle states.
+  production validate <manifest-path>
+      Validate a production manifest before consuming it downstream.
 
 Campaign research:
   research <id> [--source <evidence.json>]... [--repo <path>]
@@ -1374,6 +1383,10 @@ main() {
 	launch) cmd_launch "$@" ;;
 	promote) cmd_promote "$@" ;;
 	feedback) cmd_feedback "$@" ;;
+	production)
+		[[ -f "$CAMPAIGN_PRODUCTION_HELPER" ]] || { print_error "Campaign production helper not found: ${CAMPAIGN_PRODUCTION_HELPER}"; return 1; }
+		python3 "$CAMPAIGN_PRODUCTION_HELPER" "$@"
+		;;
 	research)
 		[[ -x "$CAMPAIGN_RESEARCH_HELPER" || -f "$CAMPAIGN_RESEARCH_HELPER" ]] || { print_error "Campaign research helper not found: ${CAMPAIGN_RESEARCH_HELPER}"; return 1; }
 		python3 "$CAMPAIGN_RESEARCH_HELPER" "$@"

--- a/.agents/scripts/campaign-production-helper.py
+++ b/.agents/scripts/campaign-production-helper.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Create, list, and validate truthful campaign production manifests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+CHANNELS = {"facebook", "instagram", "linkedin", "twitter", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"}
+ASSET_OWNERS = {"writing": "content/production-writing.md", "image": "content/production-image.md", "video": "content/production-video.md", "audio": "content/production-audio.md", "editor": "tools/video/video-editor.md"}
+DEFAULT_FORMATS = {"facebook": ("image", "1:1", None), "instagram": ("image", "4:5", None), "linkedin": ("image", "1.91:1", None), "twitter": ("writing", "text", None), "email": ("writing", "text", None), "blog": ("writing", "text", None), "youtube": ("video", "16:9", 60), "short-form": ("video", "9:16", 30), "social-linkedin": ("image", "1.91:1", None), "social-reddit": ("writing", "text", None), "social-x": ("writing", "text", None), "podcast": ("audio", "audio", 300)}
+
+
+class ManifestError(ValueError):
+    """Raised when a production contract cannot be created or trusted."""
+
+
+def digest(value: Any) -> str:
+    """Return a stable SHA-256 reference for JSON-compatible content."""
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def atomic_json_write(path: Path, document: dict[str, Any]) -> None:
+    """Atomically write a JSON document without replacing valid state on failure."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(document, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def read_document(path: Path, label: str) -> dict[str, Any]:
+    """Read one object document with a useful contract error."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"invalid {label}: {path}: {error}") from error
+    if not isinstance(document, dict):
+        raise ManifestError(f"invalid {label}: {path} must contain an object")
+    return document
+
+
+def validate_brief(document: dict[str, Any]) -> None:
+    """Validate fields that downstream production must rely on."""
+    required = ("schema_version", "brief_id", "campaign_id", "source_snapshot_sha256", "claims", "lifecycle")
+    if any(not document.get(field) for field in required) or document.get("schema_version") != 1:
+        raise ManifestError("creative brief is missing required schema-v1 fields")
+    if document["lifecycle"].get("status") != "brief_ready":
+        raise ManifestError("creative brief lifecycle must be brief_ready")
+    if not all(claim.get("evidence_reference") for claim in document["claims"]):
+        raise ManifestError("creative brief claims require evidence references")
+
+
+def validate_manifest(document: dict[str, Any]) -> None:
+    """Reject invalid status claims and incomplete downstream jobs."""
+    required = ("schema_version", "job_id", "campaign_id", "brief_id", "channel", "variant_id", "input_snapshot_sha256", "format", "execution", "lifecycle", "outputs")
+    if any(field not in document for field in required) or document.get("schema_version") != 1:
+        raise ManifestError("manifest is missing required schema-v1 fields")
+    if document["channel"] not in CHANNELS:
+        raise ManifestError("manifest has an unsupported channel")
+    status = document["lifecycle"].get("status")
+    outputs = document["outputs"]
+    if status in {"generated", "edited", "approved"} and not outputs:
+        raise ManifestError(f"manifest status {status} requires verified outputs")
+    if status in {"brief_ready", "prompts_ready", "queued", "running", "blocked"} and outputs:
+        raise ManifestError(f"manifest status {status} must not claim completed outputs")
+    if status == "blocked" and document["execution"].get("status") != "blocked":
+        raise ManifestError("blocked lifecycle requires an explicit blocked execution route")
+
+
+def build_brief(campaign_id: str, intake: dict[str, Any], revision: int) -> dict[str, Any]:
+    """Convert validated intake facts to one evidence-linked strategy brief."""
+    audience = intake["audiences"][0]
+    objective = intake["objectives"][0]
+    snapshot = digest({"intake": intake, "revision": revision})
+    disclosures = list(intake.get("disclosures", []))
+    return {
+        "schema_version": 1, "brief_id": f"brief:{campaign_id}", "campaign_id": campaign_id, "revision": revision,
+        "source_snapshot_sha256": snapshot, "objective": objective,
+        "audience_insight": {"segment": audience["segment"], "pain": audience["pains"][0] if audience["pains"] else "Unspecified pain", "outcome": audience["outcomes"][0] if audience["outcomes"] else "Unspecified outcome"},
+        "message": {"positioning": intake["positioning"]["statement"], "hook": intake["positioning"]["differentiators"][0] if intake["positioning"]["differentiators"] else intake["positioning"]["statement"], "story": intake["product"]["description"], "cta": intake["offer"]["summary"]},
+        "creative": {"copy_direction": "Use proof-linked, channel-native language without unsupported claims.", "script_direction": "Show the audience problem, evidence-backed resolution, and stated offer.", "shot_direction": "Use supplied brand and product references; do not imply real customer endorsement.", "visual_direction": "Follow the referenced brand identity and retain source provenance.", "audio_direction": "Use licensed or owned audio only; disclose synthetic voice where required."},
+        "brand_references": [intake["brand"]["reference"]], "claims": intake["proof"],
+        "authenticity": {"synthetic_people_or_voice": False, "testimonial_or_ugc_style": False, "source_requirements": ["Proof claims must retain their evidence reference."], "consent_requirements": ["Obtain documented consent before depicting identifiable people or voices."], "disclosure_requirements": disclosures + ["Disclose synthetic people, voices, testimonials, or UGC-style creative before review."]},
+        "review": {"criteria": ["Brand reference followed", "Every claim has evidence", "Rights and disclosure requirements are satisfied"], "owner": intake["approvals"]["owner"], "status": "required"},
+        "lifecycle": {"status": "brief_ready", "asset_evidence": []},
+    }
+
+
+def build_manifest(campaign_id: str, brief: dict[str, Any], channel: str, variant: int, asset_class: str, capability: str | None) -> dict[str, Any]:
+    """Build an unexecuted job without guessing a provider or asset completion."""
+    default_asset, dimensions, duration = DEFAULT_FORMATS[channel]
+    asset_class = asset_class or default_asset
+    if asset_class not in ASSET_OWNERS:
+        raise ManifestError(f"unsupported asset class: {asset_class}")
+    is_supported = capability in (None, "", asset_class)
+    execution_status = "capability_required" if is_supported else "blocked"
+    status = "brief_ready" if is_supported else "blocked"
+    snapshot = digest({"brief": brief["source_snapshot_sha256"], "channel": channel, "variant": variant, "asset_class": asset_class})
+    return {
+        "schema_version": 1, "job_id": f"job:{campaign_id}:{channel}:v{variant}", "campaign_id": campaign_id, "brief_id": brief["brief_id"], "channel": channel, "variant_id": f"v{variant}", "revision": 1, "input_snapshot_sha256": snapshot,
+        "format": {"asset_class": asset_class, "dimensions": dimensions, "duration_seconds": duration},
+        "asset_inputs": [{"reference": reference, "required": True} for reference in brief["brand_references"]],
+        "execution": {"owner": ASSET_OWNERS[asset_class], "provider_route": None, "capability": asset_class, "fallback": "Route through content/media-generation-providers.md after current capability evidence is available.", "status": execution_status},
+        "authenticity": {"disclosure_requirements": brief["authenticity"]["disclosure_requirements"], "rights_requirements": ["Record source, licence, consent, and rights evidence before approving an output."]},
+        "review": {"criteria": brief["review"]["criteria"], "status": "required"},
+        "experiment": {"experiment_id": f"experiment:{campaign_id}:{channel}:v{variant}", "hypothesis": f"The {brief['message']['hook']} hook improves {brief['objective']['metric']} for {brief['audience_insight']['segment']}."},
+        "lifecycle": {"status": status, "status_evidence": ["Creative brief created; no prompt or asset has been executed."] if is_supported else [f"Requested capability {capability} does not satisfy required {asset_class} capability."]}, "outputs": [],
+    }
+
+
+def command_create(arguments: argparse.Namespace) -> int:
+    """Create idempotent brief and job records for a selected campaign variant."""
+    campaign_dir = Path(arguments.repo).resolve() / "_campaigns" / "active" / arguments.campaign_id
+    intake = read_document(campaign_dir / "intake.json", "campaign intake")
+    if arguments.channel not in intake.get("channels", []):
+        raise ManifestError("channel must be declared by the campaign intake")
+    brief_path = campaign_dir / "drafts" / "creative-brief-v1.json"
+    brief = build_brief(arguments.campaign_id, intake, 1)
+    if brief_path.exists():
+        existing = read_document(brief_path, "creative brief")
+        validate_brief(existing)
+        if existing.get("source_snapshot_sha256") == brief["source_snapshot_sha256"]:
+            brief = existing
+        else:
+            brief["revision"] = int(existing.get("revision", 0)) + 1
+            brief["source_snapshot_sha256"] = digest({"intake": intake, "revision": brief["revision"]})
+            atomic_json_write(brief_path, brief)
+    else:
+        atomic_json_write(brief_path, brief)
+    manifest = build_manifest(arguments.campaign_id, brief, arguments.channel, arguments.variant, arguments.asset_class, arguments.capability)
+    manifest_path = campaign_dir / "drafts" / "production-manifests" / f"{arguments.channel}-v{arguments.variant}.json"
+    if manifest_path.exists():
+        existing = read_document(manifest_path, "production manifest")
+        validate_manifest(existing)
+        if existing.get("input_snapshot_sha256") == manifest["input_snapshot_sha256"]:
+            print(f"Campaign production manifest unchanged: {manifest_path}")
+            return 0
+    atomic_json_write(manifest_path, manifest)
+    print(f"Campaign creative brief written: {brief_path}")
+    print(f"Campaign production manifest written: {manifest_path}")
+    return 0
+
+
+def command_list(arguments: argparse.Namespace) -> int:
+    """List recorded jobs without inferring work from prompt files."""
+    directory = Path(arguments.repo).resolve() / "_campaigns" / "active" / arguments.campaign_id / "drafts" / "production-manifests"
+    for path in sorted(directory.glob("*.json")) if directory.is_dir() else []:
+        document = read_document(path, "production manifest")
+        validate_manifest(document)
+        print(f"{document['job_id']}\t{document['lifecycle']['status']}\t{path}")
+    return 0
+
+
+def command_validate(arguments: argparse.Namespace) -> int:
+    """Validate a standalone manifest before a downstream owner consumes it."""
+    document = read_document(Path(arguments.manifest), "production manifest")
+    validate_manifest(document)
+    print(f"Valid production manifest: {arguments.manifest}")
+    return 0
+
+
+def main() -> int:
+    """Parse the narrow campaign production contract CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    create = commands.add_parser("create")
+    create.add_argument("campaign_id")
+    create.add_argument("--channel", required=True, choices=sorted(CHANNELS))
+    create.add_argument("--variant", type=int, default=1)
+    create.add_argument("--asset-class", choices=sorted(ASSET_OWNERS))
+    create.add_argument("--capability")
+    create.add_argument("--repo", default=".")
+    create.set_defaults(handler=command_create)
+    listing = commands.add_parser("list")
+    listing.add_argument("campaign_id")
+    listing.add_argument("--repo", default=".")
+    listing.set_defaults(handler=command_list)
+    validate = commands.add_parser("validate")
+    validate.add_argument("manifest")
+    validate.set_defaults(handler=command_validate)
+    arguments = parser.parse_args()
+    if getattr(arguments, "variant", 1) < 1:
+        raise ManifestError("variant must be a positive integer")
+    return arguments.handler(arguments)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ManifestError as error:
+        print(f"campaign production: {error}", file=__import__("sys").stderr)
+        raise SystemExit(1)

--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -37,6 +37,9 @@ readonly WORKSPACE_DIR="${HOME}/.aidevops/.agent-workspace/work/content-fanout"
 readonly TEMPLATES_DIR="${WORKSPACE_DIR}/templates"
 readonly PLANS_DIR="${WORKSPACE_DIR}/plans"
 readonly OUTPUTS_DIR="${WORKSPACE_DIR}/outputs"
+readonly DEFAULT_CONTENT_FORMAT="script"
+readonly MANIFEST_READY_STATUS="prompts_ready"
+readonly NO_COMPLETED_ASSET_EVIDENCE="prompt prepared; no asset has been generated, approved, published, or measured"
 
 # All available channels (space-separated for iteration)
 readonly ALL_CHANNELS="blog email podcast short-form social-linkedin social-reddit social-x youtube"
@@ -362,7 +365,7 @@ write_channel_prompt() {
 	local outputs
 	outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
 	local formats
-	formats=$(channel_formats "$ch" 2>/dev/null || echo "script")
+	formats=$(channel_formats "$ch" 2>/dev/null || echo "$DEFAULT_CONTENT_FORMAT")
 
 	{
 		echo "# Fan-Out Prompt: ${ch}"
@@ -394,6 +397,33 @@ write_channel_prompt() {
 		echo "- [ ] No cross-posting smell (platform-native language)"
 		echo "- [ ] Story angle is consistent with brief"
 	} >"$prompt_file"
+
+	return 0
+}
+
+# Write a manifest-ready job descriptor alongside a prepared prompt.
+# Args: ch plan_id prompt_file manifest_file
+write_manifest_ready_job() {
+	local ch="$1"
+	local plan_id="$2"
+	local prompt_file="$3"
+	local manifest_file="$4"
+	local formats owner
+	formats=$(channel_formats "$ch" 2>/dev/null || echo "$DEFAULT_CONTENT_FORMAT")
+	owner=$(channel_subagent "$ch" 2>/dev/null || echo "content")
+
+	{
+		echo "schema_version: 1"
+		echo "job_id: fanout:${plan_id}:${ch}:v1"
+		echo "channel: ${ch}"
+		echo "variant_id: v1"
+		echo "owner: ${owner}"
+		echo "formats: ${formats}"
+		echo "prompt_path: ${prompt_file}"
+		echo "status: ${MANIFEST_READY_STATUS}"
+		echo "status_evidence: ${NO_COMPLETED_ASSET_EVIDENCE}"
+		echo "outputs: []"
+	} >"$manifest_file"
 
 	return 0
 }
@@ -628,6 +658,7 @@ _generate_channel_prompts() {
 			"$ch" "$PLAN_TOPIC" "$PLAN_ANGLE" "$PLAN_AUDIENCE" \
 			"$PLAN_TONE" "$PLAN_CTA" "$PLAN_NOTES" \
 			"${ch_dir}/prompt.md"
+		write_manifest_ready_job "$ch" "$PLAN_ID" "${ch_dir}/prompt.md" "${ch_dir}/manifest-ready.job"
 
 		echo "pending" >"${ch_dir}/.status"
 		completed=$((completed + 1))

--- a/.agents/scripts/tests/test-campaign-production-manifest.sh
+++ b/.agents/scripts/tests/test-campaign-production-manifest.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-campaign-production-manifest.sh — truthful production handoff contract tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+CAMPAIGN_HELPER="${REPO_ROOT}/.agents/scripts/campaign-helper.sh"
+FANOUT_HELPER="${REPO_ROOT}/.agents/scripts/content-fanout-helper.sh"
+MANIFEST_SCHEMA="${REPO_ROOT}/.agents/schemas/content-production-manifest.schema.json"
+BRIEF_SCHEMA="${REPO_ROOT}/.agents/schemas/campaign-creative-brief.schema.json"
+
+pass_count=0
+fail_count=0
+
+_pass() { printf 'PASS: %s\n' "$1"; pass_count=$((pass_count + 1)); return 0; }
+_fail() { printf 'FAIL: %s\n' "$1" >&2; fail_count=$((fail_count + 1)); return 0; }
+
+_make_repo() {
+	local root="$1" repo="$1/repo"
+	mkdir -p "$repo/_campaigns/active" "$repo/_campaigns/launched" "$repo/_campaigns/archive"
+	printf '0\n' > "$repo/_campaigns/.campaign-counter"
+	printf '%s\n' "$repo"
+	return 0
+}
+
+_write_intake() {
+	local path="$1"
+	cat > "$path" <<'JSON'
+{"schema_version":1,"brand":{"name":"Example","reference":"DESIGN.md"},"product":{"name":"Product","description":"Useful product"},"offer":{"summary":"Start trial","terms":"Terms apply"},"objectives":[{"metric":"CTR","target":"3%"}],"audiences":[{"segment":"Operators","buying_roles":["Buyer"],"pains":["Manual work"],"jobs":["Automate"],"outcomes":["Save time"]}],"positioning":{"statement":"Evidence-led automation","differentiators":["Proof first"]},"proof":[{"claim":"Cuts review time","evidence_reference":"research/study.md","approval_status":"approved"}],"objections":[],"exclusions":[],"channels":["linkedin","email"],"dates":{"start":"2026-08-01","end":"2026-08-31"},"kpis":[{"metric":"CTR","target":"3%"}],"disclosures":["Terms apply"],"sensitivity":"internal","approvals":{"owner":"Marketing","claims":"approved","creative":"required"}}
+JSON
+	return 0
+}
+
+test_create_replay_and_truthful_status() {
+	local root repo intake manifest out
+	root="$(mktemp -d "${TMPDIR:-/tmp}/campaign-production.XXXXXX")"
+	repo="$(_make_repo "$root")"
+	intake="$root/intake.json"
+	_write_intake "$intake"
+	bash "$CAMPAIGN_HELPER" new "Example" --intake "$intake" --repo "$repo" >/dev/null
+	out="$(bash "$CAMPAIGN_HELPER" production create c001-example --channel linkedin --variant 2 --repo "$repo" 2>&1)" || { _fail "production create failed: $out"; rm -rf "$root"; return 1; }
+	manifest="$repo/_campaigns/active/c001-example/drafts/production-manifests/linkedin-v2.json"
+	if [[ -f "$manifest" ]] && jq -e '.lifecycle.status == "brief_ready" and (.outputs | length == 0) and .claims? == null and .execution.provider_route == null' "$manifest" >/dev/null && grep -q 'creative brief written' <<<"$out"; then
+		_pass "creates proof-linked, unexecuted channel job"
+	else
+		_fail "production job did not preserve truthful status"
+	fi
+	out="$(bash "$CAMPAIGN_HELPER" production create c001-example --channel linkedin --variant 2 --repo "$repo" 2>&1)" || { _fail "production replay failed: $out"; rm -rf "$root"; return 1; }
+	[[ "$out" == *"unchanged"* ]] && _pass "replay preserves stable variant identity" || _fail "replay rewrote the same job"
+	bash "$CAMPAIGN_HELPER" production validate "$manifest" >/dev/null && _pass "validates created manifest" || _fail "created manifest fails validation"
+	rm -rf "$root"
+	return 0
+}
+
+test_unsupported_capability_and_invalid_promotion() {
+	local root repo intake manifest out
+	root="$(mktemp -d "${TMPDIR:-/tmp}/campaign-production.XXXXXX")"
+	repo="$(_make_repo "$root")"
+	intake="$root/intake.json"
+	_write_intake "$intake"
+	bash "$CAMPAIGN_HELPER" new "Example" --intake "$intake" --repo "$repo" >/dev/null
+	bash "$CAMPAIGN_HELPER" production create c001-example --channel linkedin --asset-class video --capability audio --repo "$repo" >/dev/null
+	manifest="$repo/_campaigns/active/c001-example/drafts/production-manifests/linkedin-v1.json"
+	jq -e '.lifecycle.status == "blocked" and .execution.status == "blocked" and (.outputs | length == 0)' "$manifest" >/dev/null && _pass "unsupported capability remains explicitly blocked" || _fail "unsupported capability silently routed"
+	jq '.lifecycle.status = "generated"' "$manifest" > "$manifest.invalid" && out="$(bash "$CAMPAIGN_HELPER" production validate "$manifest.invalid" 2>&1 || true)"
+	[[ "$out" == *"requires verified outputs"* ]] && _pass "rejects generated status without evidence" || _fail "accepted unsupported status promotion"
+	rm -rf "$root"
+	return 0
+}
+
+test_fanout_manifest_ready_job_is_not_an_asset() {
+	local root brief plan output job
+	root="$(mktemp -d "${TMPDIR:-/tmp}/campaign-production.XXXXXX")"
+	brief="$root/story.md"
+	cat > "$brief" <<'BRIEF'
+topic: Evidence-led campaign production
+angle: Truthful lifecycle status
+audience: Marketing owners
+channels: social-linkedin
+tone: practical
+cta: Review the manifest
+notes: Contract fixture
+BRIEF
+	plan="$(bash "$FANOUT_HELPER" plan "$brief" 2>&1 | grep 'Plan written:' | sed 's/.*Plan written: //')"
+	output="$(bash "$FANOUT_HELPER" run "$plan" 2>&1 | grep 'Output dir:' | sed 's/.*Output dir: *//')"
+	job="$output/social-linkedin/manifest-ready.job"
+	if [[ -f "$job" ]] && grep -q '^status: prompts_ready$' "$job" && grep -q '^outputs: \[\]$' "$job" && grep -q 'no asset has been generated' "$job"; then
+		_pass "fan-out exports manifest-ready prompts without claiming assets"
+	else
+		_fail "fan-out manifest-ready job overstated lifecycle status"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
+main() {
+	python3 -m json.tool "$MANIFEST_SCHEMA" >/dev/null
+	python3 -m json.tool "$BRIEF_SCHEMA" >/dev/null
+	test_create_replay_and_truthful_status
+	test_unsupported_capability_and_invalid_promotion
+	test_fanout_manifest_ready_job_is_not_an_asset
+	printf 'Results: %d passed, %d failed\n' "$pass_count" "$fail_count"
+	[[ "$fail_count" -eq 0 ]]
+	return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds evidence-linked creative briefs, truthful provider-neutral production manifests, capability blocking, and fan-out manifest-ready prompt jobs.

## Files Changed

.agents/configs/campaign-channel-specs.json, .agents/content.md, .agents/content/media-generation-providers.md, .agents/schemas/campaign-creative-brief.schema.json, .agents/schemas/content-production-manifest.schema.json, .agents/scripts/campaign-helper.sh, .agents/scripts/campaign-production-helper.py, .agents/scripts/content-fanout-helper.sh, .agents/scripts/tests/test-campaign-production-manifest.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-campaign-production-manifest.sh; bash .agents/scripts/tests/test-campaign-status-routing.sh; shellcheck .agents/scripts/campaign-helper.sh .agents/scripts/content-fanout-helper.sh .agents/scripts/tests/test-campaign-production-manifest.sh; python3 -m py_compile .agents/scripts/campaign-production-helper.py; .agents/scripts/linters-local.sh --changed

Resolves #30140


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.254 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-terra spent 11m and 277,170 tokens on this as a headless worker.