### PR TITLE
GH#30180: security: freeze auto-dispatch issue instructions

### DIFF
--- a/.agents/reference/auto-dispatch.md
+++ b/.agents/reference/auto-dispatch.md
@@ -37,6 +37,27 @@ Regression tests:
 - `.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh` (gh_create_issue path)
 - `.agents/scripts/tests/test-claim-task-id-autodispatch.sh` (claim-task-id path)
 
+## Auto-Dispatch Conversation Lock (GH#30180)
+
+`auto-dispatch` is both an execution authorization and an instruction-freeze
+boundary. Managed creation through `gh_create_issue` locks the conversation and
+verifies the resulting GitHub state. Pulse reconciles the complete visible open
+issue snapshot so queued and dependency-blocked auto-dispatch issues are also
+locked before any worker reads them. The final spawn gate independently repeats
+that lock and verification and fails closed if GitHub cannot confirm it.
+
+Worker cleanup retains the lock while `auto-dispatch` remains active, including
+retryable failures. Pulse unlocks only locks it owns after automatic execution
+eligibility is removed, or existing terminal lifecycle handling removes the
+label before cleanup. GitHub locking is defence-in-depth: author/collaborator
+validation and untrusted-content rules still apply to content written before the
+lock.
+
+Regression tests:
+- `.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh`
+- `.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh`
+- `.agents/scripts/tests/test-precreation-failure-skip.sh`
+
 ## General Dedup Rule — Combined Signal (t1996)
 
 The dispatch dedup signal is `(active status label) AND (non-self assignee)` — both required, neither sufficient alone. Every code path that emits a dispatch claim must consult `dispatch-dedup-helper.sh is-assigned` before assigning a worker. Label-only or assignee-only filters are not safe in multi-operator conditions.

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -56,6 +56,9 @@ source "${_DSI_SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=./shared-gh-wrappers.sh
 # shellcheck disable=SC1091
 source "${_DSI_SCRIPT_DIR}/shared-gh-wrappers.sh"
+# shellcheck source=./pulse-dispatch-core.sh
+# shellcheck disable=SC1091
+source "${_DSI_SCRIPT_DIR}/pulse-dispatch-core.sh"
 
 # Paths
 _DSI_LOG_DIR="${HOME}/.aidevops/logs"
