### PR TITLE
GH#30165: preserve durable locked issue approval

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -76,6 +76,10 @@ readonly APPROVAL_NAMESPACE="aidevops-approve"
 readonly APPROVAL_MARKER="<!-- aidevops-signed-approval -->"
 readonly _APPROVAL_NMR_LABEL="needs-maintainer-review"
 readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
+readonly _APPROVAL_AVAILABLE_LABEL="status:available"
+readonly _APPROVAL_QUEUED_LABEL="status:queued"
+readonly _APPROVAL_IN_PROGRESS_LABEL="status:in-progress"
+readonly _APPROVAL_GITHUB_ACTIONS_BOT_ID="41898282"
 readonly _APPROVAL_MISSING_FIELD="__missing__"
 readonly _APPROVAL_GH_INVALID_TOKEN="invalid-token"
 readonly _APPROVAL_BATCH_MODE="batch"
@@ -639,8 +643,29 @@ _approval_verify_issue_state() {
 		_print_error "Approval state verification failed: auto-dispatch is missing on #$target_number"
 		return 1
 	fi
-	if ! printf '%s' "$issue_json" | jq -e --arg user "$gh_user" '(.assignees // []) | any(.login == $user)' >/dev/null 2>&1; then
-		_print_error "Approval state verification failed: $gh_user is not assigned to #$target_number"
+	# Pulse may claim the issue as soon as auto-dispatch becomes visible. Accept
+	# only the initial available state or its two forward worker states here;
+	# continuity verification still authenticates every timeline mutation.
+	if ! printf '%s' "$issue_json" | jq -e \
+		--arg available "$_APPROVAL_AVAILABLE_LABEL" \
+		--arg queued "$_APPROVAL_QUEUED_LABEL" \
+		--arg in_progress "$_APPROVAL_IN_PROGRESS_LABEL" '
+			[(.labels // [])[].name] as $labels |
+			[$available, $queued, "status:claimed", $in_progress, "status:in-review", "status:done", "status:blocked"] as $core |
+			[$labels[] | select(. as $label | $core | index($label) != null)] as $current |
+			($current | length) == 1 and
+			([$available, $queued, $in_progress] | index($current[0]) != null)
+		' >/dev/null 2>&1; then
+		_print_error "Approval state verification failed: no dispatchable or active status is present on #$target_number"
+		return 1
+	fi
+	if ! printf '%s' "$issue_json" | jq -e \
+		--arg user "$gh_user" \
+		--arg available "$_APPROVAL_AVAILABLE_LABEL" '
+			[(.labels // [])[].name] as $labels |
+			(($labels | index($available)) == null) or ((.assignees // []) | any(.login == $user))
+		' >/dev/null 2>&1; then
+		_print_error "Approval state verification failed: $gh_user is not assigned to available issue #$target_number"
 		return 1
 	fi
 	if ! printf '%s' "$issue_json" | jq -e '.locked == true' >/dev/null 2>&1; then
@@ -674,6 +699,11 @@ _approval_apply_issue_lifecycle_updates() {
 	local gh_user=""
 	local edit_err=""
 	local lock_err=""
+	local status_err=""
+	local restore_err=""
+	local _ah_labels_json=""
+	local _ah_stamp_file=""
+	local _ah_had_in_review=0
 
 	gh_user=$(gh api user --jq '.login' 2>/dev/null || printf '')
 	if [[ -z "$gh_user" || "$gh_user" == "null" ]]; then
@@ -681,49 +711,67 @@ _approval_apply_issue_lifecycle_updates() {
 		return 1
 	fi
 
-	edit_err=$(gh_issue_edit_safe "$target_number" --repo "$slug" \
-		--remove-label "$_APPROVAL_NMR_LABEL" \
-		--add-label "$_APPROVAL_AUTO_DISPATCH_LABEL" \
-		--add-assignee "$gh_user" 2>&1 >/dev/null) || {
-		_print_error "Failed to update approval labels/assignee on issue #$target_number"
-		[[ -n "$edit_err" ]] && _print_error "$edit_err"
+	# Capture whether an interactive claim stamp may need cleanup before the
+	# authoritative status transition removes status:in-review.
+	_ah_labels_json=$(gh_issue_view "$target_number" --repo "$slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+	[[ ",${_ah_labels_json}," == *",status:in-review,"* ]] && _ah_had_in_review=1
+
+	# Establish the final status while NMR still blocks dispatch. This prevents
+	# the default-status workflow from owning the normal handoff path.
+	status_err=$(set_issue_status "$target_number" "$slug" "available" 2>&1 >/dev/null) || {
+		_print_error "Failed to transition approved issue #$target_number to status:available"
+		[[ -n "$status_err" ]] && _print_error "$status_err"
 		return 1
 	}
-	_print_info "Labels updated: removed needs-maintainer-review, added auto-dispatch"
+
+	# The REST fallback applies additions before removals; native gh performs one
+	# combined edit. If transport uncertainty follows a partial mutation, restore
+	# NMR synchronously before reporting failure.
+	edit_err=$(gh_issue_edit_safe "$target_number" --repo "$slug" \
+		--add-label "$_APPROVAL_AUTO_DISPATCH_LABEL" \
+		--add-assignee "$gh_user" \
+		--remove-label "$_APPROVAL_NMR_LABEL" 2>&1 >/dev/null) || {
+		_print_error "Failed to update approval labels/assignee on issue #$target_number"
+		[[ -n "$edit_err" ]] && _print_error "$edit_err"
+		restore_err=$(_approval_restore_nmr_hold issue "$target_number" "$slug" 2>&1 >/dev/null) || {
+			_print_error "Failed to restore needs-maintainer-review after uncertain lifecycle update on issue #$target_number"
+			[[ -n "$restore_err" ]] && _print_error "$restore_err"
+		}
+		return 1
+	}
+	_print_info "Lifecycle updated: status:available, removed needs-maintainer-review, added auto-dispatch"
 	_print_info "Assigned to $gh_user"
 
 	lock_err=$(_approval_lock_issue "$target_number" "$slug" 2>&1 >/dev/null) || {
 		_print_error "Approval advisory lock failure: issue #$target_number could not be locked after approval state updates"
 		[[ -n "$lock_err" ]] && _print_error "$lock_err"
+		restore_err=$(_approval_restore_nmr_hold issue "$target_number" "$slug" 2>&1 >/dev/null) || {
+			_print_error "Failed to restore needs-maintainer-review after lock uncertainty on issue #$target_number"
+			[[ -n "$restore_err" ]] && _print_error "$restore_err"
+		}
 		return 1
 	}
 	_print_info "Issue #$target_number locked (scope finalized, unlocks after worker completion)"
 
-	# t2057: idempotent release of status:in-review. Signing is the handoff to
-	# automation, so the interactive hold must lift. Best-effort: verification
-	# below checks the approval-critical state, not local stamp cleanup.
-	local _ah_labels_json
-	_ah_labels_json=$(gh_issue_view "$target_number" --repo "$slug" \
-		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
-	if [[ "$_ah_labels_json" == *"status:in-review"* ]]; then
-		local _ah_helper=""
-		if [[ -x "${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
-			_ah_helper="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
-		else
-			local _ah_script_dir
-			_ah_script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd) || _ah_script_dir=""
-			if [[ -n "$_ah_script_dir" && -x "${_ah_script_dir}/interactive-session-helper.sh" ]]; then
-				_ah_helper="${_ah_script_dir}/interactive-session-helper.sh"
-			fi
-		fi
-		if [[ -n "$_ah_helper" ]]; then
-			"$_ah_helper" release "$target_number" "$slug" >/dev/null 2>&1 || true
-			_print_info "Released status:in-review (interactive review transitioned to available)"
-		fi
+	if ! _approval_verify_issue_state "$target_number" "$slug" "$gh_user"; then
+		restore_err=$(_approval_restore_nmr_hold issue "$target_number" "$slug" 2>&1 >/dev/null) || {
+			_print_error "Failed to restore needs-maintainer-review after final-state uncertainty on issue #$target_number"
+			[[ -n "$restore_err" ]] && _print_error "$restore_err"
+		}
+		return 1
 	fi
 
-	_approval_verify_issue_state "$target_number" "$slug" "$gh_user"
-	return $?
+	# t2057: remove only the local claim stamp after the complete remote state is
+	# verified. Invoking `release` here would perform a second remote status write
+	# that can overwrite a concurrent queued worker claim. On uncertainty, retain
+	# the stamp as a durable ownership/recovery marker.
+	if [[ "$_ah_had_in_review" -eq 1 ]]; then
+		_ah_stamp_file="${_APPROVAL_HOME}/.aidevops/.agent-workspace/interactive-claims/${slug//\//-}-${target_number}.json"
+		rm -f "$_ah_stamp_file" 2>/dev/null || true
+		_print_info "Released the local interactive claim after the verified remote lifecycle handoff"
+	fi
+	return 0
 }
 
 _approval_apply_pr_lifecycle_updates() {
@@ -970,6 +1018,19 @@ _approval_continuity_actor_authorized() {
 	return 1
 }
 
+_approval_continuity_is_repository_status_default() {
+	local event="$1"
+	local subject="$2"
+	local actor="$3"
+	local actor_id="$4"
+	local actor_type="$5"
+	[[ "$event" == "labeled" && "$subject" == "$_APPROVAL_AVAILABLE_LABEL" ]] || return 1
+	[[ "$actor" == "github-actions[bot]" ]] || return 1
+	[[ "$actor_id" == "$_APPROVAL_GITHUB_ACTIONS_BOT_ID" ]] || return 1
+	[[ "$actor_type" == "Bot" ]] || return 1
+	return 0
+}
+
 _approval_verify_locked_issue_continuity() {
 	local payload="$1"
 	local current_snapshot="$2"
@@ -978,7 +1039,8 @@ _approval_verify_locked_issue_continuity() {
 	local target_number="$5"
 	local issued_at="$6"
 	local signed_lifecycle="" current_anchor="" signed_anchor="" candidate="" candidate_digest=""
-	local timeline_pages="" mutation_rows="" event="" actor="" subject="" actor_rc=0
+	local timeline_pages="" mutation_rows="" event="" actor="" subject="" actor_id="" actor_type="" actor_rc=0
+	local signed_has_status=0 saw_auto_dispatch=0 saw_status_mutation=0 saw_status_default=0
 
 	# #aidevops:trust-boundary — no embedded lifecycle proof means this is a
 	# legacy exact-snapshot approval, never continuity authority.
@@ -988,6 +1050,9 @@ _approval_verify_locked_issue_continuity() {
 		return 1
 	fi
 	signed_anchor=$(jq -c '.lock_anchor' <<<"$signed_lifecycle") || return 1
+	if jq -e '[.labels[]?.name | select(startswith("status:"))] | length > 0' <<<"$signed_lifecycle" >/dev/null 2>&1; then
+		signed_has_status=1
+	fi
 	current_anchor=$(jq -c '.lifecycle.lock_anchor // empty' <<<"$current_snapshot") || return 1
 	[[ -n "$current_anchor" && "$current_anchor" == "$signed_anchor" ]] || return 1
 	if ! jq -e '.lifecycle.locked == true' <<<"$current_snapshot" >/dev/null 2>&1; then
@@ -1021,22 +1086,35 @@ _approval_verify_locked_issue_continuity() {
 	mutation_rows=$(jq -r --arg issued "$issued_at" '
 		[.[][]? | select((.created_at // "") > $issued) | (.event // "") as $event |
 		select(["assigned","unassigned","labeled","unlabeled","milestoned","demilestoned","closed","reopened","renamed","locked","unlocked","connected","disconnected","added_to_project","moved_columns_in_project","removed_from_project","transferred","converted_to_discussion","marked_as_duplicate","unmarked_as_duplicate","pinned","unpinned"] | index($event)) |
-		[(.event // ""), (.actor.login // ""), (.label.name // .assignee.login // "")] | @tsv][]
+		[(.event // ""), (.actor.login // ""), (.label.name // .assignee.login // ""), ((.actor.id // "") | tostring), (.actor.type // "")] | @tsv][]
 	' <<<"$timeline_pages" 2>/dev/null) || return 2
 	[[ -n "$mutation_rows" ]] || return 1
 
-	while IFS=$'\t' read -r event actor subject; do
+	while IFS=$'\t' read -r event actor subject actor_id actor_type; do
 		[[ -n "$event" ]] || continue
 		case "$event:$subject" in
 		assigned:* | unassigned:* | labeled:needs-maintainer-review | unlabeled:needs-maintainer-review | labeled:auto-dispatch | unlabeled:auto-dispatch | labeled:status:available | unlabeled:status:available | labeled:status:queued | unlabeled:status:queued | labeled:status:in-review | unlabeled:status:in-review | labeled:status:in-progress | unlabeled:status:in-progress) ;;
 		*) return 1 ;;
 		esac
+		# #aidevops:trust-boundary — GitHub's official Actions bot has no
+		# collaborator permission. Accept its single non-scope-bearing default only
+		# for the expected no-status handoff sequence: an authorized maintainer first
+		# exposed auto-dispatch and no status mutation has occurred. The immutable
+		# bot ID/type prevents lookalikes; this grants no generic workflow authority.
+		if _approval_continuity_is_repository_status_default "$event" "$subject" "$actor" "$actor_id" "$actor_type"; then
+			[[ "$signed_has_status" -eq 0 && "$saw_auto_dispatch" -eq 1 && "$saw_status_mutation" -eq 0 && "$saw_status_default" -eq 0 ]] || return 1
+			saw_status_default=1
+			saw_status_mutation=1
+			continue
+		fi
 		actor_rc=0
 		_approval_continuity_actor_authorized "$slug" "$actor" || actor_rc=$?
 		[[ "$actor_rc" -eq 0 ]] || {
 			[[ "$actor_rc" -eq 2 ]] && return 2
 			return 1
 		}
+		[[ "$event:$subject" == "labeled:$_APPROVAL_AUTO_DISPATCH_LABEL" ]] && saw_auto_dispatch=1
+		[[ "$subject" == status:* ]] && saw_status_mutation=1
 	done <<<"$mutation_rows"
 	return 0
 }

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -71,7 +71,7 @@ _approval_snapshot_v2_comments_json() {
 			# optional worktree qualifier bounded to its backtick-delimited basename;
 			# trusted prose or copied markers must remain approval-significant.
 			((.author_association // $empty) == "OWNER" or (.author_association // $empty) == "MEMBER" or (.author_association // $empty) == "COLLABORATOR")
-			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
+			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n(?:<!-- aidevops:origin:interactive -->\\n)?<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
 		) | not)
 		| {
 			source: $source,

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -51,6 +51,7 @@ case "$endpoint" in
 	user) printf '%s\n' "${GH_AUTH_USER:-maintainer}" ;;
 repos/owner/repo/collaborators/trusted-collab/permission | repos/owner/repo/collaborators/maintainer/permission) printf '%s\n' "${GH_PERMISSION:-write}" ;;
 repos/owner/repo/collaborators/contributor/permission) printf '%s\n' "read" ;;
+repos/owner/repo/collaborators/github-actions%5Bbot%5D/permission | repos/owner/repo/collaborators/github-actions\[bot\]/permission) printf '%s\n' "none" ;;
 	repos/owner/repo/issues/41) cat "${FIXTURES}/issue-41.json" ;;
 repos/owner/repo/issues/41/comments*) cat "${FIXTURES}/comments-41.json" ;;
 repos/owner/repo/issues/41/timeline*) cat "${FIXTURES}/timeline-41.json" ;;
@@ -360,14 +361,20 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 ---
 [aidevops.sh](https://aidevops.sh) v3.32.175 automated scan."
 	local claim_comments=""
-	local worktree_claim_marker="<!-- aidevops-interactive-claim/v1 -->
+	local claim_writer_body="<!-- aidevops-interactive-claim/v1 -->
 <!-- ops:start -->
 > Interactive session claimed by @maintainer in \`linked-worktree\` on Linux.
 > Pulse dispatch blocked via \`status:in-review\` + self-assignment.
-<!-- ops:end -->
-<!-- aidevops:sig -->
----
-[aidevops.sh](https://aidevops.sh) v3.32.175 automated scan."
+<!-- ops:end -->"
+	local worktree_claim_marker=""
+	worktree_claim_marker=$(AIDEVOPS_SESSION_ORIGIN=interactive AIDEVOPS_SIG_CLI="Test CLI" AIDEVOPS_SIG_CLI_VERSION="1.0.0" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="1" \
+		"${SCRIPT_DIR}/../gh-signature-helper.sh" footer --body "$claim_writer_body") || return 1
+	worktree_claim_marker="${claim_writer_body}${worktree_claim_marker}"
+	if [[ "$worktree_claim_marker" != *$'<!-- ops:end -->\n<!-- aidevops:origin:interactive -->\n<!-- aidevops:sig -->'* ]]; then
+		print_result "canonical claim writer produces the verifier footer contract" 1
+		return 0
+	fi
+	print_result "canonical claim writer produces the verifier footer contract" 0
 	claim_comments=$(jq -c --arg body "$claim_marker" --arg worktree_body "$worktree_claim_marker" '.[0] += [{id:4303,node_id:"IC_4303",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$body},{id:4306,node_id:"IC_4306",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:01Z",updated_at:"2026-01-01T00:06:01Z",body:$worktree_body}]' "${FIXTURES}/comments-41.json")
 	printf '%s\n' "$claim_comments" >"${FIXTURES}/comments-41.json"
 	assert_verify "canonical interactive claim refreshes, including worktree-qualified form, preserve approval" issue 41 VERIFIED 0
@@ -428,6 +435,44 @@ append_issue_timeline_event() {
 }
 
 test_locked_issue_continuity() {
+	# Production regression from the first #30153 signature: approval-helper
+	# performed the trusted handoff, then the narrowly scoped repository workflow
+	# filled the one missing default status label under github-actions[bot].
+	write_locked_issue_fixture
+	jq '.assignees = [{id:1,node_id:"U_1",login:"maintainer",type:"User"}] | .labels += [{id:10,node_id:"L_10",name:"auto-dispatch"},{id:11,node_id:"L_11",name:"status:available"}] | .labels |= map(select(.name != "needs-maintainer-review"))' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":426,"node_id":"EV_426","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"auto-dispatch"}}'
+	append_issue_timeline_event '{"id":427,"node_id":"EV_427","event":"unlabeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"needs-maintainer-review"}}'
+	append_issue_timeline_event '{"id":428,"node_id":"EV_428","event":"assigned","created_at":"2026-01-01T00:06:02Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'
+	append_issue_timeline_event '{"id":429,"node_id":"EV_429","event":"labeled","created_at":"2026-01-01T00:06:03Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
+	assert_verify "exact repository default-status automation preserves first locked issue approval" issue 41 VERIFIED 0
+
+	# GitHub documents timeline responses in chronological order; keep that API
+	# contract executable because continuity authorization is sequence-sensitive.
+	jq '.[0] |= reverse' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	assert_verify "out-of-order timeline data fails sequence-sensitive continuity" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4291,"node_id":"EV_4291","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
+	assert_verify "official Actions default without prior auto-dispatch fails closed" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:10,node_id:"L_10",name:"auto-dispatch"},{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4292,"node_id":"EV_4292","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"auto-dispatch"}}'
+	append_issue_timeline_event '{"id":4293,"node_id":"EV_4293","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:queued"}}'
+	append_issue_timeline_event '{"id":4294,"node_id":"EV_4294","event":"labeled","created_at":"2026-01-01T00:06:02Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
+	assert_verify "official Actions default after another status mutation fails closed" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":430,"node_id":"EV_430","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":999,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
+	assert_verify "lookalike Actions bot cannot preserve locked issue approval" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:11,node_id:"L_11",name:"status:queued"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":431,"node_id":"EV_431","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:queued"}}'
+	assert_verify "official Actions bot has no generic lifecycle authority" issue 41 STALE_APPROVAL 4
+
 	write_locked_issue_fixture
 	jq '.assignees = [{id:1,node_id:"U_1",login:"maintainer",type:"User"}] | .labels += [{id:10,node_id:"L_10",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	append_issue_timeline_event '{"id":420,"node_id":"EV_420","event":"assigned","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -111,6 +111,7 @@ run_case "REST 204 lock fallback succeeds" '
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 0; }
+	set_issue_status() { return 0; }
 	gh_issue_edit_safe() { return 0; }
 	gh_issue_view() { printf "bug,auto-dispatch"; return 0; }
 	gh() {
@@ -122,7 +123,7 @@ run_case "REST 204 lock fallback succeeds" '
 		if [[ "$arg1" == "issue" && "$arg2" == "lock" ]]; then return 1; fi
 		if [[ "$arg1" == "api" && "$arg2" == "-X" && "$arg3" == "PUT" && "$arg4" == "/repos/marcusquinn/aidevops/issues/123/lock" ]]; then return 0; fi
 		if [[ "$arg1" == "api" && "$arg2" == "/repos/marcusquinn/aidevops/issues/123" ]]; then
-			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:available\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
 			return 0
 		fi
 		return 1
@@ -134,11 +135,79 @@ assert_not_contains "successful fallback does not print false lock error" "$LAST
 assert_not_contains "successful fallback does not print advisory lock failure" "$LAST_OUTPUT" "Approval advisory lock failure"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "status transition failure blocks approval handoff" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	set_issue_status() { printf "simulated status failure" >&2; return 1; }
+	gh_issue_edit_safe() { printf "UNEXPECTED EDIT"; return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		return 1
+	}
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops
+' 1
+assert_contains "status transition failure is explicit" "$LAST_OUTPUT" "Failed to transition approved issue #123 to status:available"
+assert_not_contains "status transition failure preserves NMR handoff" "$LAST_OUTPUT" "UNEXPECTED EDIT"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "partial lifecycle edit failure restores NMR" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	set_issue_status() { return 0; }
+	gh_issue_edit_safe() {
+		if [[ "$*" == *"--add-label needs-maintainer-review"* && "$*" != *"--remove-label needs-maintainer-review"* ]]; then
+			printf "RESTORE %s\n" "$*" >>"$restore_trace"
+			return 0
+		fi
+		printf "simulated partial mutation" >&2
+		return 1
+	}
+	restore_trace=$(mktemp)
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		return 1
+	}
+	rc=0
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops || rc=$?
+	cat "$restore_trace"
+	rm -f "$restore_trace"
+	exit "$rc"
+' 1
+assert_contains "partial lifecycle edit failure is explicit" "$LAST_OUTPUT" "Failed to update approval labels/assignee"
+assert_contains "partial lifecycle edit failure reasserts NMR" "$LAST_OUTPUT" "RESTORE 123 --repo marcusquinn/aidevops --add-label needs-maintainer-review"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "failed NMR restoration remains explicit" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	set_issue_status() { return 0; }
+	gh_issue_edit_safe() {
+		if [[ "$*" == *"--add-label needs-maintainer-review"* && "$*" != *"--remove-label needs-maintainer-review"* ]]; then
+			printf "simulated restore failure" >&2
+			return 1
+		fi
+		printf "simulated partial mutation" >&2
+		return 1
+	}
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		return 1
+	}
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops
+' 1
+assert_contains "failed NMR restoration reports unsafe state" "$LAST_OUTPUT" "Failed to restore needs-maintainer-review after uncertain lifecycle update"
+assert_contains "failed NMR restoration preserves root evidence" "$LAST_OUTPUT" "simulated restore failure"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "PR-backed issue lock falls back to REST without GraphQL fallback" '
 	set -uo pipefail
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 1; }
+	set_issue_status() { return 0; }
 	gh_issue_edit_safe() { return 0; }
 	gh_issue_view() { printf "bug,auto-dispatch"; return 0; }
 	gh() {
@@ -150,7 +219,7 @@ run_case "PR-backed issue lock falls back to REST without GraphQL fallback" '
 		if [[ "$arg1" == "issue" && "$arg2" == "lock" ]]; then return 1; fi
 		if [[ "$arg1" == "api" && "$arg2" == "-X" && "$arg3" == "PUT" && "$arg4" == "/repos/marcusquinn/aidevops/issues/2417/lock" ]]; then return 0; fi
 		if [[ "$arg1" == "api" && "$arg2" == "/repos/marcusquinn/aidevops/issues/2417" ]]; then
-			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:available\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
 			return 0
 		fi
 		return 1
@@ -245,6 +314,7 @@ run_case "genuine lock failure is distinguished" '
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 0; }
+	set_issue_status() { return 0; }
 	gh_issue_edit_safe() { return 0; }
 	gh() {
 		local arg1="${1:-}"

--- a/.agents/scripts/tests/test-approval-rest-fallback-state.sh
+++ b/.agents/scripts/tests/test-approval-rest-fallback-state.sh
@@ -66,25 +66,154 @@ success_output=$(run_case "verified success" '
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 0; }
-	gh_issue_edit_safe() { printf "%s\n" "$*" >"${TMPDIR:-/tmp}/approval-edit-args.$$"; return 0; }
+	set_issue_status() {
+		local issue="$1"
+		local repo="$2"
+		local status="$3"
+		shift 3
+		printf "STATUS %s %s %s %s\n" "$issue" "$repo" "$status" "$*"
+		[[ "$issue" == "123" && "$repo" == "marcusquinn/aidevops" && "$status" == "available" && "$#" -eq 0 ]]
+		return $?
+	}
+	gh_issue_edit_safe() {
+		local arg=""
+		local saw_auto_dispatch=0
+		for arg in "$@"; do
+			[[ "$arg" == "auto-dispatch" ]] && saw_auto_dispatch=1
+		done
+		[[ "$saw_auto_dispatch" -eq 1 ]] || return 1
+		return 0
+	}
 	gh_issue_view() { printf "bug,auto-dispatch"; return 0; }
 	gh() {
 		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
 		if [[ "${1:-}" == "issue" && "${2:-}" == "lock" ]]; then return 1; fi
 		if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "PUT" ]]; then return 0; fi
 		if [[ "${1:-}" == "api" && "${2:-}" == "/repos/marcusquinn/aidevops/issues/123" ]]; then
-			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:available\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
 			return 0
 		fi
 		return 1
 	}
 	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops
 ' 0)
-if printf '%s' "$success_output" | grep -q "Labels updated"; then
-	echo "  PASS: success path reports label update after verified edit"
+if printf '%s' "$success_output" | grep -q "Lifecycle updated"; then
+	echo "  PASS: success path reports lifecycle update after verified edit"
 	PASS=$((PASS + 1))
 else
-	echo "  FAIL: success path reports label update after verified edit"
+	echo "  FAIL: success path reports lifecycle update after verified edit"
+	FAIL=$((FAIL + 1))
+fi
+echo "  PASS: success path writes status:available synchronously"
+PASS=$((PASS + 1))
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+progressed_output=$(run_case "dispatcher progression before final verification" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	test_home=$(mktemp -d)
+	_APPROVAL_HOME="$test_home"
+	mkdir -p "$test_home/.aidevops/.agent-workspace/interactive-claims"
+	stamp_file="$test_home/.aidevops/.agent-workspace/interactive-claims/marcusquinn-aidevops-123.json"
+	printf "{}" >"$stamp_file"
+	_rest_should_fallback() { return 0; }
+	set_issue_status() { return 0; }
+	gh_issue_edit_safe() { return 0; }
+	gh_issue_view() { printf "bug,status:in-review"; return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		if [[ "${1:-}" == "issue" && "${2:-}" == "lock" ]]; then return 0; fi
+		if [[ "${1:-}" == "api" && "${2:-}" == "/repos/marcusquinn/aidevops/issues/123" ]]; then
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:queued\"}],\"assignees\":[{\"login\":\"worker-runner\"}],\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops
+	[[ ! -f "$stamp_file" ]] || exit 9
+	rm -rf "$test_home"
+' 0)
+if printf '%s' "$progressed_output" | grep -q "Approval state verification failed"; then
+	echo "  FAIL: queued dispatcher progression is accepted"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: queued dispatcher progression is accepted"
+	PASS=$((PASS + 1))
+fi
+echo "  PASS: lifecycle handoff removes only the local claim stamp"
+PASS=$((PASS + 1))
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+invalid_progression_output=$(run_case "invalid lifecycle state fails closed" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	test_home=$(mktemp -d)
+	_APPROVAL_HOME="$test_home"
+	mkdir -p "$test_home/.aidevops/.agent-workspace/interactive-claims"
+	stamp_file="$test_home/.aidevops/.agent-workspace/interactive-claims/marcusquinn-aidevops-123.json"
+	printf "{}" >"$stamp_file"
+	restore_trace=$(mktemp)
+	set_issue_status() { return 0; }
+	gh_issue_edit_safe() { printf "RESTORE %s\n" "$*" >>"$restore_trace"; return 0; }
+	gh_issue_view() { printf "bug,status:in-review"; return 0; }
+	_approval_lock_issue() { return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		if [[ "${1:-}" == "api" && "${2:-}" == "/repos/marcusquinn/aidevops/issues/123" ]]; then
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:blocked\"}],\"assignees\":[],\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	rc=0
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops || rc=$?
+	[[ -f "$stamp_file" ]] || rc=9
+	cat "$restore_trace"
+	rm -f "$restore_trace"
+	rm -rf "$test_home"
+	exit "$rc"
+' 1)
+if printf '%s' "$invalid_progression_output" | grep -q -- "--add-label needs-maintainer-review"; then
+	echo "  PASS: invalid lifecycle state restores NMR"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: invalid lifecycle state restores NMR"
+	FAIL=$((FAIL + 1))
+fi
+echo "  PASS: failed lifecycle verification retains the local claim stamp"
+PASS=$((PASS + 1))
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+dual_status_output=$(run_case "dual core status fails closed" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	restore_trace=$(mktemp)
+	set_issue_status() { return 0; }
+	gh_issue_edit_safe() { printf "RESTORE %s\n" "$*" >>"$restore_trace"; return 0; }
+	gh_issue_view() { printf "bug,status:in-review"; return 0; }
+	_approval_lock_issue() { return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		if [[ "${1:-}" == "api" && "${2:-}" == "/repos/marcusquinn/aidevops/issues/123" ]]; then
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"},{\"name\":\"status:available\"},{\"name\":\"status:queued\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	rc=0
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops || rc=$?
+	cat "$restore_trace"
+	rm -f "$restore_trace"
+	exit "$rc"
+' 1)
+if printf '%s' "$dual_status_output" | grep -q -- "--add-label needs-maintainer-review"; then
+	echo "  PASS: dual core status restores NMR"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: dual core status restores NMR"
 	FAIL=$((FAIL + 1))
 fi
 
@@ -93,18 +222,38 @@ failure_output=$(run_case "edit failure blocks success" '
 	set -uo pipefail
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
-	gh_issue_edit_safe() { printf "simulated edit failure" >&2; return 1; }
+	set_issue_status() { return 0; }
+	restore_trace=$(mktemp)
+	gh_issue_edit_safe() {
+		if [[ "$*" == *"--add-label needs-maintainer-review"* && "$*" != *"--remove-label needs-maintainer-review"* ]]; then
+			printf "RESTORE %s\n" "$*" >>"$restore_trace"
+			return 0
+		fi
+		printf "simulated edit failure" >&2
+		return 1
+	}
 	gh() {
 		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then printf "marcusquinn"; return 0; fi
 		return 1
 	}
-	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops
+	rc=0
+	_approval_apply_issue_lifecycle_updates 123 marcusquinn/aidevops || rc=$?
+	cat "$restore_trace"
+	rm -f "$restore_trace"
+	exit "$rc"
 ' 1)
 if printf '%s' "$failure_output" | grep -q "Failed to update approval labels/assignee"; then
 	echo "  PASS: edit failure surfaces accurate blocked reason"
 	PASS=$((PASS + 1))
 else
 	echo "  FAIL: edit failure surfaces accurate blocked reason"
+	FAIL=$((FAIL + 1))
+fi
+if printf '%s' "$failure_output" | grep -q -- "RESTORE .*--add-label needs-maintainer-review"; then
+	echo "  PASS: edit uncertainty restores NMR synchronously"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: edit uncertainty restores NMR synchronously"
 	FAIL=$((FAIL + 1))
 fi
 


### PR DESCRIPTION
## Summary

Implementation for issue #30165.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/approval-snapshot-v2.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh, .agents/scripts/tests/test-approval-rest-fallback-state.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30165


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.255 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-sol spent 1h 16m and 906,314 tokens on this with the user in an interactive session.