### PR TITLE
GH#30186: fix: preserve Remotion help behavior

### DIFF
--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -230,7 +230,7 @@ function renderStill(opts) {
 // Main
 const opts = parseArgs();
 
-if (!opts.brief && !opts.still && !opts.help) {
+function printUsage() {
   console.log(`
 Higgsfield Post-Production Renderer (Remotion)
 
@@ -255,10 +255,11 @@ Still options:
   --font               Font family (default: Inter)
   --output             Output file path (default: graphic.png)
 `);
-  process.exit(0);
 }
 
-if (opts.still) {
+if (opts.help || (!opts.brief && !opts.still)) {
+  printUsage();
+} else if (opts.still) {
   renderStill(opts);
 } else {
   renderVideo(opts);

--- a/.agents/scripts/higgsfield/remotion/render.test.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.test.mjs
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { buildRenderProps, buildSceneVideoFilenames, normalizeCaptions, validateBrief } from "./render-contract.mjs";
+import { execFileSync } from "node:child_process";
+import {
+  buildRenderProps,
+  buildSceneVideoFilenames,
+  normalizeCaptions,
+  validateBrief,
+} from "./render-contract.mjs";
 
 const aspectDimensions = { "9:16": [1080, 1920] };
 const brief = { aspect: "9:16", scenes: [{ prompt: "one", duration: 1, fit: "contain" }] };
@@ -15,8 +21,20 @@ assert.deepEqual(
   ["scene-0.mp4"]
 );
 assert.throws(
-  () => validateBrief({ ...brief, scenes: [...brief.scenes, { prompt: "two", duration: 1 }] }, ["one.mp4"], aspectDimensions),
+  () =>
+    validateBrief(
+      { ...brief, scenes: [...brief.scenes, { prompt: "two", duration: 1 }] },
+      ["one.mp4"],
+      aspectDimensions,
+    ),
   /scene\/video count mismatch/
 );
+const renderPath = new URL("./render.mjs", import.meta.url).pathname;
+const helpOutput = execFileSync(process.execPath, [renderPath, "--help"], {
+  encoding: "utf8",
+});
+assert.match(helpOutput, /Higgsfield Post-Production Renderer/);
 
-console.log("PASS: renderer rejects mismatched scenes and unsafe caption timing");
+console.log(
+  "PASS: renderer rejects mismatched scenes and unsafe caption timing, and prints help safely",
+);


### PR DESCRIPTION
## Summary

Recovered the prior renderer help-path repair, rebased it onto origin/main, and preserved --help output without entering render input processing. The regression test invokes the CLI directly.

## Files Changed

.agents/scripts/higgsfield/remotion/render.mjs, .agents/scripts/higgsfield/remotion/render.test.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node .agents/scripts/higgsfield/remotion/render.test.mjs; node .agents/scripts/higgsfield/remotion/render.mjs --help; node --check .agents/scripts/higgsfield/remotion/render.mjs; git diff --check origin/main...HEAD

Resolves #30186


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.257 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 3m and 53,332 tokens on this as a headless worker.