### PR TITLE
GH#30182: guard CodeFactor JMAP findings

### DIFF
--- a/.agents/scripts/tests/test-email-jmap-push.py
+++ b/.agents/scripts/tests/test-email-jmap-push.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression tests for JMAP EventSource URL validation and SSE parsing."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+HELPER_PATH = SCRIPTS_DIR / "email_jmap_push.py"
+sys.path.insert(0, str(SCRIPTS_DIR))
+SPEC = importlib.util.spec_from_file_location("email_jmap_push", HELPER_PATH)
+assert SPEC and SPEC.loader
+HELPER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HELPER)
+
+
+class EventSourceUrlTests(unittest.TestCase):
+    """Lock in the local guard for CodeFactor's dynamic URL finding."""
+
+    def test_accepts_absolute_http_endpoints(self) -> None:
+        """Permit only absolute HTTP(S) EventSource URLs."""
+        for url in ("https://mail.example/events", "http://localhost/events"):
+            with self.subTest(url=url):
+                self.assertEqual(HELPER._validate_event_source_url(url), url)
+
+    def test_rejects_non_http_or_relative_endpoints(self) -> None:
+        """Reject schemes that urllib must never open for JMAP push."""
+        for url in ("file:///etc/passwd", "ftp://mail.example/events", "/events", "https:///events"):
+            with self.subTest(url=url):
+                with self.assertRaisesRegex(ValueError, "must use HTTP"):
+                    HELPER._validate_event_source_url(url)
+
+    def test_sse_parser_emits_structured_event(self) -> None:
+        """Keep parsing outside the stream loop to bound its complexity."""
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            HELPER._emit_sse_event("state", '{"changed": true}')
+        event = json.loads(output.getvalue())
+        self.assertEqual(event["event_type"], "state")
+        self.assertEqual(event["data"], {"changed": True})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-email-jmap-push.py
+++ b/.agents/scripts/tests/test-email-jmap-push.py
@@ -17,7 +17,8 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 HELPER_PATH = SCRIPTS_DIR / "email_jmap_push.py"
 sys.path.insert(0, str(SCRIPTS_DIR))
 SPEC = importlib.util.spec_from_file_location("email_jmap_push", HELPER_PATH)
-assert SPEC and SPEC.loader
+if not SPEC or not SPEC.loader:
+    raise RuntimeError(f"Unable to load {HELPER_PATH}")
 HELPER = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(HELPER)
 

--- a/.agents/scripts/tests/test-email-jmap-push.sh
+++ b/.agents/scripts/tests/test-email-jmap-push.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${SCRIPT_DIR}/test-email-jmap-push.py"


### PR DESCRIPTION
## Summary

Add focused regression coverage for the validated HTTP(S)-only JMAP EventSource boundary and extracted SSE event parser that address the recurring CodeFactor findings already fixed on main.

## Files Changed

.agents/scripts/tests/test-email-jmap-push.py, .agents/scripts/tests/test-email-jmap-push.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused Python tests pass; Remotion contract test passes; Biome, ShellCheck, compileall, git diff check, and linters-local --changed --no-cache pass.

Resolves #30182


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.256 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 6m and 106,648 tokens on this with the user in an interactive session.