@@ -1569,6 +1572,13 @@ _dsi_dispatch_after_dedup_clear() {
 	# on the same worktree cannot be joined by a second manual launch.
 	if ! _dsi_guard_no_existing_dispatch "$issue_number" "$repo_slug" "$_DSI_WORKTREE_PATH"; then
 		_dsi_reset_after_prelaunch_failure "$issue_number" "$repo_slug" "$self_login" "existing_dispatch_after_precreate"
+		return 1
+	fi
+
+	# aidevops:trust-boundary — manual dispatch has the same immutable issue
+	# instruction contract as Pulse and must fail closed before runtime launch.
+	if ! lock_issue_for_worker "$issue_number" "$repo_slug"; then
+		_dsi_reset_after_prelaunch_failure "$issue_number" "$repo_slug" "$self_login" "conversation_lock_failed"
 		return 1
 	fi
 

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -297,6 +297,18 @@ _unlock_issue_after_dispatch_release() {
 		return 0
 	fi
 
+	local labels=""
+	if ! labels=$(gh api "repos/${repo_slug}/issues/${issue_number}" --jq '[.labels[]? | .name] | join(",")' 2>/dev/null); then
+		print_warning "Failed to verify labels before release unlock for #${issue_number} in ${repo_slug}; retaining conversation lock"
+		return 0
+	fi
+	# aidevops:trust-boundary — a retryable auto-dispatch issue remains frozen
+	# between workers; release only the claim, not the public instruction surface.
+	if [[ ",$labels," == *,auto-dispatch,* && ",$labels," != *,no-auto-dispatch,* ]]; then
+		print_info "Retaining conversation lock for auto-dispatch issue #${issue_number} in ${repo_slug} after claim release"
+		return 0
+	fi
+
 	unlock_output=$(gh issue unlock "$issue_number" --repo "$repo_slug" 2>&1) || {
 		if _hrff_unlock_failure_is_benign "$unlock_output"; then
 			print_info "Release unlock skipped for GitHub issue #${issue_number} in ${repo_slug}: already unlocked"

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -236,26 +236,82 @@ check_dispatch_dedup() {
 }
 
 #######################################
-# Lock an issue (and any linked PRs) to prevent mid-flight prompt
-# injection (t1894, t1934). Once a worker is dispatched, the issue
-# state is frozen — any comment arriving after dispatch is either
-# noise or adversarial. Lock the conversation to prevent influence.
+# Lock an issue (and any linked PRs) to prevent prompt injection
+# (t1894, t1934, GH#30180). Auto-dispatch is the authorization boundary,
+# so the issue must be frozen before it enters worker-readable context.
 # Also locks open PRs linked to the issue (worker may read PR comments).
-# Non-fatal: locking failure doesn't block dispatch.
+# The issue lock is strict and verified; linked PR locks remain best-effort.
 #######################################
 lock_issue_for_worker() {
 	local issue_num="$1"
 	local slug="$2"
 	local reason="${3:-resolved}"
 
-	[[ -n "$issue_num" && -n "$slug" ]] || return 0
+	[[ -n "$issue_num" && -n "$slug" ]] || return 1
 
-	# Lock the issue itself
-	gh issue lock "$issue_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1 || true
+	# aidevops:trust-boundary — never launch a worker when the mutable public
+	# instruction surface could not be frozen and independently re-read.
+	local locked_state=""
+	if ! gh issue lock "$issue_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
+		return 1
+	fi
+	locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked == true' 2>/dev/null) || locked_state=""
+	if [[ "$locked_state" != "true" ]]; then
+		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
+		return 1
+	fi
+	_record_auto_dispatch_lock "$issue_num" "$slug" || return 1
 	echo "[pulse-wrapper] Locked #${issue_num} in ${slug} during worker execution (t1934)" >>"$LOGFILE"
 
 	# Lock any open PRs linked to this issue (t1934: PRs have same injection surface)
 	_lock_linked_prs "$issue_num" "$slug" "$reason"
+
+	return 0
+}
+
+_auto_dispatch_lock_marker() {
+	local issue_num="$1"
+	local slug="$2"
+	local lock_dir="${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR:-${HOME}/.aidevops/cache/auto-dispatch-locks}"
+	local lock_key="${slug//\//--}-${issue_num}"
+	printf '%s/%s\n' "$lock_dir" "$lock_key"
+	return 0
+}
+
+_record_auto_dispatch_lock() {
+	local issue_num="$1"
+	local slug="$2"
+	local marker=""
+	marker=$(_auto_dispatch_lock_marker "$issue_num" "$slug") || return 1
+	mkdir -p "${marker%/*}" 2>/dev/null || return 1
+	: >"$marker" 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
+# Reconcile conversation locks for every visible auto-dispatch issue,
+# including blocked and queued work that cannot reach the launch path yet.
+# Only markers owned by this mechanism may trigger an unlock.
+#######################################
+reconcile_auto_dispatch_issue_locks() {
+	local slug="$1"
+	local issue_json="$2"
+	local issue_num="" marker="" labels="" labels_csv=""
+	[[ -n "$slug" && -n "$issue_json" ]] || return 1
+
+	while IFS=$'\t' read -r issue_num labels; do
+		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+		marker=$(_auto_dispatch_lock_marker "$issue_num" "$slug") || continue
+		labels_csv=",${labels},"
+		if [[ "$labels_csv" == *,auto-dispatch,* && "$labels_csv" != *,no-auto-dispatch,* ]]; then
+			lock_issue_for_worker "$issue_num" "$slug" || return 1
+		elif [[ -f "$marker" && "$labels_csv" != *,no-auto-dispatch,* ]]; then
+			gh issue unlock "$issue_num" --repo "$slug" >/dev/null 2>&1 || return 1
+			rm -f "$marker" 2>/dev/null || return 1
+			echo "[pulse-wrapper] Unlocked #${issue_num} in ${slug} after auto-dispatch removal (GH#30180)" >>"$LOGFILE"
+		fi
+	done < <(printf '%s' "$issue_json" | jq -r '.[] | [(.number | tostring), ([.labels[]? | .name? // .] | join(","))] | @tsv' 2>/dev/null)
 
 	return 0
 }
@@ -288,9 +344,9 @@ _lock_linked_prs() {
 }
 
 #######################################
-# Unlock an issue (and any linked PRs) after worker completion or
-# failure (t1894, t1934). Symmetric with lock_issue_for_worker.
-# Non-fatal: unlocking failure is logged but doesn't block.
+# Release conversation locks after terminal worker handling only when the issue
+# is no longer auto-dispatch eligible. Retryable work stays frozen across the
+# worker-to-Pulse handoff, closing the post-worker comment race (GH#30180).
 #######################################
 unlock_issue_after_worker() {
 	local issue_num="$1"
@@ -298,8 +354,22 @@ unlock_issue_after_worker() {
 
 	[[ -n "$issue_num" && -n "$slug" ]] || return 0
 
-	# Unlock the issue itself
+	local labels=""
+	if ! labels=$(gh api "repos/${slug}/issues/${issue_num}" --jq '[.labels[]? | .name] | join(",")' 2>/dev/null); then
+		echo "[pulse-wrapper] Could not verify labels before unlocking #${issue_num} in ${slug}; retaining conversation lock (GH#30180)" >>"$LOGFILE"
+		return 1
+	fi
+	# aidevops:trust-boundary — auto-dispatch remains authoritative across
+	# retries, so completion cleanup must not reopen its instruction surface.
+	if [[ ",$labels," == *,auto-dispatch,* && ",$labels," != *,no-auto-dispatch,* ]]; then
+		echo "[pulse-wrapper] Retained conversation lock for auto-dispatch #${issue_num} in ${slug} after worker handoff (GH#30180)" >>"$LOGFILE"
+		return 0
+	fi
+
 	gh issue unlock "$issue_num" --repo "$slug" >/dev/null 2>&1 || true
+	local marker=""
+	marker=$(_auto_dispatch_lock_marker "$issue_num" "$slug") || marker=""
+	[[ -z "$marker" ]] || rm -f "$marker" 2>/dev/null || true
 	echo "[pulse-wrapper] Unlocked #${issue_num} in ${slug} after worker completion (t1934)" >>"$LOGFILE"
 
 	# Unlock any open PRs linked to this issue (symmetric with lock)

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1780,7 +1780,10 @@ _dispatch_launch_worker() {
 
 	# t1894/t1934: Lock issue and linked PRs during worker execution.
 	_ds_t0=$(_ds_now_ns)
-	lock_issue_for_worker "$issue_number" "$repo_slug"
+	if ! lock_issue_for_worker "$issue_number" "$repo_slug"; then
+		_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "conversation_lock_failed" 2 || return $?
+	fi
 	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
 
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -291,6 +291,16 @@ list_dispatchable_issue_candidates_json() {
 	fi
 	rm -f "$issue_dispatch_err"
 
+	# GH#30180: auto-dispatch is the worker-authorization boundary, not the
+	# later spawn boundary. Reconcile from the complete raw open-issue snapshot
+	# so queued and dependency-blocked issues are frozen too.
+	if [[ "$snapshot_succeeded" -eq 1 ]] && declare -F reconcile_auto_dispatch_issue_locks >/dev/null 2>&1; then
+		reconcile_auto_dispatch_issue_locks "$repo_slug" "$issue_json" || {
+			printf '[pulse-wrapper] auto-dispatch lock reconciliation failed for %s; affected dispatches remain fail-closed\n' \
+				"$repo_slug" >>"$LOGFILE"
+		}
+	fi
+
 	local candidates_json=""
 	candidates_json=$(_filter_dispatchable_issue_candidates_json "$issue_json")
 

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -458,6 +458,47 @@ _gh_ci_prepare_parent_contract_and_signature() {
 	return 0
 }
 
+_gh_lock_created_auto_dispatch_issue() {
+	local issue_number="$1"
+	local target_repo="$2"
+	local lock_dir="${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR:-${HOME}/.aidevops/cache/auto-dispatch-locks}"
+	local lock_key="${target_repo//\//--}-${issue_number}"
+	local locked_state=""
+
+	# aidevops:trust-boundary — freeze worker-authorized instructions at
+	# creation time instead of leaving a public comment window until spawn.
+	if gh issue lock "$issue_number" --repo "$target_repo" --reason resolved >/dev/null 2>&1; then
+		locked_state=$(gh api "repos/${target_repo}/issues/${issue_number}" --jq '.locked == true' 2>/dev/null) || locked_state=""
+	fi
+	if [[ "$locked_state" != "true" ]]; then
+		print_warning "Issue #${issue_number} was created with auto-dispatch, but its conversation lock could not be verified; Pulse will fail closed before worker spawn."
+		return 1
+	fi
+	mkdir -p "$lock_dir" 2>/dev/null || return 1
+	: >"${lock_dir}/${lock_key}" 2>/dev/null || return 1
+	return 0
+}
+
+_gh_finish_created_issue() {
+	local issue_output="$1"
+	local target_repo="$2"
+	local auto_assignee="$3"
+	shift 3
+	local issue_number="${issue_output##*/}"
+	issue_number="${issue_number%%[[:space:]]*}"
+
+	if [[ "$issue_number" =~ ^[0-9]+$ ]] &&
+		_gh_wrapper_args_have_label "$_GH_CREATE_AUTO_DISPATCH_LABEL" "$@"; then
+		_gh_lock_created_auto_dispatch_issue "$issue_number" "$target_repo" || true
+	fi
+	if [[ -n "$auto_assignee" && "$issue_number" =~ ^[0-9]+$ ]] &&
+		! gh issue edit "$issue_number" --repo "$target_repo" --add-assignee "$auto_assignee" >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
+		print_warning "Issue #${issue_number} was created, but automatic assignment to ${auto_assignee} failed; continuing with the durable issue."
+	fi
+	_gh_auto_link_sub_issue "$issue_output" "$@"
+	return 0
+}
+
 gh_create_issue() {
 	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_issue 2>/dev/null || true
@@ -547,15 +588,7 @@ gh_create_issue() {
 	fi
 	echo "$issue_output"
 	if [[ $rc -eq 0 ]]; then
-		if [[ -n "$auto_assignee" ]]; then
-			local issue_number="${issue_output##*/}"
-			issue_number="${issue_number%%[[:space:]]*}"
-			if [[ "$issue_number" =~ ^[0-9]+$ ]] &&
-				! gh issue edit "$issue_number" --repo "$target_repo" --add-assignee "$auto_assignee" >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
-				print_warning "Issue #${issue_number} was created, but automatic assignment to ${auto_assignee} failed; continuing with the durable issue."
-			fi
-		fi
-		_gh_auto_link_sub_issue "$issue_output" "$@"
+		_gh_finish_created_issue "$issue_output" "$target_repo" "$auto_assignee" "$@"
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
+++ b/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+TMP=$(mktemp -d -t gh30180.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+LOGFILE="${TMP}/pulse.log"
+GH_CALLS="${TMP}/gh-calls.log"
+AIDEVOPS_AUTO_DISPATCH_LOCK_DIR="${TMP}/locks"
+export LOGFILE GH_CALLS AIDEVOPS_AUTO_DISPATCH_LOCK_DIR
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local message="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL: %s\n' "$message"
+	return 0
+}
+
+GH_LOCKED=true
+GH_LOCK_RC=0
+gh() {
+	printf '%s\n' "$*" >>"$GH_CALLS"
+	if [[ "$1" == "issue" && "$2" == "lock" ]]; then
+		return "$GH_LOCK_RC"
+	fi
+	if [[ "$1" == "api" ]]; then
+		printf '%s\n' "$GH_LOCKED"
+		return 0
+	fi
+	return 0
+}
+
+gh_pr_list() {
+	return 0
+}
+
+export -f gh gh_pr_list
+
+# shellcheck source=../pulse-dispatch-core.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+
+: >"$GH_CALLS"
+if lock_issue_for_worker 41 owner/repo &&
+	grep -q -- 'issue lock 41 --repo owner/repo --reason resolved' "$GH_CALLS" &&
+	grep -q -- 'api repos/owner/repo/issues/41 --jq .locked == true' "$GH_CALLS" &&
+	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-41" ]]; then
+	pass "strict lock succeeds only after independent verification"
+else
+	fail "strict lock succeeds only after independent verification"
+fi
+
+: >"$GH_CALLS"
+GH_LOCKED=false
+if ! lock_issue_for_worker 42 owner/repo &&
+	grep -q -- 'dispatch remains blocked' "$LOGFILE"; then
+	pass "unverified issue lock fails closed"
+else
+	fail "unverified issue lock fails closed"
+fi
+
+: >"$GH_CALLS"
+GH_LOCKED=true
+snapshot='[
+  {"number":51,"labels":[{"name":"auto-dispatch"},{"name":"status:blocked"}]},
+  {"number":52,"labels":[{"name":"auto-dispatch"},{"name":"status:queued"}]},
+  {"number":53,"labels":[]},
+  {"number":55,"labels":[{"name":"no-auto-dispatch"}]}
+]'
+mkdir -p "$AIDEVOPS_AUTO_DISPATCH_LOCK_DIR"
+: >"${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-53"
+: >"${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-55"
+if reconcile_auto_dispatch_issue_locks owner/repo "$snapshot" &&
+	grep -q -- 'issue lock 51 --repo owner/repo' "$GH_CALLS" &&
+	grep -q -- 'issue lock 52 --repo owner/repo' "$GH_CALLS" &&
+	grep -q -- 'issue unlock 53 --repo owner/repo' "$GH_CALLS" &&
+	[[ ! -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-53" ]] &&
+	! grep -q -- 'issue unlock 55 --repo owner/repo' "$GH_CALLS"; then
+	pass "reconciliation covers blocked and queued issues without undoing lockdowns"
+else
+	fail "reconciliation covers blocked and queued issues without undoing lockdowns"
+fi
+
+: >"$GH_CALLS"
+gh() {
+	printf '%s\n' "$*" >>"$GH_CALLS"
+	if [[ "$1" == "api" ]]; then
+		printf 'auto-dispatch,status:queued\n'
+	fi
+	return 0
+}
+export -f gh
+if unlock_issue_after_worker 54 owner/repo &&
+	! grep -q -- 'issue unlock 54' "$GH_CALLS" &&
+	grep -q -- 'Retained conversation lock' "$LOGFILE"; then
+	pass "worker handoff retains lock while auto-dispatch remains active"
+else
+	fail "worker handoff retains lock while auto-dispatch remains active"
+fi
+
+printf '\n%d tests, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -499,6 +499,35 @@ test_ceremony_failure_blocks_launch_and_releases_claim() {
 	return 0
 }
 
+test_conversation_lock_failure_blocks_manual_launch() {
+	reset_test_state
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local launch_log="${test_dir}/launch.log"
+	local rc=0
+
+	(
+		_DSI_ARG_NO_CEREMONY=0
+		_DSI_WORKTREE_PATH="$test_dir"
+		_dsi_apply_prelaunch_ceremony_if_enabled() { return 0; }
+		_dsi_create_worktree() { return 0; }
+		_dsi_guard_no_existing_dispatch() { return 0; }
+		lock_issue_for_worker() { return 1; }
+		_dsi_reset_after_prelaunch_failure() { return 0; }
+		_dsi_launch_and_report() {
+			printf 'launched\n' >"$launch_log"
+			return 0
+		}
+		_dsi_dispatch_after_dedup_clear 1 owner/repo runner-self session-key >/dev/null 2>&1
+	) || rc=$?
+
+	local blocked=1
+	[[ "$rc" -eq 1 && ! -e "$launch_log" ]] && blocked=0
+	print_result "manual dispatch lock failure blocks worker launch" "$blocked" "rc=$rc"
+	rm -rf "$test_dir"
+	return 0
+}
+
 test_no_ceremony_flag_parses_correctly() {
 	reset_test_state
 
@@ -1450,6 +1479,7 @@ _run_tests() {
 	test_ceremony_handles_empty_self_login
 	test_ceremony_handles_set_issue_status_failure
 	test_ceremony_failure_blocks_launch_and_releases_claim
+	test_conversation_lock_failure_blocks_manual_launch
 	test_no_ceremony_flag_parses_correctly
 	test_model_override_guidance_is_provider_neutral
 	test_load_issue_meta_accepts_lowercase_open

--- a/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
+++ b/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
@@ -26,6 +26,7 @@
 #   3. auto-dispatch in labels → [INFO] skip log emitted
 #   4. auto-dispatch in comma-separated list → --assignee NOT passed
 #   5. caller passes explicit --assignee → always forwarded (no override)
+#   6. auto-dispatch creation locks and verifies the issue conversation
 #
 # Stub strategy: define `gh` as a shell function AFTER sourcing the helper.
 # Shell functions take precedence over PATH binaries, so the stub captures
@@ -120,6 +121,14 @@ gh() {
 		printf '"testuser"\n'
 		return 0
 	fi
+	if [[ "$1" == "api" && "$2" == "repos/owner/repo/issues/9991" ]]; then
+		printf 'true\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "$2" == "repos/owner/repo" ]]; then
+		printf 'false\n'
+		return 0
+	fi
 	if [[ "$1" == "issue" && "$2" == "create" ]]; then
 		printf 'https://github.com/owner/repo/issues/9991\n'
 		return 0
@@ -155,6 +164,14 @@ if ! grep -q -- "--assignee" "$GH_CALLS" 2>/dev/null; then
 else
 	fail "auto-dispatch in labels → --assignee NOT passed" \
 		"gh was called with --assignee when auto-dispatch was present"
+fi
+
+if grep -q -- "issue lock 9991 --repo owner/repo --reason resolved" "$GH_CALLS" 2>/dev/null &&
+	grep -q -- "api repos/owner/repo/issues/9991 --jq .locked == true" "$GH_CALLS" 2>/dev/null; then
+	pass "auto-dispatch creation freezes and verifies the issue conversation"
+else
+	fail "auto-dispatch creation freezes and verifies the issue conversation" \
+		"expected issue lock plus independent locked-state read"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -56,6 +56,10 @@ gh() {
 			printf 'api-login\n'
 			return 0
 		fi
+		if [[ "$path" == repos/*/issues/* && "${GH_ISSUE_LABELS:-}" != "" ]]; then
+			printf '%s\n' "$GH_ISSUE_LABELS"
+			return 0
+		fi
 		local method="GET" body="" prev=""
 		local arg
 		for arg in "$@"; do
@@ -235,6 +239,7 @@ else
 fi
 
 : >"$CALL_LOG"
+GH_ISSUE_LABELS=bug
 GH_UNLOCK_MODE=already_unlocked _unlock_issue_after_dispatch_release "12345" "owner/repo"
 if grep -q 'INFO Release unlock skipped for GitHub issue #12345 in owner/repo: already unlocked' "$CALL_LOG" &&
 	! grep -q 'WARN Failed to unlock released' "$CALL_LOG"; then
@@ -246,12 +251,23 @@ else
 fi
 
 : >"$CALL_LOG"
+GH_ISSUE_LABELS=bug
 GH_UNLOCK_MODE=hard_fail _unlock_issue_after_dispatch_release "12345" "owner/repo"
 if grep -q 'WARN Failed to unlock released GitHub issue #12345 in owner/repo (non-fatal): GraphQL: repository access denied' "$CALL_LOG"; then
 	printf 'PASS hard unlock failures include issue, repo, and cause\n'
 else
 	printf 'FAIL hard unlock failure did not include issue, repo, and cause\n'
 	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+GH_ISSUE_LABELS=auto-dispatch,status:available _unlock_issue_after_dispatch_release "12345" "owner/repo"
+if grep -q 'INFO Retaining conversation lock for auto-dispatch issue #12345' "$CALL_LOG" &&
+	! grep -q '^UNLOCK ' "$CALL_LOG"; then
+	printf 'PASS auto-dispatch claim release retains conversation lock\n'
+else
+	printf 'FAIL auto-dispatch claim release reopened conversation\n'
 	exit 1
 fi
 

--- a/.agents/scripts/tests/test-pr-conversation-lock-routing.sh
+++ b/.agents/scripts/tests/test-pr-conversation-lock-routing.sh
@@ -89,6 +89,10 @@ gh() {
 		printf 'Resolves #42\n'
 		return 0
 	fi
+	if [[ "$group" == "api" ]]; then
+		printf 'bug\n'
+		return 0
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -750,7 +750,7 @@ _dlw_assign_and_label() {
 }
 lock_issue_for_worker() {
 	printf 'lock\n' >>"$ORCHESTRATOR_CALLS_FILE"
-	return 0
+	return "${STUB_LOCK_RC:-0}"
 }
 _dlw_post_launch_hooks() { return 0; }
 
@@ -775,6 +775,21 @@ else
 	fail "assignment failure occurs at final boundary before lock and spawn" "calls='$actual_calls'"
 fi
 STUB_ASSIGN_RC=0
+
+# A conversation-lock failure must stop before runtime spawn.
+: >"$ORCHESTRATOR_CALLS_FILE"
+: >"${TMP}/setsid-calls.txt"
+STUB_LOCK_RC=1
+lock_failure_rc=0
+_dispatch_launch_worker "77781" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-lock-failure" "" "{}" || lock_failure_rc=$?
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$lock_failure_rc" -eq 2 && "$actual_calls" == *"lock "* && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "conversation-lock failure blocks worker spawn"
+else
+	fail "conversation-lock failure blocks worker spawn" "rc=$lock_failure_rc calls='$actual_calls'"
+fi
+STUB_LOCK_RC=0
 
 # A repeated-zero-output hold must stop before worktree, ownership, lock, or spawn.
 : >"$ORCHESTRATOR_CALLS_FILE"

--- a/.agents/scripts/worker-watchdog-kill.sh
+++ b/.agents/scripts/worker-watchdog-kill.sh
@@ -206,7 +206,17 @@ _watchdog_unlock_issue_and_prs() {
 
 	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 0
 
-	# Unlock the issue
+	local labels=""
+	if ! labels=$(gh api "repos/${repo_slug}/issues/${issue_number}" --jq '[.labels[]? | .name] | join(",")' 2>/dev/null); then
+		log_msg "Could not verify labels for #${issue_number} in ${repo_slug}; retained conversation lock"
+		return 0
+	fi
+	# aidevops:trust-boundary — watchdog recovery must not reopen a retryable
+	# worker-authorized instruction surface to public comments.
+	if [[ ",$labels," == *,auto-dispatch,* && ",$labels," != *,no-auto-dispatch,* ]]; then
+		log_msg "Retained conversation lock for auto-dispatch #${issue_number} in ${repo_slug} after watchdog kill"
+		return 0
+	fi
 	gh issue unlock "$issue_number" --repo "$repo_slug" >/dev/null 2>&1 || true
 	log_msg "Unlocked #${issue_number} in ${repo_slug} after watchdog kill (t1934)"
 


### PR DESCRIPTION
## Summary

Lock auto-dispatch issues at creation and Pulse reconciliation, verify locks before every worker launch, preserve locks across retries/watchdog/manual dispatch, and avoid undoing explicit human lockdowns.

## Files Changed

.agents/reference/auto-dispatch.md, .agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/tests/test-auto-dispatch-conversation-lock.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh, .agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh, .agents/scripts/tests/test-headless-runtime-release-unlock.sh, .agents/scripts/tests/test-pr-conversation-lock-routing.sh, .agents/scripts/tests/test-precreation-failure-skip.sh, .agents/scripts/worker-watchdog-kill.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: live GitHub issue #30180 lock verified; ShellCheck; focused lock, headless release, watchdog routing, manual dispatch, and precreation tests; linters-local.sh --changed.

Resolves #30180


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.256 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 35m and 254,458 tokens on this with the user in an interactive session.