### PR TITLE
GH#30179: fix stale OpenCode pin repair locks

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1668,6 +1668,40 @@ _provision_headless_opencode_runtime() {
 }
 
 #######################################
+# Recover an abandoned OpenCode repair lock after its bounded wait expires.
+# Installer temp roots encode their owner PID; any live or unrecognizable owner
+# keeps the lock fail-closed. Only an empty lock directory is removed.
+#######################################
+_recover_stale_opencode_pin_repair_lock() {
+	local pin="$1"
+	local repair_lock_dir="$2"
+	local runtime_root="${STATE_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}/opencode-runtimes"
+	local temp_root=""
+	local owner_pid=""
+	local found_temp_root=0
+
+	for temp_root in "$runtime_root/.${pin}.install."*; do
+		[[ -e "$temp_root" ]] || continue
+		found_temp_root=1
+		owner_pid="${temp_root##*.install.}"
+		if [[ ! "$owner_pid" =~ ^[0-9]+$ ]] || kill -0 "$owner_pid" 2>/dev/null; then
+			return 1
+		fi
+	done
+
+	if [[ "$found_temp_root" -eq 1 ]]; then
+		for temp_root in "$runtime_root/.${pin}.install."*; do
+			[[ -e "$temp_root" ]] || continue
+			rm -rf "$temp_root" || return 1
+		done
+	fi
+
+	rmdir "$repair_lock_dir" 2>/dev/null || return 1
+	print_warning "Recovered stale OpenCode ${pin} repair lock"
+	return 0
+}
+
+#######################################
 # Version guard -- bind affected worker launches to an isolated exact-version
 # OpenCode runtime. General/interactive installs remain free to track latest.
 #######################################
@@ -1697,8 +1731,15 @@ _enforce_opencode_version_pin() {
 	mkdir -p "$repair_lock_base" 2>/dev/null || true
 	local repair_lock_acquired=0
 	local repair_lock_waited=0
+	local stale_recovery_attempted=0
 	while ! mkdir "$repair_lock_dir" 2>/dev/null; do
 		if [[ "$repair_lock_waited" -ge "30" ]]; then
+			if [[ "$stale_recovery_attempted" -eq 0 ]] &&
+				_recover_stale_opencode_pin_repair_lock "$pin" "$repair_lock_dir"; then
+				stale_recovery_attempted=1
+				repair_lock_waited=0
+				continue
+			fi
 			print_error "Timed out waiting for OpenCode ${pin} repair lock -- refusing headless launch"
 			return 1
 		fi

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -54,6 +54,7 @@ extract_function() {
 		/^_validate_opencode_binary\(\)/, /^}/ { print; next }
 		/^_resolve_headless_opencode_install_binary\(\)/, /^}/ { print; next }
 		/^_provision_headless_opencode_runtime\(\)/, /^}/ { print; next }
+		/^_recover_stale_opencode_pin_repair_lock\(\)/, /^}/ { print; next }
 		/^_enforce_opencode_version_pin\(\)/, /^}$/ { print; next }
 	' "$HEADLESS_RUNTIME_LIB" >>"$SANDBOX/extract.sh"
 	if ! grep -q '^aidevops_opencode_pin_applies()' "$SANDBOX/extract.sh" ||
@@ -61,6 +62,7 @@ extract_function() {
 		! grep -q '^_validate_opencode_binary()' "$SANDBOX/extract.sh" ||
 		! grep -q '^_resolve_headless_opencode_install_binary()' "$SANDBOX/extract.sh" ||
 		! grep -q '^_provision_headless_opencode_runtime()' "$SANDBOX/extract.sh" ||
+		! grep -q '^_recover_stale_opencode_pin_repair_lock()' "$SANDBOX/extract.sh" ||
 		! grep -q '^_enforce_opencode_version_pin()' "$SANDBOX/extract.sh"; then
 		printf 'FAIL: extraction did not capture OpenCode version functions\n' >&2
 		exit 1
@@ -264,6 +266,48 @@ reuse_rc=0
 ) || reuse_rc=$?
 assert_eq "existing isolated runtime reuse status" "0" "$reuse_rc"
 assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SANDBOX/version-guard/calls" | tr -d ' ')"
+
+printf 'Test 4c: stale repair lock and dead installer root are recovered\n'
+mkdir -p "$SANDBOX/stale-repair/state/opencode-pin-repair.lock" \
+	"$SANDBOX/stale-repair/state/opencode-runtimes/.1.18.16.install.99999999/prefix"
+stale_repair_rc=0
+(
+	source_extracted
+	STATE_DIR="$SANDBOX/stale-repair/state"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
+	HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	AIDEVOPS_TEST_UNAME_M="x86_64"
+	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
+	print_warning() { return 0; }
+	print_info() { return 0; }
+	print_error() { return 0; }
+	sleep() { return 0; }
+	PATH="$SANDBOX/version-guard/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
+) || stale_repair_rc=$?
+assert_eq "dead installer repair status" "0" "$stale_repair_rc"
+assert_eq "dead installer root removed" "0" "$([[ -e "$SANDBOX/stale-repair/state/opencode-runtimes/.1.18.16.install.99999999" ]] && printf '1\n' || printf '0\n')"
+assert_eq "repair lock released after provisioning" "0" "$([[ -e "$SANDBOX/stale-repair/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
+
+printf 'Test 4d: live installer keeps repair lock fail-closed\n'
+mkdir -p "$SANDBOX/live-repair/state/opencode-pin-repair.lock" \
+	"$SANDBOX/live-repair/state/opencode-runtimes/.1.18.16.install.$$/prefix"
+live_repair_rc=0
+(
+	source_extracted
+	STATE_DIR="$SANDBOX/live-repair/state"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
+	HEADLESS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT"
+	AIDEVOPS_TEST_UNAME_M="x86_64"
+	AIDEVOPS_OPENCODE_PIN_PLATFORM_OVERRIDE="Linux"
+	print_warning() { return 0; }
+	print_info() { return 0; }
+	print_error() { return 0; }
+	sleep() { return 0; }
+	PATH="$SANDBOX/version-guard/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
+) || live_repair_rc=$?
+assert_eq "live installer repair status" "1" "$live_repair_rc"
+assert_eq "live installer root preserved" "1" "$([[ -d "$SANDBOX/live-repair/state/opencode-runtimes/.1.18.16.install.$$/prefix" ]] && printf '1\n' || printf '0\n')"
+assert_eq "live installer lock preserved" "1" "$([[ -d "$SANDBOX/live-repair/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
 
 printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
 mkdir -p "$SANDBOX/version-install-failure/state"


### PR DESCRIPTION
## Summary

Recover abandoned OpenCode pin repair locks and dead installer temp roots after the bounded wait while preserving fail-closed behavior for live installers.

## Files Changed

.agents/scripts/headless-runtime-lib.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — OpenCode version-policy regression suite (25 passed); ShellCheck; git diff --check; bun run typecheck; local review bundle 6b1a6704f774bfeecb21e6677585e06556af64c48be92a368ec6a12bfb0e3bce

Resolves #30179


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.256 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 6m and 52,952 tokens on this with the user in an interactive session.