### PR TITLE
GH#30157: fix: preserve planning publication audit evidence

### DIFF
--- a/.agents/scripts/gh-audit-anomaly-filter.jq
+++ b/.agents/scripts/gh-audit-anomaly-filter.jq
@@ -95,6 +95,25 @@ def expected_full_loop_review_transition:
   and ((.after.labels // []) | index("status:in-progress") == null)
   and ((.after.labels // []) | index("status:in-review") != null);
 
+def expected_planning_publication_transition:
+  comparable_state
+  and .op == $issue_edit
+  and .caller_function == "_publication_reconcile_one"
+  and framework_script("planning-publication-reconcile.sh")
+  and .flags.planning_publication_verified == "v1-current-state"
+  and .suspicious == ["protected_label_removed:no-auto-dispatch"]
+  and (.delta.labels_removed // []) == ["no-auto-dispatch"]
+  and ((.delta.labels_added // []) | all(
+    . == "auto-dispatch" or . == "status:available" or . == "status:blocked"
+  ))
+  and (.delta.title_delta_pct == 0)
+  and (.delta.body_delta_pct == 0)
+  and ((.before.labels // []) | index("no-auto-dispatch") != null)
+  and ((.before.labels // []) | index("publication:pending") != null)
+  and ((.after.labels // []) | index("no-auto-dispatch") == null)
+  and ((.after.labels // []) | index("publication:pending") != null)
+  and ((.after.labels // []) | index("auto-dispatch") != null);
+
 # Snapshot-read failures are observability degradation, not evidence of a
 # destructive mutation. Keep them in the immutable audit log, but do not file a
 # security-anomaly issue unless the same entry contains another suspicious
@@ -120,5 +139,6 @@ select(try ((.suspicious | length) > 0) catch true)
   or expected_permission_block_transition
   or expected_trusted_author_nmr_transition
   or expected_full_loop_review_transition
+  or expected_planning_publication_transition
   or unavailable_capture_only
 ) catch false) | not)

--- a/.agents/scripts/planning-publication-reconcile.sh
+++ b/.agents/scripts/planning-publication-reconcile.sh
@@ -10,6 +10,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=./issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"
+# shellcheck source=./shared-gh-wrappers.sh
+source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
 
 PUBLICATION_PENDING_LABEL="publication:pending"
 PUBLICATION_AVAILABLE_LABEL="status:available"
@@ -101,7 +103,8 @@ _publication_reconcile_one() {
 	[[ -n "$status_label" ]] && projected_labels="${projected_labels:+${projected_labels},}${status_label}"
 
 	if [[ -n "$projected_labels" ]]; then
-		"${SCRIPT_DIR}/gh-write-helper.sh" issue edit "$issue_num" --repo "$repo" \
+		# Keep audit provenance at the reconciler instead of the generic CLI shim.
+		gh_issue_edit_safe "$issue_num" --repo "$repo" \
 			--add-label "$projected_labels" >/dev/null || return 1
 	fi
 	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json number,title,state,labels) || return 1
@@ -113,7 +116,7 @@ _publication_reconcile_one() {
 
 	# The blocker is intentionally the final mutation. Every prior failure leaves
 	# the issue undispatchable and safely retryable.
-	"${SCRIPT_DIR}/gh-write-helper.sh" issue edit "$issue_num" --repo "$repo" \
+	gh_issue_edit_safe "$issue_num" --repo "$repo" \
 		--remove-label "$PUBLICATION_PENDING_LABEL" >/dev/null || return 1
 	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json labels) || return 1
 	if _publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL"; then

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -307,6 +307,17 @@ _gh_audit_record_op() {
 		_gh_audit_verify_full_loop_review_transition "$repo" "$number" "$before_json" "$after_json"; then
 		flags_json='{"pr_review_handoff_verified":"v1-current-state"}'
 	fi
+	# aidevops:trust-boundary — planning publication may remove its temporary
+	# manual hold only after preserving publication:pending. Require an exact,
+	# content-preserving transition and re-read the current issue so a generic
+	# wrapper invocation cannot suppress an unrelated protected-label removal.
+	if [[ "$op" == "$_GH_AUDIT_ISSUE_EDIT_OP" &&
+		"$caller_function" == "_publication_reconcile_one" ]] &&
+		[[ "$caller_script" == */agents/scripts/planning-publication-reconcile.sh ||
+			"$caller_script" == */.agents/scripts/planning-publication-reconcile.sh ]] &&
+		_gh_audit_verify_planning_publication_transition "$repo" "$number" "$before_json" "$after_json"; then
+		flags_json='{"planning_publication_verified":"v1-current-state"}'
+	fi
 
 	GH_AUDIT_QUIET=true "$audit_helper" record \
 		--op "$op" \
@@ -356,6 +367,48 @@ _gh_audit_verify_full_loop_review_transition() {
 		(.state | strings | ascii_downcase) == $open
 		and ([.labels[]?.name] | index($review) != null)
 		and ([.labels[]?.name] | index($active) == null)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+#######################################
+# Verify that planning publication released only its temporary manual hold.
+# Args: repo, issue number, before JSON, after JSON
+# Returns: 0 only for a comparable no-auto-dispatch removal that retains the
+# publication blocker and is still reflected by the current remote issue.
+#######################################
+_gh_audit_verify_planning_publication_transition() {
+	local repo="$1"
+	local number="$2"
+	local before_json="$3"
+	local after_json="$4"
+	local issue_json=""
+	local manual_hold="no-auto-dispatch"
+	local publication_hold="publication:pending"
+	local auto_dispatch="auto-dispatch"
+	local open_state="open"
+
+	[[ -n "$repo" && "$number" =~ ^[0-9]+$ ]] || return 1
+	jq -e -n --arg manual "$manual_hold" --arg publication "$publication_hold" \
+		--arg auto "$auto_dispatch" --argjson before "$before_json" --argjson after "$after_json" '
+		($before.capture_status // "ok") == "ok"
+		and ($after.capture_status // "ok") == "ok"
+		and $before.title_len == $after.title_len
+		and $before.body_len == $after.body_len
+		and ([$before.labels[]?] | index($manual) != null)
+		and ([$before.labels[]?] | index($publication) != null)
+		and ([$after.labels[]?] | index($manual) == null)
+		and ([$after.labels[]?] | index($publication) != null)
+		and ([$after.labels[]?] | index($auto) != null)
+	' >/dev/null 2>&1 || return 1
+
+	issue_json=$(gh api "repos/${repo}/issues/${number}" 2>/dev/null) || return 1
+	printf '%s\n' "$issue_json" | jq -e --arg manual "$manual_hold" \
+		--arg publication "$publication_hold" --arg auto "$auto_dispatch" --arg open "$open_state" '
+		(.state | strings | ascii_downcase) == $open
+		and ([.labels[]?.name] | index($manual) == null)
+		and ([.labels[]?.name] | index($publication) != null)
+		and ([.labels[]?.name] | index($auto) != null)
 	' >/dev/null 2>&1 || return 1
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -69,12 +69,14 @@ cat >"$LOG_FILE" <<'EOF'
 {"ts":"2026-07-31T00:20:00Z","op":"issue_edit","repo":"example/repo","number":21,"caller_script":"/runtime/agents/scripts/full-loop-helper-commit.sh","caller_function":"_label_issue_in_review","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["status:in-review"]},"suspicious":["protected_label_removed:status:in-progress"]}
 {"ts":"2026-07-31T00:21:00Z","op":"issue_edit","repo":"example/repo","number":22,"caller_script":"/runtime/agents/scripts/full-loop-helper.sh","caller_function":"main","flags":{"pr_review_handoff_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["status:in-review"]},"suspicious":["protected_label_removed:status:in-progress"]}
 {"ts":"2026-07-31T00:22:00Z","op":"issue_edit","repo":"example/repo","number":23,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["monitoring"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["monitoring","needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:23:00Z","op":"issue_edit","repo":"example/repo","number":24,"caller_script":"/runtime/agents/scripts/planning-publication-reconcile.sh","caller_function":"_publication_reconcile_one","flags":{"planning_publication_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["no-auto-dispatch","publication:pending"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["auto-dispatch","status:blocked","publication:pending"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["no-auto-dispatch"],"labels_added":["auto-dispatch","status:blocked"]},"suspicious":["protected_label_removed:no-auto-dispatch"]}
+{"ts":"2026-07-31T00:24:00Z","op":"issue_edit","repo":"example/repo","number":25,"caller_script":"/runtime/agents/scripts/planning-publication-reconcile.sh","caller_function":"_publication_reconcile_one","flags":{"planning_publication_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["no-auto-dispatch"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["no-auto-dispatch"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:no-auto-dispatch"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 13"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 14"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
 [[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
@@ -88,6 +90,7 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"| #19 |"* ]] || fail "unavailable capture with an additional destructive signal was hidden"
 [[ "$output" == *"| #21 |"* ]] || fail "unverified full-loop handoff was hidden"
 [[ "$output" == *"| #23 |"* ]] || fail "permission block without a prior active status was hidden"
+[[ "$output" == *"| #25 |"* ]] || fail "planning transition without publication evidence was hidden"
 [[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
 [[ "$output" != *"private/repo"* ]] || fail "private repository name leaked into the report"
 [[ "$output" != *"inaccessible/repo"* ]] || fail "unverified repository name leaked into the report"
@@ -95,7 +98,8 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"public/repo"* ]] || fail "verified public repository name was redacted"
 [[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* &&
 	"$output" != *"| #12 |"* && "$output" != *"| #14 |"* && "$output" != *"| #17 |"* &&
-	"$output" != *"| #18 |"* && "$output" != *"| #20 |"* && "$output" != *"| #22 |"* ]] ||
+	"$output" != *"| #18 |"* && "$output" != *"| #20 |"* && "$output" != *"| #22 |"* &&
+	"$output" != *"| #24 |"* ]] ||
 	fail "an exact expected transition remained actionable"
 
 MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
@@ -181,6 +185,40 @@ _gh_actor_has_repo_write_authority() {
 	[[ "$repo_slug" == "example/repo" ]] || return 2
 	[[ "$actor" == "trusted-runner" || ("$actor" == "trusted-author" && "$association" == "COLLABORATOR") ]]
 	return $?
+}
+gh() {
+	local command="$1"
+	local resource="${2:-}"
+	[[ "$command" == "api" && "$resource" == "repos/example/repo/issues/24" ]] || return 1
+	printf '%s\n' '{"state":"open","labels":[{"name":"auto-dispatch"},{"name":"status:blocked"},{"name":"publication:pending"}]}'
+	return 0
+}
+_gh_audit_record_op \
+	"issue_edit" "example/repo" "24" \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["no-auto-dispatch","publication:pending"]}' \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["auto-dispatch","status:blocked","publication:pending"]}' \
+	"/runtime/agents/scripts/planning-publication-reconcile.sh" \
+	"_publication_reconcile_one" "1"
+jq -e 'select(.number == 24) | .flags.planning_publication_verified == "v1-current-state"' "$PROOF_LOG" >/dev/null ||
+	fail "verified planning publication transition did not produce audit proof"
+
+gh() {
+	local command="$1"
+	local resource="${2:-}"
+	[[ "$command" == "api" ]] || return 1
+	case "$resource" in
+	repos/example/repo/issues/25 | repos/example/repo/issues/27)
+		printf '%s\n' '{"user":{"login":"trusted-author","type":"User"},"author_association":"COLLABORATOR","labels":[{"name":"hold-for-review"}]}'
+		;;
+	repos/example/repo/issues/26)
+		printf '%s\n' '{"user":{"login":"external-author","type":"User"},"author_association":"CONTRIBUTOR","labels":[]}'
+		;;
+	user)
+		printf '%s\n' "$CURRENT_ACTOR"
+		;;
+	*) return 1 ;;
+	esac
+	return 0
 }
 _gh_audit_record_op \
 	"issue_edit" "example/repo" "25" \

--- a/.agents/scripts/tests/test-planning-publication-reconcile.sh
+++ b/.agents/scripts/tests/test-planning-publication-reconcile.sh
@@ -14,6 +14,8 @@ REMOVE_PATTERN='--remove-label "$PUBLICATION_PENDING_LABEL"'
 WORKFLOW_PATTERN='--repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"'
 # shellcheck disable=SC2016
 VERIFY_PATTERN='_publication_issue_has_labels "$issue_json" "$projected_labels"'
+# shellcheck disable=SC2016
+SAFE_EDIT_PATTERN='gh_issue_edit_safe "$issue_num" --repo "$repo"'
 
 # shellcheck source=../planning-publication-reconcile.sh
 source "$RECONCILER"
@@ -32,6 +34,10 @@ grep -Fq '_publication_exact_default_snapshot' "$RECONCILER"
 grep -Fq '_publication_validate_mapping' "$RECONCILER"
 grep -Fq 'verify-brief-helper.sh" check-readiness' "$RECONCILER"
 grep -Fq -- "$REMOVE_PATTERN" "$RECONCILER"
+grep -Fq -- "$SAFE_EDIT_PATTERN" "$RECONCILER"
+if grep -Fq 'gh-write-helper.sh" issue edit' "$RECONCILER"; then
+	exit 1
+fi
 grep -Fq 'Reconcile pending planning publication' "$WORKFLOW"
 grep -Fq -- "$WORKFLOW_PATTERN" "$WORKFLOW"
 


### PR DESCRIPTION
## Summary

Preserve planning-publication reconciler provenance, verify its no-auto-dispatch transition against live issue state, and suppress only the exact audited transition.

## Files Changed

.agents/scripts/gh-audit-anomaly-filter.jq, .agents/scripts/planning-publication-reconcile.sh, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh, .agents/scripts/tests/test-planning-publication-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh; bash .agents/scripts/tests/test-planning-publication-reconcile.sh; shellcheck .agents/scripts/planning-publication-reconcile.sh .agents/scripts/shared-gh-wrappers-safe-edit.sh .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh .agents/scripts/tests/test-planning-publication-reconcile.sh; git diff --check

Resolves #30157


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.254 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-terra spent 9m and 208,510 tokens on this as a headless worker.