### PR TITLE
GH#30160: prevent Tabby profile config corruption

### DIFF
--- a/.agents/scripts/tabby_yaml_helpers.py
+++ b/.agents/scripts/tabby_yaml_helpers.py
@@ -11,20 +11,52 @@ and new profile/group insertion.
 
 from __future__ import annotations
 
+import os
 import re
+import tempfile
 from typing import Optional
+
+import yaml
 
 
 def load_yaml_simple(path: str) -> str:
-    """Load file content as string."""
+    """Load and validate a Tabby YAML document as text."""
     with open(path, "r") as f:
-        return f.read()
+        content = f.read()
+    validate_yaml_document(content)
+    return content
 
 
 def save_yaml(path: str, content: str) -> None:
-    """Save content to file."""
-    with open(path, "w") as f:
-        f.write(content)
+    """Validate and atomically replace a Tabby YAML document."""
+    validate_yaml_document(content)
+    destination = os.path.abspath(path)
+    directory = os.path.dirname(destination)
+    mode = os.stat(destination).st_mode & 0o777
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{os.path.basename(destination)}.", dir=directory, text=True
+    )
+    try:
+        with os.fdopen(descriptor, "w") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, destination)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def validate_yaml_document(content: str) -> None:
+    """Require a mapping document with list-valued Tabby sections."""
+    document = yaml.safe_load(content)
+    if not isinstance(document, dict):
+        raise ValueError("Tabby config must be a YAML mapping")
+    for key in ("profiles", "groups"):
+        value = document.get(key)
+        if value is not None and not isinstance(value, list):
+            raise ValueError(f"Tabby config '{key}' must be a list")
 
 
 _CWD_LINE_RE = re.compile(r"^(?P<indent>\s+)cwd:\s*(?P<value>.*)$")
@@ -185,6 +217,14 @@ def find_version_insert_at(lines: list[str]) -> int:
 def insert_profiles_block(config_text: str, new_block: str) -> str:
     """Insert new_block into the profiles section of config_text."""
     lines = config_text.split("\n")
+    for i, line in enumerate(lines):
+        inline_empty = re.match(r"^(profiles:)\s*\[\]\s*(#.*)?$", line)
+        if inline_empty:
+            comment = inline_empty.group(2)
+            lines[i] = f"profiles:{f' {comment}' if comment else ''}"
+            break
+        if re.match(r"^profiles:\s*\S", line):
+            raise ValueError("Unsupported inline profiles value")
     has_profiles_key, insert_line = find_profiles_insert_line(lines)
 
     if not has_profiles_key:

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -280,6 +280,80 @@ resolved=$(HOME="${tmp_root}" XDG_CONFIG_HOME="${config_home}" TABBY_CONFIG="${e
 resolved=$(HOME="${tmp_root}" TABBY_CONFIG='' TABBY_CONFIG_DIRECTORY='' bash "${TABBY_HELPER}" config-path Darwin)
 [[ "$resolved" == "${tmp_root}/Library/Application Support/tabby/config.yaml" ]] && _pass "macOS default preserved" || _fail "macOS default mismatch: ${resolved}"
 
+_info "Test 12: sync converts inline empty profiles and keeps valid YAML"
+inline_config="${tmp_root}/inline-empty.yaml"
+printf 'version: 8\nprofiles: []\ngroups: []\n' >"${inline_config}"
+if PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${inline_config}" >/dev/null &&
+	python3 -c 'import sys, yaml; value = yaml.safe_load(open(sys.argv[1])); assert isinstance(value["profiles"], list) and value["profiles"]' "${inline_config}" &&
+	! grep -qF 'profiles: []' "${inline_config}"; then
+	_pass "inline empty profiles converted to valid block list"
+else
+	_fail "inline empty profiles sync failed"
+fi
+
+_info "Test 13: missing and block-empty profiles shapes remain valid"
+for shape in missing block_empty; do
+	shape_config="${tmp_root}/${shape}.yaml"
+	if [[ "${shape}" == "missing" ]]; then
+		printf 'version: 8\ngroups: []\n' >"${shape_config}"
+	else
+		printf 'version: 8\nprofiles:\ngroups: []\n' >"${shape_config}"
+	fi
+	if PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${shape_config}" >/dev/null &&
+		python3 -c 'import sys, yaml; value = yaml.safe_load(open(sys.argv[1])); assert isinstance(value["profiles"], list) and value["profiles"]' "${shape_config}"; then
+		_pass "${shape} profiles shape remains valid"
+	else
+		_fail "${shape} profiles shape failed"
+	fi
+done
+
+_info "Test 14: malformed source is rejected without modification"
+malformed_config="${tmp_root}/malformed.yaml"
+printf 'version: 8\nprofiles: []\n  - name: broken\ngroups: []\n' >"${malformed_config}"
+malformed_before=$(shasum -a 256 "${malformed_config}" | cut -d ' ' -f 1)
+if PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${malformed_config}" --status-only >/dev/null 2>&1; then
+	_fail "malformed status unexpectedly succeeded"
+else
+	malformed_after=$(shasum -a 256 "${malformed_config}" | cut -d ' ' -f 1)
+	[[ "${malformed_before}" == "${malformed_after}" ]] && _pass "malformed source rejected unchanged" || _fail "malformed source changed"
+fi
+
+_info "Test 15: failed candidate validation preserves the active config"
+run_python_test "invalid candidate is not written" "${load_module_code}
+import pathlib, tempfile
+from tabby_yaml_helpers import save_yaml
+path = pathlib.Path(tempfile.mkdtemp()) / 'config.yaml'
+original = 'version: 8\\nprofiles: []\\ngroups: []\\n'
+path.write_text(original)
+try:
+    save_yaml(str(path), 'version: 8\\nprofiles: []\\n  - broken\\n')
+except Exception:
+    pass
+else:
+    raise AssertionError('invalid candidate accepted')
+assert path.read_text() == original
+"
+
+_info "Test 16: atomic replacement failure preserves the active config"
+run_python_test "replacement failure leaves original unchanged" "${load_module_code}
+import pathlib, tempfile
+from unittest import mock
+from tabby_yaml_helpers import save_yaml
+path = pathlib.Path(tempfile.mkdtemp()) / 'config.yaml'
+original = 'version: 8\\nprofiles: []\\ngroups: []\\n'
+candidate = 'version: 8\\nprofiles:\\n  - name: demo\\ngroups: []\\n'
+path.write_text(original)
+with mock.patch('tabby_yaml_helpers.os.replace', side_effect=OSError('simulated')):
+    try:
+        save_yaml(str(path), candidate)
+    except OSError:
+        pass
+    else:
+        raise AssertionError('replacement failure was ignored')
+assert path.read_text() == original
+assert list(path.parent.glob('.config.yaml.*')) == []
+"
+
 echo ""
 if ((fail_count == 0)); then
 	printf '%bAll %d tests passed.%b\n' "${TEST_GREEN}" "${pass_count}" "${TEST_NC}"


### PR DESCRIPTION
## Summary

Validate Tabby YAML before status or sync, convert inline empty profile lists safely, and atomically replace configs only after complete validation.

## Files Changed

.agents/scripts/tabby_yaml_helpers.py, .agents/scripts/tests/test-tabby-profile-sync.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 20 focused Tabby regression tests; Python compile; ShellCheck; local linters; closeout review bundle c535e0c420a843b7cb17b8953221778e7683c8f245fd59d3ed1b087bcbe032f7

Resolves #30160


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.254 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-sol spent 30m and 221,381 tokens on this with the user in an interactive session.