### PR TITLE
GH#30190: fix: preserve awardsapp pulse worker dispatch

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -170,7 +170,7 @@ _ddpr_graphql_open_commits() {
 	local owner="${repo_slug%%/*}"
 	local repo="${repo_slug#*/}"
 	local response="" pr_json=""
-	[[ -n "$owner" && -n "$repo" && "$owner" != "$repo" && "$repo" != */* ]] || return 1
+	[[ -n "$owner" && -n "$repo" && "$repo_slug" == */* && "$repo" != */* ]] || return 1
 
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -173,7 +173,7 @@ _full_loop_pr_readiness_json_graphql() {
 	local response="" pr_json=""
 	local jq_string_type="string"
 
-	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$owner" != "$name" ]] || return 1
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$repo_slug" == */* ]] || return 1
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="full-loop-readiness-exact-cost" \

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -596,7 +596,13 @@ _merge_fetch_pinned_commit_objects() {
 			fetch --quiet --no-tags -- "$remote_url" "refs/heads/${base_ref}" || return 1
 		fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
 			rev-parse FETCH_HEAD 2>/dev/null) || return 1
-		[[ "$fetched_sha" == "$base_sha" ]] || return 1
+		if [[ "$fetched_sha" != "$base_sha" ]]; then
+			_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+				fetch --quiet --no-tags -- "$remote_url" "$base_sha" || return 1
+			fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+				rev-parse FETCH_HEAD 2>/dev/null) || return 1
+			[[ "$fetched_sha" == "$base_sha" ]] || return 1
+		fi
 	fi
 	if ! _merge_run_repository_isolated_git "$real_git" -C "$object_repo" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
 		[[ -n "$remote_url" ]] || return 1

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1229,10 +1229,11 @@ _is_task_committed_to_main() {
 #######################################
 # Detect labels that mean a human/review workflow owns the target.
 #
-# status:in-review and origin:interactive are live interactive hold signals only
-# while the issue is not explicitly worker-dispatchable. auto-dispatch is the
-# handoff signal for issues left by an interactive session after the human has
-# moved on, so it must not strand work forever (GH#22964/GH#22965).
+# status:in-review is a live interactive hold signal while the issue is not
+# explicitly worker-dispatchable. origin:interactive is provenance only unless a
+# same-session owner/assignee is still attached; unassigned status:available
+# issues must remain dispatchable so TODO/brief sync does not strand worker-ready
+# backlog items that lack auto-dispatch labels.
 #
 # Args:
 #   $1 - issue metadata JSON with optional .labels[].name
@@ -1242,7 +1243,14 @@ _dispatch_has_interactive_hold() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
-		jq -e '(.labels // []) | map(.name) | ((index("auto-dispatch") | not) and (index("status:in-review") or index("origin:interactive")))' >/dev/null 2>&1
+		jq -e '
+			([.labels[]?.name]) as $labels |
+			(($labels | index("auto-dispatch")) | not) and
+			(
+				($labels | index("status:in-review")) or
+				(($labels | index("origin:interactive")) and (((.assignees // []) | length) > 0))
+			)
+		' >/dev/null 2>&1
 	return $?
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-gates.sh
+++ b/.agents/scripts/pulse-dispatch-worker-gates.sh
@@ -284,6 +284,9 @@ PY
 _dlw_allow_soft_canary_failure() {
 	local reason="$1"
 	_dlw_canary_failure_is_soft "$reason" || return 1
+	if _dlw_min_worker_floor_active; then
+		return 0
+	fi
 	_dlw_recent_worker_evidence || return 1
 	return 0
 }
@@ -330,7 +333,11 @@ _dlw_canary_preflight() {
 	local canary_reason
 	canary_reason=$(_dlw_canary_last_failure_reason)
 	if _dlw_allow_soft_canary_failure "$canary_reason"; then
-		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: soft worker canary failure reason=${canary_reason} bypassed because recent worker evidence exists (bounded t3449)" >>"$LOGFILE"
+		if _dlw_min_worker_floor_active; then
+			echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: soft worker canary failure reason=${canary_reason} bypassed to preserve minimum worker floor (bounded t3449/t2878)" >>"$LOGFILE"
+		else
+			echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: soft worker canary failure reason=${canary_reason} bypassed because recent worker evidence exists (bounded t3449)" >>"$LOGFILE"
+		fi
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -168,7 +168,7 @@ _pulse_merge_admin_pr_json_graphql() {
 	local name="${repo_slug#*/}"
 	local response="" pr_json=""
 
-	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$owner" != "$name" ]] || return 1
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$repo_slug" == */* && "$name" != */* ]] || return 1
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="pulse-admin-authority-exact-cost" \

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -346,6 +346,28 @@ test_has_open_pr_detects_response_metered_commit_reference() {
 	return 0
 }
 
+test_has_open_pr_allows_owner_repo_same_name() {
+	local output=""
+	export GH_OPEN_COMMITS_JSON='[{"number":1061,"title":"Same-name repo fix","isDraft":false,"commits":[{"messageHeadline":"Fixes #10001 in same-name owner repo"}]}]'
+	printf '' >"$GH_GRAPHQL_CALL_LOG"
+
+	if output=$("$HELPER_SCRIPT" has-open-pr 10001 awardsapp/awardsapp 't10001: same-name repo dispatch dedup'); then
+		unset GH_OPEN_COMMITS_JSON
+		if [[ "$output" == *"open PR #1061 has commits targeting issue #10001"* ]] && \
+			grep -qF '1|dispatch-dedup-open-commits-exact-cost|' "$GH_GRAPHQL_CALL_LOG"; then
+			print_result "has-open-pr supports owner/repo slugs with identical names" 0
+			return 0
+		fi
+		print_result "has-open-pr supports owner/repo slugs with identical names" 1 "output=${output}"
+		return 0
+	fi
+
+	unset GH_OPEN_COMMITS_JSON
+	print_result "has-open-pr supports owner/repo slugs with identical names" 1 \
+		"Expected same-name repo slug to reach open-commit PR lookup"
+	return 0
+}
+
 test_has_open_pr_returns_nonzero_without_match() {
 	set_gh_fixtures ''
 	set_gh_pr_view_fixtures ''
@@ -943,6 +965,7 @@ main() {
 	test_has_open_pr_detects_closing_keyword
 	test_has_open_pr_detects_task_id_fallback
 	test_has_open_pr_detects_response_metered_commit_reference
+	test_has_open_pr_allows_owner_repo_same_name
 	test_has_open_pr_returns_nonzero_without_match
 	test_has_open_pr_ignores_planning_for_reference
 	test_has_open_pr_ignores_planning_ref_reference

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -34,6 +34,20 @@ export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 export STOP_FLAG="${HOME}/.aidevops/logs/stop"
 : >"$LOGFILE"
 
+TEST_BIN="${TEST_ROOT}/bin"
+mkdir -p "$TEST_BIN"
+cat >"${TEST_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == "-i" && "$3" == "user" ]]; then
+	printf 'HTTP/2 200\r\nx-ratelimit-resource: core\r\nx-ratelimit-limit: 5000\r\nx-ratelimit-remaining: 4999\r\nx-ratelimit-reset: 1789999999\r\n\r\n{}\n'
+	exit 0
+fi
+printf '{}\n'
+exit 0
+EOF
+chmod +x "${TEST_BIN}/gh"
+export PATH="${TEST_BIN}:$PATH"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../pulse-capacity.sh
 source "${SCRIPT_DIR}/pulse-capacity.sh"
@@ -823,6 +837,34 @@ EOF
 	return 0
 }
 
+test_soft_canary_failure_bypasses_under_minimum_floor_without_recent_evidence() {
+	local fake_helper worker_log state_dir
+	fake_helper="${TEST_ROOT}/fake-floor-canary.sh"
+	worker_log="${TEST_ROOT}/worker-floor.log"
+	state_dir="${HOME}/.aidevops/.agent-workspace/headless-runtime"
+	cat >"$fake_helper" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+mkdir -p "$state_dir"
+date +%s >"${state_dir}/canary-last-fail"
+printf 'transient\n' >"${state_dir}/canary-last-fail.reason"
+exit 1
+EOF
+	chmod +x "$fake_helper"
+	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	AIDEVOPS_HEADLESS_RUNTIME_DIR="$state_dir"
+	AIDEVOPS_DISPATCH_LEDGER_DIR="${TEST_ROOT}/empty-ledger"
+	mkdir -p "$AIDEVOPS_DISPATCH_LEDGER_DIR"
+	TEST_ACTIVE_WORKERS=5
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	if _dlw_canary_preflight 104 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: soft failure bypassed under minimum worker floor" 0
+	else
+		print_result "canary: soft failure bypassed under minimum worker floor" 1
+	fi
+	return 0
+}
+
 test_capacity_raises_soft_cap_to_floor
 test_capacity_reads_min_floor_from_config_default
 test_capacity_respects_existing_higher_cap
@@ -846,6 +888,7 @@ test_early_exit_refill_reuses_precomputed_active_count
 test_active_pulse_refill_uses_min_floor_above_raw_max
 test_soft_canary_failure_bypasses_with_recent_worker_evidence
 test_hard_canary_failure_blocks_despite_recent_worker_evidence
+test_soft_canary_failure_bypasses_under_minimum_floor_without_recent_evidence
 
 echo ""
 echo "===================="

--- a/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
@@ -258,6 +258,16 @@ test_full_loop_readiness_integration() {
 	fi
 
 	: >"$GH_LOG"
+	rc=0
+	_full_loop_verify_pr_readiness 42 awardsapp/awardsapp >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -q -- "-F owner=awardsapp -F name=awardsapp" "$GH_LOG" \
+		&& grep -q "exact-checks awardsapp/awardsapp 42 required" "$GH_LOG"; then
+		record_result "full-loop readiness supports same-name owner/repo slugs" 0
+	else
+		record_result "full-loop readiness supports same-name owner/repo slugs" 1
+	fi
+
+	: >"$GH_LOG"
 	export READINESS_RESPONSE_MODE="missing-cost"
 	rc=0
 	_full_loop_verify_pr_readiness 42 owner/repo >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -1428,6 +1428,9 @@ test_prospective_todo_merge_guard() {
 	base_sha=$(<"${fixture_root}/base.sha")
 	head_sha=$(<"${fixture_root}/head.sha")
 	remote_url=$(<"${fixture_root}/remote.url")
+	printf 'advance target default branch after PR snapshot\n' >>"${fixture_root}/work/TODO.md"
+	/usr/bin/git -C "${fixture_root}/work" commit -q -am 'advance target main after PR snapshot' || return 0
+	/usr/bin/git -C "${fixture_root}/work" push -q origin main || return 0
 	storage_before=$(prospective_git_storage_digest "$fixture_dir")
 	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_before=1; fi
 	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" live "$remote_url" >/dev/null || rc=$?

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -117,13 +117,23 @@ test_interactive_hold_blocks_in_review_without_handoff() {
 	return 0
 }
 
-test_interactive_hold_blocks_origin_interactive() {
-	local meta='{"labels":[{"name":"origin:interactive"},{"name":"bug"}]}'
+test_interactive_hold_allows_unassigned_origin_interactive() {
+	local meta='{"labels":[{"name":"origin:interactive"},{"name":"status:available"},{"name":"bug"}],"assignees":[]}'
 	if _dispatch_has_interactive_hold "$meta"; then
-		print_result "interactive hold blocks origin:interactive" 0
+		print_result "interactive hold allows unassigned origin:interactive backlog" 1 "provenance-only origin:interactive must not strand available work"
 		return 0
 	fi
-	print_result "interactive hold blocks origin:interactive" 1 "expected origin:interactive to block"
+	print_result "interactive hold allows unassigned origin:interactive backlog" 0
+	return 0
+}
+
+test_interactive_hold_blocks_assigned_origin_interactive() {
+	local meta='{"labels":[{"name":"origin:interactive"},{"name":"bug"}],"assignees":[{"login":"owner"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold blocks assigned origin:interactive" 0
+		return 0
+	fi
+	print_result "interactive hold blocks assigned origin:interactive" 1 "expected assigned origin:interactive work to block"
 	return 0
 }
 
@@ -214,7 +224,8 @@ main() {
 	test_pr_guard_uses_rest_issue_object
 	test_pr_guard_allows_plain_issue
 	test_interactive_hold_blocks_in_review_without_handoff
-	test_interactive_hold_blocks_origin_interactive
+	test_interactive_hold_allows_unassigned_origin_interactive
+	test_interactive_hold_blocks_assigned_origin_interactive
 	test_interactive_hold_allows_auto_dispatch_handoff
 	test_interactive_hold_allows_auto_dispatch_review_handoff
 	test_interactive_hold_allows_worker_issue

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -306,6 +306,28 @@ test_case_a_collaborator_pr_returns_0() {
 	return 0
 }
 
+test_case_a2_same_name_owner_repo_pr_returns_0() {
+	set_fixture '[{"name":"bug"},{"name":"tier:standard"}]' 'false' \
+		'## Summary\n\nResolves #101' 'VERIFIED'
+
+	local result
+	_pulse_merge_admin_safety_check "101" "awardsapp/awardsapp"
+	result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case A2: same-name owner/repo PR returns 0" 1 \
+			"Expected 0, got ${result}; log=$(cat "$LOGFILE")"
+		return 0
+	fi
+	if ! grep -qF 'gh api graphql' "$GH_LOG"; then
+		print_result "Case A2: same-name owner/repo reaches GraphQL metadata read" 1 \
+			"Expected GraphQL metadata call; calls=$(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "Case A2: same-name owner/repo PR — returns 0" 0
+	return 0
+}
+
 test_case_l_collaborator_linked_issue_nmr_blocks_final_gate() {
 	: >"$LOGFILE"
 	set_fixture '[{"name":"bug"}]' 'false' \
@@ -709,6 +731,7 @@ main() {
 	fi
 
 	test_case_a_collaborator_pr_returns_0
+	test_case_a2_same_name_owner_repo_pr_returns_0
 	test_case_b_external_no_linked_issue_returns_1
 	test_case_c_external_no_approval_returns_1
 	test_case_d_external_with_approval_returns_0


### PR DESCRIPTION
Resolves #30190

## Summary

Root fix:
- Preserve bounded pulse dispatch when the worker canary has a soft/inconclusive failure but the minimum worker floor is active.

Collateral hardening found while diagnosing awardsapp/awardsapp queue stalls:
- Allow same-name `owner/repo` slugs such as `awardsapp/awardsapp` in dispatch dedup, merge authority, and full-loop readiness GraphQL helpers.
- Treat unassigned `origin:interactive` + available backlog as dispatchable unless it has a live review/assignment hold.
- Fetch pinned base commit objects for prospective TODO validation when the base branch advanced after PR snapshot.

## Evidence

Observed local production symptom before the fix:
- `worker-activity-helper.sh summary --since 6h --repo awardsapp/awardsapp --pr-check`: no terminal worker outcomes.
- `pulse-current-state-helper.sh --window 1h/6h --json`: dispatch blocked by `pre_runtime_failure:canary_preflight` and `interactive_review_hold`.
- `opencode-pin-canary.sh canary`: baseline returned `RESULT=inconclusive` with `UnknownError`.

Observed after local deployment of this branch:
- `./setup.sh --stage agents --non-interactive` activated the fixed runtime bundle and restarted Pulse.
- `pulse-current-state-helper.sh --window 30m --json`: workers spawned for awardsapp issues.
- `worker-activity-helper.sh summary --since 1h --repo awardsapp/awardsapp --pr-check`: `Result classes: {"success":1}`, `PRs opened: 2`, `PRs merged: 2`, `Issues solved and closed: 1`.
- awardsapp open issue count moved `81 -> 80 -> 79`.
- `#9635` closed with `status:done` and `solved:worker`; `#9637` closed.

## Verification

- `bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh`
- `bash .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh`
- `bash .agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh`
- `bash .agents/scripts/tests/test-full-loop-merge.sh`
- `bash .agents/scripts/tests/test-dispatch-min-concurrency.sh`
- `shellcheck .agents/scripts/dispatch-dedup-pr.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-merge-gates.sh .agents/scripts/full-loop-helper-commit.sh .agents/scripts/full-loop-helper-merge.sh .agents/scripts/pulse-dispatch-worker-gates.sh .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh .agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh .agents/scripts/tests/test-full-loop-merge.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh`
- `bun run typecheck`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.256 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.5 spent 5m and 16,126 tokens on this with the user in an interactive session.