### PR TITLE
GH#30173: detect continued-session worker activity

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -61,6 +61,43 @@ readonly _HRFF_RETRY_CLASS_REMEDIATION="meaningful_remediation"
 readonly _HRFF_RETRY_CLASS_UNKNOWN="unknown"
 readonly _HRFF_SESSION_COUNT_QUERY_PREFIX="SELECT count(*) FROM session WHERE time_created >= "
 
+#######################################
+# Count worker activity created during an attempt.
+# Fresh sessions count directly. A continued session also counts messages
+# created after the attempt began because its session row predates the attempt.
+#
+# Args:
+#   $1 = OpenCode database path
+#   $2 = worker start epoch in milliseconds
+#   $3 = persisted session ID (optional)
+# Outputs: non-negative count, or an empty string when session evidence fails
+#######################################
+_hrff_worker_activity_count() {
+	local db_path="$1"
+	local start_epoch_ms="$2"
+	local persisted_session="${3:-}"
+	local session_count=""
+	local message_count="0"
+	local persisted_session_sql=""
+
+	session_count=$(sqlite3 "$db_path" \
+		"${_HRFF_SESSION_COUNT_QUERY_PREFIX}${start_epoch_ms}" \
+		2>/dev/null) || session_count=""
+	[[ "$session_count" =~ ^[0-9]+$ ]] || {
+		printf '%s' ""
+		return 0
+	}
+	if [[ -n "$persisted_session" ]]; then
+		persisted_session_sql="${persisted_session//\'/\'\'}"
+		message_count=$(sqlite3 "$db_path" \
+			"SELECT count(*) FROM message WHERE session_id = '${persisted_session_sql}' AND time_created >= ${start_epoch_ms}" \
+			2>/dev/null) || message_count="0"
+		[[ "$message_count" =~ ^[0-9]+$ ]] || message_count="0"
+	fi
+	printf '%s' "$((session_count + message_count))"
+	return 0
+}
+
 # Per-issue transient rate-limit release circuit breaker (t3570 / GH#23102).
 # These defaults intentionally keep the first transient failures visible while
 # suppressing repeated CLAIM_RELEASED storms during provider capacity outages.
