### PR TITLE
GH#30151: isolate pinned OpenCode headless runtime

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -47,6 +47,9 @@ readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6"
 readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
+# Linux headless dispatch may bind this to an aidevops-managed exact-version
+# runtime without mutating the general/interactive OpenCode installation.
+HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
 readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 readonly DISPATCH_LEDGER_HELPER="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 readonly OAUTH_POOL_HELPER="${SCRIPT_DIR}/oauth-pool-helper.sh"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1568,47 +1568,130 @@ _find_alternative_opencode_binary() {
 }
 
 #######################################
-# Version guard -- enforce OPENCODE_PINNED_VERSION for affected worker launches.
-#
-# Something outside our control (unknown process, worker side-effect)
-# periodically upgrades opencode to @latest. This guard runs on every
-# canary check and reinstalls the pinned version if it drifted.
-# Cheap: one `opencode --version` + optional package-managed repair and
-# verification.
-# Returns non-zero when repair fails or the installed runtime remains drifted,
-# allowing every headless launch path to fail closed before starting a worker.
+# Resolve the native OpenCode executable from an isolated npm prefix.
+#######################################
+_resolve_headless_opencode_install_binary() {
+	local install_root="$1"
+	local machine_arch="${AIDEVOPS_TEST_UNAME_M:-}"
+	if [[ -z "$machine_arch" ]]; then
+		machine_arch=$(uname -m 2>/dev/null || true)
+	fi
+	local package_arch=""
+	case "$machine_arch" in
+	x86_64 | amd64) package_arch="x64" ;;
+	aarch64 | arm64) package_arch="arm64" ;;
+	*) return 1 ;;
+	esac
+
+	local base="opencode-linux-${package_arch}"
+	local suffixes=("")
+	if [[ "$package_arch" == "x64" ]] && ! grep -qE '(^|[[:space:]])avx2([[:space:]]|$)' /proc/cpuinfo 2>/dev/null; then
+		suffixes=("-baseline" "")
+	fi
+	if ldd --version 2>&1 | grep -qi musl; then
+		if [[ "$package_arch" == "x64" ]]; then
+			suffixes=("-musl" "-baseline-musl" "" "-baseline")
+		else
+			suffixes=("-musl" "")
+		fi
+	fi
+
+	local suffix=""
+	for suffix in "${suffixes[@]}"; do
+		local binary="$install_root/node_modules/${base}${suffix}/bin/opencode"
+		if [[ -x "$binary" ]]; then
+			printf '%s\n' "$binary"
+			return 0
+		fi
+	done
+	return 1
+}
+
+#######################################
+# Install an exact OpenCode release into an isolated, versioned prefix and
+# publish it atomically. The runtime uses the normal HOME only after install so
+# existing provider authentication remains available to workers.
+#######################################
+_provision_headless_opencode_runtime() {
+	local pin="$1"
+	local runtime_root="${STATE_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}/opencode-runtimes"
+	local install_root="$runtime_root/$pin"
+	local existing_bin=""
+	if existing_bin=$(_resolve_headless_opencode_install_binary "$install_root" 2>/dev/null) &&
+		_validate_opencode_binary "$existing_bin" && [[ "${_VALIDATE_OC_VERSION#v}" == "$pin" ]]; then
+		HEADLESS_OPENCODE_BIN="$existing_bin"
+		return 0
+	fi
+
+	command -v npm >/dev/null 2>&1 || {
+		print_error "Cannot provision pinned OpenCode ${pin}: npm is unavailable"
+		return 1
+	}
+	mkdir -p "$runtime_root" || return 1
+	local temp_root="$runtime_root/.${pin}.install.$$"
+	local isolated_home="$temp_root/home"
+	local isolated_cache="$temp_root/cache"
+	mkdir -p "$temp_root/prefix" "$isolated_home" "$isolated_cache" || return 1
+	if ! env -i HOME="$isolated_home" PATH="$PATH" \
+		GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+		npm_config_userconfig=/dev/null npm_config_cache="$isolated_cache" \
+		npm install --ignore-scripts --no-audit --no-fund --prefix "$temp_root/prefix" \
+		"opencode-ai@${pin}" >/dev/null 2>&1; then
+		print_error "Failed to provision isolated OpenCode ${pin}; general installation was not changed"
+		rm -rf "$temp_root"
+		return 1
+	fi
+	local candidate_bin=""
+	if ! candidate_bin=$(_resolve_headless_opencode_install_binary "$temp_root/prefix") ||
+		! _validate_opencode_binary "$candidate_bin" || [[ "${_VALIDATE_OC_VERSION#v}" != "$pin" ]]; then
+		print_error "Isolated OpenCode ${pin} failed exact-version verification"
+		rm -rf "$temp_root"
+		return 1
+	fi
+
+	local stale_root="$runtime_root/.${pin}.stale.$$"
+	if [[ -e "$install_root" ]]; then
+		mv "$install_root" "$stale_root" || {
+			rm -rf "$temp_root"
+			return 1
+		}
+	fi
+	if ! mv "$temp_root/prefix" "$install_root"; then
+		[[ ! -e "$stale_root" ]] || mv "$stale_root" "$install_root" 2>/dev/null || true
+		rm -rf "$temp_root"
+		return 1
+	fi
+	rm -rf "$temp_root" "$stale_root"
+	HEADLESS_OPENCODE_BIN=$(_resolve_headless_opencode_install_binary "$install_root") || return 1
+	print_info "OpenCode headless runtime ready at pinned version ${pin}"
+	return 0
+}
+
+#######################################
+# Version guard -- bind affected worker launches to an isolated exact-version
+# OpenCode runtime. General/interactive installs remain free to track latest.
 #######################################
 _enforce_opencode_version_pin() {
 	local pin="${OPENCODE_PINNED_VERSION:-}"
 	# No pin or pin is "latest" -> nothing to enforce
 	if [[ -z "$pin" || "$pin" == "latest" ]]; then
+		HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
 		return 0
 	fi
 	# The scheduled compatibility evaluator must exercise its isolated candidate,
 	# not repair it back to the current pin before the canary starts.
 	if [[ "${AIDEVOPS_OPENCODE_PIN_CANDIDATE_EVALUATION:-0}" == "1" ]]; then
+		HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
 		return 0
 	fi
 	local pin_platform="${AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE:-$(uname -s 2>/dev/null || printf 'unknown')}"
 	if ! aidevops_opencode_pin_applies "$pin_platform" "headless"; then
+		HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
 		return 0
 	fi
 
-	local installed=""
-	if ! installed=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null); then
-		installed="unknown"
-	fi
-	installed="${installed#v}"
-	installed="${installed%%[[:space:]]*}"
-	[[ "$installed" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || installed="unknown"
-
-	if [[ "$installed" == "$pin" ]]; then
-		return 0
-	fi
-
-	# Multiple Pulse candidates can hit the canary at once. Serialise the repair
-	# path so concurrent workers do not race a global package-manager reinstall
-	# and falsely fail closed while another process is restoring the same pin.
+	# Multiple Pulse candidates can hit the canary at once. Serialize isolated
+	# provisioning so workers never race while publishing the pinned runtime.
 	local repair_lock_base="${STATE_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 	local repair_lock_dir="${repair_lock_base}/opencode-pin-repair.lock"
 	mkdir -p "$repair_lock_base" 2>/dev/null || true
@@ -1624,45 +1707,12 @@ _enforce_opencode_version_pin() {
 	done
 	repair_lock_acquired=1
 
-	# Another canary may have repaired the runtime while this process waited.
-	if ! installed=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null); then
-		installed="unknown"
-	fi
-	installed="${installed#v}"
-	installed="${installed%%[[:space:]]*}"
-	[[ "$installed" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || installed="unknown"
-	if [[ "$installed" == "$pin" ]]; then
-		rmdir "$repair_lock_dir" 2>/dev/null || true
-		return 0
-	fi
-
-	print_warning "OpenCode version drift: installed=$installed, pin=$pin -- reinstalling"
-	local repair_cmd=""
-	if ! repair_cmd=$(aidevops_opencode_upgrade_command "$pin"); then
-		print_error "Cannot build OpenCode ${pin} repair command -- refusing headless launch"
-		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
-		return 1
-	fi
-	if ! AIDEVOPS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT" bash -c "$repair_cmd" >/dev/null 2>&1; then
-		print_error "Failed to restore OpenCode to ${pin} -- refusing headless launch"
-		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
-		return 1
-	fi
-
-	local restored=""
-	if ! restored=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null); then
-		restored="unknown"
-	fi
-	restored="${restored#v}"
-	restored="${restored%%[[:space:]]*}"
-	[[ "$restored" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || restored="unknown"
-	if [[ "$restored" != "$pin" ]]; then
-		print_error "OpenCode version mismatch after repair: installed=$restored, pin=$pin -- refusing headless launch"
+	if ! _provision_headless_opencode_runtime "$pin"; then
+		print_error "OpenCode ${pin} isolated runtime provisioning failed -- refusing headless launch"
 		[[ "$repair_lock_acquired" -eq 0 ]] || rmdir "$repair_lock_dir" 2>/dev/null || true
 		return 1
 	fi
 	rmdir "$repair_lock_dir" 2>/dev/null || true
-	print_info "OpenCode restored to ${pin}"
 	return 0
 }
 
@@ -1772,9 +1822,9 @@ _canary_negative_cache_is_active() {
 _resolve_canary_opencode_binary() {
 	local fail_cache_file="$1"
 	local fail_reason_file="$2"
-	_CANARY_EFFECTIVE_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	_CANARY_EFFECTIVE_OPENCODE_BIN="${HEADLESS_OPENCODE_BIN:-$OPENCODE_BIN_DEFAULT}"
 	local validate_rc=0
-	_validate_opencode_binary "$OPENCODE_BIN_DEFAULT" || validate_rc=$?
+	_validate_opencode_binary "$_CANARY_EFFECTIVE_OPENCODE_BIN" || validate_rc=$?
 	if [[ "$validate_rc" -eq 0 ]]; then
 		return 0
 	fi
@@ -1783,14 +1833,14 @@ _resolve_canary_opencode_binary() {
 	local wrong_version="${_VALIDATE_OC_VERSION:-<missing>}"
 	local alt_bin=""
 	if alt_bin=$(_find_alternative_opencode_binary); then
-		print_warning "Canary: OPENCODE_BIN_DEFAULT='${OPENCODE_BIN_DEFAULT}' is invalid (version='${wrong_version}', rc=${validate_rc}) — falling back to '${alt_bin}' (t2887)"
+		print_warning "Canary: headless OpenCode binary='${_CANARY_EFFECTIVE_OPENCODE_BIN}' is invalid (version='${wrong_version}', rc=${validate_rc}) — falling back to '${alt_bin}' (t2887)"
 		_CANARY_EFFECTIVE_OPENCODE_BIN="$alt_bin"
 		export OPENCODE_BIN="$alt_bin"
 		return 0
 	fi
 
 	# Structural failure: stamp config_error so later attempts fail fast.
-	print_warning "Canary: OPENCODE_BIN_DEFAULT='${OPENCODE_BIN_DEFAULT}' returns '${wrong_version}' (rc=${validate_rc}) — not anomalyco/opencode."
+	print_warning "Canary: headless OpenCode binary='${_CANARY_EFFECTIVE_OPENCODE_BIN}' returns '${wrong_version}' (rc=${validate_rc}) — not anomalyco/opencode."
 	print_warning "Canary: searched $(_opencode_fixed_candidate_dirs_for_warning) — no valid binary found."
 	print_warning "Canary: install with 'npm install -g opencode-ai' or set OPENCODE_BIN to a valid binary (t2887)."
 	mkdir -p "${STATE_DIR}" 2>/dev/null || true

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -490,7 +490,7 @@ _build_run_cmd() {
 	shift 7
 
 	# Emit base command args as null-delimited tokens (bash 3.2 compat: no local -a in subshell)
-	printf '%s\0' "$OPENCODE_BIN_DEFAULT" run "$prompt" --dir "$work_dir" -m "$selected_model" --title "$title" --format json
+	printf '%s\0' "${HEADLESS_OPENCODE_BIN:-$OPENCODE_BIN_DEFAULT}" run "$prompt" --dir "$work_dir" -m "$selected_model" --title "$title" --format json
 	if [[ -n "$agent_name" ]]; then
 		printf '%s\0' --agent "$agent_name"
 	fi

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -95,7 +95,7 @@ get_auth_signature() {
 	case "$provider" in
 	anthropic)
 		local auth_status auth_mtime
-		auth_status=$(timeout_sec 10 "$OPENCODE_BIN_DEFAULT" auth status 2>/dev/null || true)
+		auth_status=$(timeout_sec 10 "${HEADLESS_OPENCODE_BIN:-$OPENCODE_BIN_DEFAULT}" auth status 2>/dev/null || true)
 		auth_mtime=$(file_mtime "$OPENCODE_AUTH_FILE")
 		auth_material="${auth_material}|status=${auth_status}|mtime=${auth_mtime}"
 		;;
@@ -106,7 +106,7 @@ get_auth_signature() {
 			# OpenAI can also be authenticated via OpenCode OAuth (no direct API key needed).
 			# Include the OAuth auth status in the signature so backoff clears on re-auth.
 			local auth_status auth_mtime
-			auth_status=$(timeout_sec 10 "$OPENCODE_BIN_DEFAULT" auth status 2>/dev/null || true)
+			auth_status=$(timeout_sec 10 "${HEADLESS_OPENCODE_BIN:-$OPENCODE_BIN_DEFAULT}" auth status 2>/dev/null || true)
 			auth_mtime=$(file_mtime "$OPENCODE_AUTH_FILE")
 			auth_material="${auth_material}|status=${auth_status}|mtime=${auth_mtime}|env=missing"
 		fi

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -51,10 +51,16 @@ extract_function() {
 		/^_opencode_upgrade_cmd\(\)/, /^}$/ { print; next }
 	' "$TOOL_VERSION_CHECK" >>"$SANDBOX/extract.sh"
 	awk '
+		/^_validate_opencode_binary\(\)/, /^}/ { print; next }
+		/^_resolve_headless_opencode_install_binary\(\)/, /^}/ { print; next }
+		/^_provision_headless_opencode_runtime\(\)/, /^}/ { print; next }
 		/^_enforce_opencode_version_pin\(\)/, /^}$/ { print; next }
 	' "$HEADLESS_RUNTIME_LIB" >>"$SANDBOX/extract.sh"
 	if ! grep -q '^aidevops_opencode_pin_applies()' "$SANDBOX/extract.sh" ||
 		! grep -q '^_opencode_upgrade_cmd()' "$SANDBOX/extract.sh" ||
+		! grep -q '^_validate_opencode_binary()' "$SANDBOX/extract.sh" ||
+		! grep -q '^_resolve_headless_opencode_install_binary()' "$SANDBOX/extract.sh" ||
+		! grep -q '^_provision_headless_opencode_runtime()' "$SANDBOX/extract.sh" ||
 		! grep -q '^_enforce_opencode_version_pin()' "$SANDBOX/extract.sh"; then
 		printf 'FAIL: extraction did not capture OpenCode version functions\n' >&2
 		exit 1
@@ -201,74 +207,77 @@ printf "npm %s\n" "$*" >>"'"$SANDBOX"'/npm-case/calls"'
 )
 assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/npm-case/calls" | sed 's/;$//')"
 
-printf 'Test 4: headless version guard restores the pinned release\n'
-mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin"
-# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+printf 'Test 4: headless guard provisions an isolated pin without changing newer general install\n'
+mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin" "$SANDBOX/version-guard/state"
 write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
-version=$(<"'"$SANDBOX"'/version-guard/version")
-printf "%s\n" "$version"'
+printf "1.18.17\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
-printf "1.18.16\n" >"'"$SANDBOX"'/version-guard/version"'
-printf '1.18.7\n' >"$SANDBOX/version-guard/version"
+prefix=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "--prefix" ]]; then prefix="$2"; shift 2; continue; fi
+  shift
+done
+mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
+cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
+#!/usr/bin/env bash
+printf "1.18.16\n"
+BIN
+chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 guard_rc=0
+headless_bin=""
 (
 	source_extracted
 	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
+	HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	STATE_DIR="$SANDBOX/version-guard/state"
+	AIDEVOPS_TEST_UNAME_M="x86_64"
 	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
 	print_warning() { return 0; }
 	print_info() { return 0; }
 	print_error() { return 0; }
 	PATH="$SANDBOX/version-guard/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
+	printf '%s\n' "$HEADLESS_OPENCODE_BIN" >"$SANDBOX/version-guard/headless-bin"
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
-assert_eq "headless repair uses resolved binary outside PATH" "1.18.16" "$("$SANDBOX/version-guard/runtime/opencode")"
-assert_eq "headless pin reinstall command" "install -g opencode-ai@1.18.16" "$(tr '\n' ';' <"$SANDBOX/version-guard/calls" | sed 's/;$//')"
+headless_bin=$(<"$SANDBOX/version-guard/headless-bin")
+assert_eq "general install remains newer" "1.18.17" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "isolated headless runtime is pinned" "1.18.16" "$("$headless_bin")"
+install_call=$(<"$SANDBOX/version-guard/calls")
+[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.16.install."*"/prefix opencode-ai@1.18.16" ]] && install_shape="valid" || install_shape="invalid"
+assert_eq "isolated install requests exact pin" "valid" "$install_shape"
 
-printf 'Test 4b: concurrent headless version guard waits for repair and avoids duplicate reinstall\n'
-mkdir -p "$SANDBOX/version-guard-lock/runtime" "$SANDBOX/version-guard-lock/bin" "$SANDBOX/version-guard-lock/state"
-# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
-write_executable "$SANDBOX/version-guard-lock/runtime/opencode" '#!/usr/bin/env bash
-version=$(<"'"$SANDBOX"'/version-guard-lock/version")
-printf "%s\n" "$version"'
-# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
-write_executable "$SANDBOX/version-guard-lock/bin/npm" '#!/usr/bin/env bash
-printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard-lock/calls"
-printf "1.18.16\n" >"'"$SANDBOX"'/version-guard-lock/version"'
-printf '1.18.7\n' >"$SANDBOX/version-guard-lock/version"
-mkdir "$SANDBOX/version-guard-lock/state/opencode-pin-repair.lock"
-(
- sleep 1
- printf '1.18.16\n' >"$SANDBOX/version-guard-lock/version"
- rmdir "$SANDBOX/version-guard-lock/state/opencode-pin-repair.lock"
-) &
-lock_repair_pid=$!
-guard_rc=0
+printf 'Test 4b: existing isolated pin is reused without package-manager mutation\n'
+reuse_rc=0
 (
 	source_extracted
-	STATE_DIR="$SANDBOX/version-guard-lock/state"
-	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard-lock/runtime/opencode"
+	STATE_DIR="$SANDBOX/version-guard/state"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
+	HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	AIDEVOPS_TEST_UNAME_M="x86_64"
 	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
 	print_warning() { return 0; }
 	print_info() { return 0; }
 	print_error() { return 0; }
-	PATH="$SANDBOX/version-guard-lock/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
-) || guard_rc=$?
-wait "$lock_repair_pid" 2>/dev/null || true
-assert_eq "headless pin repair lock wait status" "0" "$guard_rc"
-assert_eq "headless pin repair lock avoids duplicate reinstall" "0" "$([[ -f "$SANDBOX/version-guard-lock/calls" ]] && wc -l <"$SANDBOX/version-guard-lock/calls" || printf '0\n')"
+	PATH="$SANDBOX/version-guard/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
+) || reuse_rc=$?
+assert_eq "existing isolated runtime reuse status" "0" "$reuse_rc"
+assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SANDBOX/version-guard/calls" | tr -d ' ')"
 
-printf 'Test 5: headless version guard fails closed when reinstall fails\n'
-mkdir -p "$SANDBOX/version-install-failure"
+printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
+mkdir -p "$SANDBOX/version-install-failure/state"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.7\n"'
+printf "1.18.17\n"'
 write_executable "$SANDBOX/version-install-failure/npm" '#!/usr/bin/env bash
 exit 42'
 guard_rc=0
 (
 	source_extracted
+	STATE_DIR="$SANDBOX/version-install-failure/state"
 	OPENCODE_BIN_DEFAULT="$SANDBOX/version-install-failure/opencode"
+	HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	AIDEVOPS_TEST_UNAME_M="x86_64"
 	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
 	print_warning() { return 0; }
 	print_info() { return 0; }
@@ -277,42 +286,28 @@ guard_rc=0
 ) || guard_rc=$?
 assert_eq "headless failed reinstall status" "1" "$guard_rc"
 
-printf 'Test 6: headless version guard verifies the repaired binary\n'
-mkdir -p "$SANDBOX/version-mismatch"
-write_executable "$SANDBOX/version-mismatch/opencode" '#!/usr/bin/env bash
-printf "1.18.7\n"'
-write_executable "$SANDBOX/version-mismatch/npm" '#!/usr/bin/env bash
-exit 0'
-guard_rc=0
+printf 'Test 6: non-Linux headless dispatch keeps the general binary\n'
+scope_rc=0
 (
 	source_extracted
-	OPENCODE_BIN_DEFAULT="$SANDBOX/version-mismatch/opencode"
-	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
+	HEADLESS_OPENCODE_BIN="unexpected"
+	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Darwin"
 	print_warning() { return 0; }
 	print_info() { return 0; }
 	print_error() { return 0; }
-	PATH="$SANDBOX/version-mismatch:$SYSTEM_PATH" _enforce_opencode_version_pin
-) || guard_rc=$?
-assert_eq "headless post-repair mismatch status" "1" "$guard_rc"
+	_enforce_opencode_version_pin
+	printf '%s\n' "$HEADLESS_OPENCODE_BIN" >"$SANDBOX/version-guard/non-linux-bin"
+) || scope_rc=$?
+assert_eq "non-Linux scope status" "0" "$scope_rc"
+assert_eq "non-Linux uses general binary" "$SANDBOX/version-guard/runtime/opencode" "$(<"$SANDBOX/version-guard/non-linux-bin")"
 
-printf 'Test 7: headless version guard rejects a failed version probe\n'
-mkdir -p "$SANDBOX/version-probe-failure"
-write_executable "$SANDBOX/version-probe-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.9\n"
-exit 3'
-write_executable "$SANDBOX/version-probe-failure/npm" '#!/usr/bin/env bash
-exit 0'
-guard_rc=0
-(
-	source_extracted
-	OPENCODE_BIN_DEFAULT="$SANDBOX/version-probe-failure/opencode"
-	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
-	print_warning() { return 0; }
-	print_info() { return 0; }
-	print_error() { return 0; }
-	PATH="$SANDBOX/version-probe-failure:$SYSTEM_PATH" _enforce_opencode_version_pin
-) || guard_rc=$?
-assert_eq "headless failed version probe status" "1" "$guard_rc"
+printf 'Test 7: headless run and auth paths consume the isolated runtime binding\n'
+model_source="$REPO_ROOT/.agents/scripts/headless-runtime-model.sh"
+provider_source="$REPO_ROOT/.agents/scripts/headless-runtime-provider.sh"
+# shellcheck disable=SC2016 # Literal source pattern, not a shell expansion.
+binding_count=$(grep -c 'HEADLESS_OPENCODE_BIN:-\$OPENCODE_BIN_DEFAULT' "$model_source" "$provider_source" | awk -F: '{ total += $2 } END { print total + 0 }')
+assert_eq "isolated runtime reaches run and auth call sites" "3" "$binding_count"
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Provision an aidevops-managed exact-version OpenCode runtime for Linux headless dispatch, bind worker run/auth/canary paths to it, and leave the general installation tracking latest.

## Files Changed

.agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-model.sh, .agents/scripts/headless-runtime-provider.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with the integrated headless version-policy harness: a newer general binary remains 1.18.17 while dispatch resolves isolated 1.18.16; reuse, failed provisioning, platform scope, run/auth binding, pin policy, candidate discovery, worktree/database runtime suites, ShellCheck, and linters-local.sh all pass.

Resolves #30151


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.254 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-sol spent 9h 43m and 272,091 tokens on this with the user in an interactive session.