@@ -645,9 +682,8 @@ classify_worker_exit() {
 		if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$_db_zo" \
 			&& "$start_epoch_ms" =~ ^[0-9]+$ && "$start_epoch_ms" -gt 0 ]]; then
 			local _cnt_zo=""
-			_cnt_zo=$(sqlite3 "$_db_zo" \
-				"${_HRFF_SESSION_COUNT_QUERY_PREFIX}${start_epoch_ms}" \
-				2>/dev/null) || _cnt_zo=""
+			_cnt_zo=$(_hrff_worker_activity_count "$_db_zo" "$start_epoch_ms" \
+				"${_invoke_persisted_session:-}")
 			if [[ "$_cnt_zo" =~ ^[0-9]+$ && "$_cnt_zo" -eq 0 ]]; then
 				printf '%s' "worker_noop_zero_output"
 				return 0
@@ -978,7 +1014,8 @@ _hrff_worker_session_count() {
 	local count="0"
 	[[ -n "$active_db" && -f "$active_db" ]] || active_db="$shared_db"
 	if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$active_db" && "$start_epoch_ms" =~ ^[0-9]+$ && "$start_epoch_ms" -gt 0 ]]; then
-		count=$(sqlite3 "$active_db" "${_HRFF_SESSION_COUNT_QUERY_PREFIX}${start_epoch_ms}" 2>/dev/null) || count="0"
+		count=$(_hrff_worker_activity_count "$active_db" "$start_epoch_ms" \
+			"${_invoke_persisted_session:-}")
 	fi
 	[[ "$count" =~ ^[0-9]+$ ]] || count="0"
 	printf '%s\n' "$count"
@@ -1254,9 +1291,8 @@ _exit_trap_handler() {
 			[[ -z "$_db" || ! -f "$_db" ]] && _db="$_shared"
 			if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$_db" && "$_start_ms" =~ ^[0-9]+$ ]] && (( _start_ms > 0 )); then
 				local _cnt=""
-				_cnt=$(sqlite3 "$_db" \
-					"${_HRFF_SESSION_COUNT_QUERY_PREFIX}${_start_ms}" \
-					2>/dev/null) || _cnt=""
+				_cnt=$(_hrff_worker_activity_count "$_db" "$_start_ms" \
+					"${_invoke_persisted_session:-}")
 				[[ "$_cnt" =~ ^[0-9]+$ ]] && session_count="$_cnt"
 			fi
 		else

--- a/.agents/scripts/tests/test-worker-exit-classifier.sh
+++ b/.agents/scripts/tests/test-worker-exit-classifier.sh
@@ -74,7 +74,7 @@ teardown() {
 _make_db() {
 	local db_path="$1"
 	sqlite3 "$db_path" \
-		"CREATE TABLE IF NOT EXISTS session (id TEXT, title TEXT, time_created INTEGER);" \
+		"CREATE TABLE IF NOT EXISTS session (id TEXT, title TEXT, time_created INTEGER); CREATE TABLE IF NOT EXISTS message (id TEXT, session_id TEXT, time_created INTEGER);" \
 		2>/dev/null
 	return 0
 }
@@ -84,6 +84,17 @@ _insert_session() {
 	local ts_ms="$2"
 	sqlite3 "$db_path" \
 		"INSERT INTO session VALUES ('test-id-$(date +%s%N)', 'test session', ${ts_ms});" \
+		2>/dev/null
+	return 0
+}
+
+_insert_message() {
+	local db_path="$1"
+	local session_id="$2"
+	local ts_ms="$3"
+	local session_id_sql="${session_id//\'/\'\'}"
+	sqlite3 "$db_path" \
+		"INSERT INTO message VALUES ('message-$(date +%s%N)', '${session_id_sql}', ${ts_ms});" \
 		2>/dev/null
 	return 0
 }
@@ -185,6 +196,57 @@ test_clean_exit_session_before_start() {
 	unset _WORKER_ISOLATED_DB_PATH
 
 	assert_eq "worker_noop_zero_output (clean, session before start)" "$result" "worker_noop_zero_output"
+	return 0
+}
+
+# GH#30173: a continued session retains its original creation time, so a new
+# message scoped to that session is the attempt activity signal.
+test_clean_exit_continued_session_with_new_message() {
+	local db_path="${TMPDIR_TEST}/clean-continued-session.db"
+	local persisted_session="continued'session"
+	_make_db "$db_path"
+	local old_ts=$(( $(_now_ms) - 10000 ))
+	sqlite3 "$db_path" \
+		"INSERT INTO session VALUES ('continued''session', 'continued session', ${old_ts});" \
+		2>/dev/null
+	local start_ms
+	start_ms=$(_now_ms)
+	_insert_message "$db_path" "$persisted_session" "$start_ms"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	_WORKER_START_EPOCH_MS="$start_ms"
+	_invoke_persisted_session="$persisted_session"
+	local result
+	result=$(classify_worker_exit 0 "$start_ms")
+	local activity_count
+	activity_count=$(_hrff_worker_session_count)
+	unset _WORKER_ISOLATED_DB_PATH _WORKER_START_EPOCH_MS _invoke_persisted_session
+
+	assert_eq "clean (continued session with new message)" "$result" "clean"
+	assert_eq "continued-session activity count" "$activity_count" "1"
+	return 0
+}
+
+test_clean_exit_continued_session_without_scoped_activity() {
+	local db_path="${TMPDIR_TEST}/clean-continued-session-no-activity.db"
+	local persisted_session="continued-session"
+	_make_db "$db_path"
+	local old_ts=$(( $(_now_ms) - 10000 ))
+	sqlite3 "$db_path" \
+		"INSERT INTO session VALUES ('continued-session', 'continued session', ${old_ts});" \
+		2>/dev/null
+	local start_ms
+	start_ms=$(_now_ms)
+	_insert_message "$db_path" "different-session" "$start_ms"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	_invoke_persisted_session="$persisted_session"
+	local result
+	result=$(classify_worker_exit 0 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH _invoke_persisted_session
+
+	assert_eq "worker_noop_zero_output (continued session without scoped activity)" \
+		"$result" "worker_noop_zero_output"
 	return 0
 }
 
@@ -487,6 +549,8 @@ main() {
 	test_clean_exit_zero_sessions
 	test_clean_exit_with_sessions
 	test_clean_exit_session_before_start
+	test_clean_exit_continued_session_with_new_message
+	test_clean_exit_continued_session_without_scoped_activity
 	test_signal_killed_with_zero_sessions
 	test_crash_during_startup_empty_db
 	test_crash_during_startup_no_db


### PR DESCRIPTION
## Summary

Count post-start messages scoped to persisted OpenCode sessions so successful continued workers are not reported as zero-output.

## Files Changed

.agents/scripts/headless-runtime-failure.sh, .agents/scripts/tests/test-worker-exit-classifier.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with isolated SQLite fixtures for continued-session scoped activity and genuine no-activity; worker exit classifier 21/21; failure classification 110/110; full headless runtime helper suite; ShellCheck; local linters.

Resolves #30173


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.256 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 19m and 270,354 tokens on this with the user in an interactive session.