### PR TITLE
t18232: feat: bridge campaign schedules to outbound queue

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -351,6 +351,17 @@ write was not accepted. `operations-list` returns bounded, content-free receipt
 metadata; it never returns body text, handles, profile names, or raw provider
 responses.
 
+### Reviewed campaign distribution bridge
+
+`campaign-distribution-helper.py` is a producer/read-model bridge for approved
+campaign outputs. It validates the production manifest's review, provenance,
+rights, and output digest before it can preview or create a stable X/Reddit queue
+draft. `enqueue --approve-until EPOCH` is an explicit owner approval request; the
+bridge never runs a provider. It stores receipt-derived state in the campaign's
+`distribution/` record and, when given a calendar schedule ID, projects the same
+state back to that row. `unknown` remains unknown until `reconcile` supplies queue
+evidence; replaying the same source and intent key recreates the same operation.
+
 ## Mention and reply workflow
 
 Notification projection is a mutable local overlay on immutable mention/reply

--- a/.agents/configs/campaign-channel-specs.json
+++ b/.agents/configs/campaign-channel-specs.json
@@ -33,7 +33,9 @@
     },
     "twitter": {
       "canonical_id": "twitter",
-      "fanout_aliases": ["social-x"],
+      "fanout_aliases": ["social-x", "x"],
+      "outbound_channel": "x",
+      "outbound_provider": "xapi",
       "display_name": "Twitter / X",
       "max_words": 50,
       "format": "micro",
@@ -50,6 +52,18 @@
       "cta_style": "button",
       "sections": ["subject_line", "preview_text", "greeting", "body", "cta", "signature"],
       "guidelines": "Subject line: 6-10 words, curiosity or benefit-driven. Preview text: extends subject, not repeats it. Body: scannable with subheadings. Single primary CTA button. P.S. line for secondary offer. Mobile-first formatting."
+    },
+    "reddit": {
+      "canonical_id": "reddit",
+      "fanout_aliases": ["social-reddit"],
+      "outbound_channel": "reddit",
+      "outbound_provider": "reddit",
+      "display_name": "Reddit",
+      "max_words": 400,
+      "format": "community-post",
+      "cta_style": "discussion",
+      "sections": ["title", "body", "disclosure"],
+      "guidelines": "Use a reviewed title and body. Name the destination subreddit at enqueue time; follow community rules and required disclosures."
     },
     "blog": {
       "canonical_id": "blog",

--- a/.agents/schemas/campaign-distribution.schema.json
+++ b/.agents/schemas/campaign-distribution.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Campaign Distribution Record v1",
+  "description": "A producer record for an approval-bound outbound operation; it never authorizes or executes a provider write.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "source_id", "campaign_id", "channel", "operation_id", "intent_key", "status"],
+  "properties": {
+    "version": {"const": 1},
+    "source_id": {"type": "string", "minLength": 1},
+    "campaign_id": {"type": "string", "minLength": 1},
+    "channel": {"enum": ["x", "reddit"]},
+    "operation_id": {"type": "string", "minLength": 1},
+    "intent_key": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "scheduled_at": {"type": "integer", "minimum": 0},
+    "status": {"enum": ["preview", "draft", "approved", "claimed", "unknown", "failed", "succeeded", "cancelled"]},
+    "provider_remote_id": {"type": ["string", "null"]},
+    "updated_at": {"type": "integer", "minimum": 0}
+  }
+}

--- a/.agents/schemas/campaign-intake.schema.json
+++ b/.agents/schemas/campaign-intake.schema.json
@@ -16,7 +16,7 @@
     "proof": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["claim", "evidence_reference", "approval_status"], "properties": {"claim": {"type": "string", "minLength": 1, "maxLength": 2000}, "evidence_reference": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^(?!/)(?!~)(?!.*(^|/)\\.\\.(/|$)).+"}, "approval_status": {"enum": ["approved", "pending", "rejected"]}}}},
     "objections": {"type": "array", "items": {"type": "string"}},
     "exclusions": {"type": "array", "items": {"type": "string"}},
-    "channels": {"type": "array", "minItems": 1, "items": {"enum": ["facebook", "instagram", "linkedin", "twitter", "email", "blog"]}},
+    "channels": {"type": "array", "minItems": 1, "items": {"enum": ["facebook", "instagram", "linkedin", "twitter", "reddit", "email", "blog"]}},
     "dates": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"type": "string", "format": "date"}, "end": {"type": "string", "format": "date"}}},
     "kpis": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/metric"}},
     "disclosures": {"type": "array", "items": {"type": "string"}},

--- a/.agents/schemas/content-production-manifest.schema.json
+++ b/.agents/schemas/content-production-manifest.schema.json
@@ -10,7 +10,7 @@
     "job_id": {"type": "string", "pattern": "^job:[a-z0-9][a-z0-9:-]{0,240}$"},
     "campaign_id": {"type": "string", "minLength": 1},
     "brief_id": {"type": "string", "minLength": 1},
-    "channel": {"enum": ["facebook", "instagram", "linkedin", "twitter", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"]},
+    "channel": {"enum": ["facebook", "instagram", "linkedin", "twitter", "reddit", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"]},
     "variant_id": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
     "revision": {"type": "integer", "minimum": 1},
     "input_snapshot_sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},

--- a/.agents/scripts/campaign-distribution-helper.py
+++ b/.agents/scripts/campaign-distribution-helper.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bridge reviewed campaign outputs to the approval-bound social queue.
+
+This producer validates reviewed campaign evidence, creates one stable queue draft,
+and projects queue receipts.  It has no provider implementation or run command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from campaign_production_contract import ManifestError, read_document, validate_distribution_eligibility
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_QUEUE_HELPER = SCRIPT_DIR / "knowledge-social-helper.sh"
+CHANNELS = {
+    "x": {"aliases": {"x", "twitter", "social-x"}, "provider": "xapi"},
+    "reddit": {"aliases": {"reddit", "social-reddit"}, "provider": "reddit"},
+}
+PUBLIC_STATES = {"draft", "approved", "claimed", "unknown", "failed", "succeeded", "cancelled"}
+
+
+class DistributionError(ValueError):
+    """Raised when a campaign cannot safely become an outbound intent."""
+
+
+def _canonical_channel(channel: str) -> str:
+    for canonical, values in CHANNELS.items():
+        if channel in values["aliases"]:
+            return canonical
+    raise DistributionError("channel must be x or reddit (aliases: twitter, social-x, social-reddit)")
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _campaign_dir(value: str) -> Path:
+    path = Path(value).resolve()
+    if not path.is_dir():
+        raise DistributionError("campaign directory is unavailable")
+    return path
+
+
+def _safe_output(campaign_dir: Path, manifest: dict[str, Any], requested: str | None) -> Path:
+    outputs = manifest["outputs"]
+    if requested is None:
+        if len(outputs) != 1:
+            raise DistributionError("select one reviewed output with --output")
+        requested = outputs[0]["path"]
+    output = (campaign_dir / requested).resolve()
+    if campaign_dir not in output.parents or not output.is_file():
+        raise DistributionError("distribution output is missing or outside its campaign")
+    matching = next((entry for entry in outputs if entry["path"] == requested), None)
+    if matching is None:
+        raise DistributionError("selected output is not recorded by the approved manifest")
+    digest = "sha256:" + hashlib.sha256(output.read_bytes()).hexdigest()
+    if digest != matching["sha256"]:
+        raise DistributionError("selected output no longer matches approved evidence")
+    return output
+
+
+def _source(arguments: argparse.Namespace) -> tuple[Path, dict[str, Any], Path, str, str, str]:
+    campaign_dir = _campaign_dir(arguments.campaign_dir)
+    manifest_path = Path(arguments.manifest).resolve()
+    if campaign_dir not in manifest_path.parents:
+        raise DistributionError("production manifest must be inside its campaign")
+    manifest = read_document(manifest_path, "production manifest")
+    validate_distribution_eligibility(manifest, campaign_dir)
+    channel = _canonical_channel(arguments.channel or str(manifest["channel"]))
+    output = _safe_output(campaign_dir, manifest, arguments.output)
+    scheduled_at = int(arguments.scheduled_at)
+    if scheduled_at < 0:
+        raise DistributionError("scheduled_at must be a non-negative epoch")
+    source_id = f"campaign:{manifest['campaign_id']}:{manifest['variant_id']}:{channel}"
+    intent_key = _digest({
+        "source_id": source_id, "channel": channel, "output_sha256": hashlib.sha256(output.read_bytes()).hexdigest(),
+        "scheduled_at": scheduled_at, "connection_id": arguments.connection_id, "account_id": arguments.account_id,
+        "destination_id": getattr(arguments, "destination_id", None),
+        "subject_sha256": (
+            hashlib.sha256(Path(arguments.subject).read_bytes()).hexdigest()
+            if getattr(arguments, "subject", None) and Path(arguments.subject).is_file()
+            else None
+        ),
+    })
+    return campaign_dir, manifest, output, channel, source_id, intent_key
+
+
+def _operation_id(source_id: str, intent_key: str) -> str:
+    return "op_campaign_" + hashlib.sha256(f"{source_id}:{intent_key}".encode()).hexdigest()[:32]
+
+
+def _record_path(campaign_dir: Path, source_id: str) -> Path:
+    return campaign_dir / "distribution" / (hashlib.sha256(source_id.encode()).hexdigest() + ".json")
+
+
+def _write_record(campaign_dir: Path, record: dict[str, Any]) -> None:
+    destination = _record_path(campaign_dir, record["source_id"])
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(".tmp")
+    temporary.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
+
+
+def _queue(arguments: argparse.Namespace, command: list[str]) -> Any:
+    helper = Path(arguments.queue_helper).resolve()
+    if not helper.is_file():
+        raise DistributionError("outbound queue helper is unavailable")
+    result = subprocess.run([str(helper), *command], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise DistributionError(f"outbound queue rejected operation: {result.stderr.strip() or result.stdout.strip()}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise DistributionError("outbound queue returned invalid receipt metadata") from error
+
+
+def _project_calendar(arguments: argparse.Namespace, record: dict[str, Any]) -> None:
+    if not arguments.calendar_db:
+        return
+    if arguments.calendar_schedule_id is None:
+        raise DistributionError("--calendar-db requires --calendar-schedule-id")
+    database = sqlite3.connect(arguments.calendar_db)
+    try:
+        database.execute(
+            "UPDATE schedule SET distribution_id=?,operation_id=?,operation_state=?,remote_id=? WHERE id=?",
+            (record["source_id"], record["operation_id"], record["status"], record.get("provider_remote_id"), arguments.calendar_schedule_id),
+        )
+        if database.total_changes != 1:
+            raise DistributionError("calendar schedule is unavailable")
+        database.commit()
+    finally:
+        database.close()
+
+
+def _record(arguments: argparse.Namespace, state: str, receipt: dict[str, Any] | None = None) -> dict[str, Any]:
+    campaign_dir, manifest, _output, channel, source_id, intent_key = _source(arguments)
+    record = {
+        "version": 1, "source_id": source_id, "campaign_id": manifest["campaign_id"], "channel": channel,
+        "operation_id": _operation_id(source_id, intent_key), "intent_key": intent_key,
+        "scheduled_at": int(arguments.scheduled_at), "status": state, "provider_remote_id": None,
+        "updated_at": int(time.time()),
+    }
+    if receipt:
+        record["status"] = receipt.get("state", state)
+        record["provider_remote_id"] = receipt.get("provider_remote_id")
+    if record["status"] not in PUBLIC_STATES | {"preview"}:
+        raise DistributionError("outbound queue returned an unsupported operation state")
+    _write_record(campaign_dir, record)
+    _project_calendar(arguments, record)
+    return record
+
+
+def command_preview(arguments: argparse.Namespace) -> int:
+    campaign_dir, manifest, _output, channel, source_id, intent_key = _source(arguments)
+    del campaign_dir
+    record = {
+        "version": 1, "source_id": source_id, "campaign_id": manifest["campaign_id"], "channel": channel,
+        "operation_id": _operation_id(source_id, intent_key), "intent_key": intent_key,
+        "scheduled_at": int(arguments.scheduled_at), "status": "preview", "provider_remote_id": None,
+        "updated_at": int(time.time()),
+    }
+    # Preview is intentionally non-mutating: it does not write a record, calendar
+    # row, queue operation, approval, or invoke a provider.
+    print(json.dumps(record, sort_keys=True))
+    return 0
+
+
+def _private_copy(output: Path) -> Path:
+    descriptor, name = tempfile.mkstemp(prefix="campaign-distribution-", text=True)
+    path = Path(name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(output.read_bytes())
+        return path
+    except BaseException:
+        os.close(descriptor)
+        path.unlink(missing_ok=True)
+        raise
+
+
+def command_enqueue(arguments: argparse.Namespace) -> int:
+    campaign_dir, _manifest, output, channel, source_id, intent_key = _source(arguments)
+    operation_id = _operation_id(source_id, intent_key)
+    body = _private_copy(output)
+    try:
+        command = ["operation-create", "--alias", arguments.alias, "--connection-id", arguments.connection_id,
+                   "--account-id", arguments.account_id, "--action", "post", "--body-file", str(body),
+                   "--scheduled-at", str(arguments.scheduled_at), "--operation-id", operation_id]
+        if arguments.base:
+            command.extend(["--base", arguments.base])
+        if channel == "reddit":
+            if not arguments.destination_id or not arguments.subject:
+                raise DistributionError("Reddit distribution requires --destination-id and --subject")
+            subject = _private_copy(Path(arguments.subject)) if Path(arguments.subject).is_file() else None
+            if subject is None:
+                raise DistributionError("Reddit --subject must name a reviewed private subject file")
+            try:
+                command.extend(["--destination-id", arguments.destination_id, "--subject-file", str(subject)])
+                receipt = _queue(arguments, command)
+            finally:
+                subject.unlink(missing_ok=True)
+        else:
+            receipt = _queue(arguments, command)
+    finally:
+        body.unlink(missing_ok=True)
+    if arguments.approve_until is not None:
+        if arguments.approve_until <= int(time.time()):
+            raise DistributionError("--approve-until must be a future epoch")
+        approval = ["operation-approve", "--alias", arguments.alias, "--operation-id", operation_id,
+                    "--expires-at", str(arguments.approve_until)]
+        if arguments.base:
+            approval.extend(["--base", arguments.base])
+        receipt = _queue(arguments, approval)
+    record = _record(arguments, receipt["state"], receipt)
+    print(json.dumps(record, sort_keys=True))
+    return 0
+
+
+def command_status(arguments: argparse.Namespace) -> int:
+    campaign_dir, _manifest, _output, _channel, source_id, intent_key = _source(arguments)
+    operation_id = _operation_id(source_id, intent_key)
+    command = ["operations-list", "--alias", arguments.alias, "--operation-id", operation_id]
+    if arguments.base:
+        command.extend(["--base", arguments.base])
+    result = _queue(arguments, command)
+    if not result:
+        raise DistributionError("outbound operation is unavailable")
+    record = _record(arguments, result[0]["state"], result[0])
+    print(json.dumps(record, sort_keys=True))
+    return 0
+
+
+def command_reconcile(arguments: argparse.Namespace) -> int:
+    _campaign_dir, _manifest, _output, _channel, source_id, intent_key = _source(arguments)
+    command = ["operation-reconcile", "--alias", arguments.alias, "--operation-id", _operation_id(source_id, intent_key),
+               "--outcome", arguments.outcome]
+    if arguments.provider_id:
+        command.extend(["--provider-id", arguments.provider_id])
+    if arguments.base:
+        command.extend(["--base", arguments.base])
+    receipt = _queue(arguments, command)
+    record = _record(arguments, receipt["state"], receipt)
+    print(json.dumps(record, sort_keys=True))
+    return 0
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--campaign-dir", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--channel")
+    parser.add_argument("--output")
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--scheduled-at", type=int, required=True)
+    parser.add_argument("--alias", default="workspace:default")
+    parser.add_argument("--base")
+    parser.add_argument("--calendar-db")
+    parser.add_argument("--calendar-schedule-id", type=int)
+    parser.add_argument("--queue-helper", default=str(DEFAULT_QUEUE_HELPER))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    preview = commands.add_parser("preview")
+    _common(preview)
+    preview.set_defaults(handler=command_preview)
+    enqueue = commands.add_parser("enqueue")
+    _common(enqueue)
+    enqueue.add_argument("--destination-id")
+    enqueue.add_argument("--subject")
+    enqueue.add_argument("--approve-until", type=int)
+    enqueue.set_defaults(handler=command_enqueue)
+    status = commands.add_parser("status")
+    _common(status)
+    status.set_defaults(handler=command_status)
+    reconcile = commands.add_parser("reconcile")
+    _common(reconcile)
+    reconcile.add_argument("--outcome", choices=("succeeded", "not-sent"), required=True)
+    reconcile.add_argument("--provider-id")
+    reconcile.set_defaults(handler=command_reconcile)
+    arguments = parser.parse_args()
+    return arguments.handler(arguments)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (DistributionError, ManifestError) as error:
+        print(f"campaign distribution: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/.agents/scripts/campaign-distribution-helper.py
+++ b/.agents/scripts/campaign-distribution-helper.py
@@ -116,9 +116,13 @@ def _write_record(campaign_dir: Path, record: dict[str, Any]) -> None:
 
 def _queue(arguments: argparse.Namespace, command: list[str]) -> Any:
     helper = Path(arguments.queue_helper).resolve()
-    if not helper.is_file():
+    if not helper.is_file() or not os.access(helper, os.X_OK):
         raise DistributionError("outbound queue helper is unavailable")
-    result = subprocess.run([str(helper), *command], text=True, capture_output=True, check=False)
+    # The executable is a locally resolved, executable queue helper; command values
+    # are passed as a fixed argument vector rather than through a shell.
+    result = subprocess.run(  # nosec B603
+        [str(helper), *command], text=True, capture_output=True, check=False
+    )
     if result.returncode != 0:
         raise DistributionError(f"outbound queue rejected operation: {result.stderr.strip() or result.stdout.strip()}")
     try:

--- a/.agents/scripts/campaign-helper.sh
+++ b/.agents/scripts/campaign-helper.sh
@@ -60,9 +60,10 @@ readonly CAMPAIGNS_LEARNINGS_FILE="learnings.md"
 readonly CAMPAIGNS_DRAFTS_DIR="drafts"
 readonly CAMPAIGNS_INTAKE_FILE="intake.json"
 readonly CAMPAIGNS_CHANNEL_SPECS="${SCRIPT_DIR}/../configs/campaign-channel-specs.json"
-readonly CAMPAIGNS_VALID_CHANNELS="facebook instagram linkedin twitter email blog"
+readonly CAMPAIGNS_VALID_CHANNELS="facebook instagram linkedin twitter reddit email blog"
 readonly CAMPAIGN_RESEARCH_HELPER="${SCRIPT_DIR}/campaign-research-helper.py"
 readonly CAMPAIGN_PRODUCTION_HELPER="${SCRIPT_DIR}/campaign-production-helper.py"
+readonly CAMPAIGN_DISTRIBUTION_HELPER="${SCRIPT_DIR}/campaign-distribution-helper.py"
 
 # ---------------------------------------------------------------------------
 # Error helpers — centralise repeated messages to satisfy string-literal ratchet
@@ -170,8 +171,8 @@ _next_campaign_id() {
 		current="$(cat "$counter_file" 2>/dev/null || echo "0")"
 		[[ "$current" =~ ^[0-9]+$ ]] || current=0
 	fi
-	local next=$(( current + 1 ))
-	printf '%d' "$next" > "$counter_file"
+	local next=$((current + 1))
+	printf '%d' "$next" >"$counter_file"
 	printf 'c%03d' "$next"
 	return 0
 }
@@ -195,7 +196,7 @@ _read_validated_intake() {
 		(.objectives | type == $json_array and length > 0) and (.audiences | type == $json_array and length > 0) and
 		(.positioning | type == $json_object) and (.positioning.statement | type == $json_string and length > 0) and (.proof | type == $json_array and length > 0) and
 		(all(.proof[]; type == $json_object and (.claim | type == $json_string and length > 0) and (.evidence_reference | type == $json_string and length > 0 and test("^(?!/)(?!~)(?!.*(^|/)\\.\\.(/|$)).+")) and (.approval_status | IN($approved, $pending, $rejected)))) and
-		(.channels | type == $json_array and length > 0 and all(.[]; IN("facebook", "instagram", "linkedin", "twitter", "email", "blog"))) and
+		(.channels | type == $json_array and length > 0 and all(.[]; IN("facebook", "instagram", "linkedin", "twitter", "reddit", "email", "blog"))) and
 		(.dates | type == $json_object) and (.dates.start | type == $json_string and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) and (.dates.end | type == $json_string and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) and .dates.start <= .dates.end and
 		(.kpis | type == $json_array and length > 0) and (.disclosures | type == $json_array) and (.sensitivity | IN("public", "internal", "sensitive")) and
 		(.approvals | type == $json_object) and (.approvals.owner | type == $json_string and length > 0) and (.approvals.claims | IN($approved, $pending, $required)) and (.approvals.creative | IN($approved, $pending, $required))
@@ -1400,6 +1401,10 @@ main() {
 	production)
 		[[ -f "$CAMPAIGN_PRODUCTION_HELPER" ]] || { print_error "Campaign production helper not found: ${CAMPAIGN_PRODUCTION_HELPER}"; return 1; }
 		python3 "$CAMPAIGN_PRODUCTION_HELPER" "$@"
+		;;
+	distribution)
+		[[ -f "$CAMPAIGN_DISTRIBUTION_HELPER" ]] || { print_error "Campaign distribution helper not found: ${CAMPAIGN_DISTRIBUTION_HELPER}"; return 1; }
+		python3 "$CAMPAIGN_DISTRIBUTION_HELPER" "$@"
 		;;
 	research)
 		[[ -x "$CAMPAIGN_RESEARCH_HELPER" || -f "$CAMPAIGN_RESEARCH_HELPER" ]] || { print_error "Campaign research helper not found: ${CAMPAIGN_RESEARCH_HELPER}"; return 1; }

--- a/.agents/scripts/campaign_production_contract.py
+++ b/.agents/scripts/campaign_production_contract.py
@@ -11,7 +11,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-CHANNELS = {"facebook", "instagram", "linkedin", "twitter", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"}
+CHANNELS = {"facebook", "instagram", "linkedin", "twitter", "reddit", "email", "blog", "youtube", "short-form", "social-linkedin", "social-reddit", "social-x", "podcast"}
 ASSET_OWNERS = {"writing": "content/production-writing.md", "image": "content/production-image.md", "video": "content/production-video.md", "audio": "content/production-audio.md", "editor": "tools/video/video-editor.md"}
 DEFAULT_FORMATS = {
     "facebook": ("image", "1:1", None), "instagram": ("image", "4:5", None),
@@ -19,7 +19,7 @@ DEFAULT_FORMATS = {
     "email": ("writing", "text", None), "blog": ("writing", "text", None),
     "youtube": ("video", "16:9", 60), "short-form": ("video", "9:16", 30),
     "social-linkedin": ("image", "1.91:1", None), "social-reddit": ("writing", "text", None),
-    "social-x": ("writing", "text", None), "podcast": ("audio", "audio", 300),
+    "social-x": ("writing", "text", None), "reddit": ("writing", "text", None), "podcast": ("audio", "audio", 300),
 }
 
 

--- a/.agents/scripts/content-calendar-helper.sh
+++ b/.agents/scripts/content-calendar-helper.sh
@@ -108,6 +108,14 @@ validate_positive_int() {
 	return 0
 }
 
+# Validate a real Gregorian calendar date without accepting platform-specific
+# normalisation such as 2026-02-30.
+validate_calendar_date() {
+	local value="$1"
+	python3 -c 'import datetime, sys; datetime.date.fromisoformat(sys.argv[1])' "$value" >/dev/null 2>&1 || return 1
+	return 0
+}
+
 # =============================================================================
 # Database Initialization
 # =============================================================================
@@ -139,6 +147,10 @@ init_db() {
             scheduled_time  TEXT DEFAULT '',
             status          TEXT DEFAULT 'scheduled',
             published_url   TEXT DEFAULT '',
+            distribution_id TEXT DEFAULT '',
+            operation_id    TEXT DEFAULT '',
+            operation_state TEXT DEFAULT '',
+            remote_id       TEXT DEFAULT '',
             created_at      TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
             FOREIGN KEY (content_id) REFERENCES content_items(id)
         );
@@ -156,12 +168,18 @@ init_db() {
 
         CREATE INDEX IF NOT EXISTS idx_schedule_date ON schedule(scheduled_date);
         CREATE INDEX IF NOT EXISTS idx_schedule_platform ON schedule(platform);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_schedule_idempotency ON schedule(content_id, platform, scheduled_date, scheduled_time);
         CREATE INDEX IF NOT EXISTS idx_content_stage ON content_items(stage);
         CREATE INDEX IF NOT EXISTS idx_cadence_platform ON cadence_log(platform, post_date);
     " 2>/dev/null || {
 		print_error "Failed to initialize content calendar database"
 		return 1
 	}
+	# Existing calendars retain their rows; new nullable bridge projection columns
+	# are added independently because CREATE TABLE does not migrate old databases.
+	for column in distribution_id operation_id operation_state remote_id; do
+		sqlite3 "$CC_DB" "ALTER TABLE schedule ADD COLUMN ${column} TEXT DEFAULT '';" 2>/dev/null || true
+	done
 
 	return 0
 }
@@ -364,9 +382,17 @@ cmd_schedule() {
 		return 1
 	fi
 
-	# Validate date format
+	# Validate an actual UTC calendar date and optional time, not only its shape.
 	if ! [[ "$sched_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
 		print_error "Invalid date format. Use YYYY-MM-DD"
+		return 1
+	fi
+	if ! validate_calendar_date "$sched_date"; then
+		print_error "Invalid calendar date: ${sched_date}"
+		return 1
+	fi
+	if [[ -n "$sched_time" && ! "$sched_time" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+		print_error "Invalid time format. Use HH:MM (UTC)"
 		return 1
 	fi
 
@@ -380,9 +406,18 @@ cmd_schedule() {
 		return 1
 	fi
 
+	local escaped_platform escaped_date escaped_time
+	escaped_platform="$(sql_escape "$platform")"
+	escaped_date="$(sql_escape "$sched_date")"
+	escaped_time="$(sql_escape "$sched_time")"
+	if sqlite3 "$CC_DB" "SELECT 1 FROM schedule WHERE content_id=${content_id} AND platform='${escaped_platform}' AND scheduled_date='${escaped_date}' AND scheduled_time='${escaped_time}' LIMIT 1;" | grep -q 1; then
+		print_error "An identical schedule already exists for content item #${content_id}"
+		return 1
+	fi
+
 	sqlite3 "$CC_DB" "
         INSERT INTO schedule (content_id, platform, scheduled_date, scheduled_time)
-        VALUES (${content_id}, '${platform}', '${sched_date}', '${sched_time}');
+        VALUES (${content_id}, '${escaped_platform}', '${escaped_date}', '${escaped_time}');
     "
 
 	local title

--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -573,6 +573,36 @@ write_run_summary() {
 	return 0
 }
 
+# Emit only stable source references for a manifest-ready channel prompt. These
+# references let the campaign distribution bridge consume reviewed outputs later
+# without treating generated prompts as approved assets.
+# Args: output_dir plan_id channel
+write_distribution_reference() {
+	local output_dir="$1"
+	local plan_id="$2"
+	local channel="$3"
+	local reference="${output_dir}/${channel}/distribution-reference.json"
+
+	case "$channel" in
+	social-x) channel="x" ;;
+	social-reddit) channel="reddit" ;;
+	*) return 0 ;;
+	esac
+
+	{
+		printf '{\n'
+		printf '  "version": 1,\n'
+		printf '  "source": "fanout:%s:%s",\n' "$plan_id" "$channel"
+		printf '  "channel": "%s",\n' "$channel"
+		printf '  "status": "prompts_ready",\n'
+		printf '  "bridge": "campaign-distribution-helper.py",\n'
+		printf '  "requires": ["approved production manifest", "verified output", "queue approval"]\n'
+		printf '}\n'
+	} >"$reference"
+
+	return 0
+}
+
 # ─── Commands ─────────────────────────────────────────────────────────
 
 cmd_plan() {
@@ -659,6 +689,7 @@ _generate_channel_prompts() {
 			"$PLAN_TONE" "$PLAN_CTA" "$PLAN_NOTES" \
 			"${ch_dir}/prompt.md"
 		write_manifest_ready_job "$ch" "$PLAN_ID" "${ch_dir}/prompt.md" "${ch_dir}/manifest-ready.job"
+		write_distribution_reference "$output_dir" "$PLAN_ID" "$ch"
 
 		echo "pending" >"${ch_dir}/.status"
 		completed=$((completed + 1))

--- a/.agents/scripts/tests/test-campaign-distribution-bridge.py
+++ b/.agents/scripts/tests/test-campaign-distribution-bridge.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic contracts for reviewed campaign distribution queue bridging."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER = REPO_ROOT / ".agents" / "scripts" / "campaign-distribution-helper.py"
+
+
+class CampaignDistributionBridgeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.campaign = self.root / "campaign"
+        output = self.campaign / "creative" / "post.txt"
+        output.parent.mkdir(parents=True)
+        output.write_text("Reviewed launch post", encoding="utf-8")
+        digest = "sha256:" + hashlib.sha256(output.read_bytes()).hexdigest()
+        self.manifest = self.campaign / "drafts" / "production-manifests" / "twitter-v1.json"
+        self.manifest.parent.mkdir(parents=True)
+        self.manifest.write_text(json.dumps({
+            "schema_version": 1, "job_id": "job:c001:x:v1", "campaign_id": "c001", "brief_id": "brief:c001",
+            "channel": "twitter", "variant_id": "v1", "revision": 1, "input_snapshot_sha256": "sha256:" + "a" * 64,
+            "format": {"asset_class": "writing", "dimensions": "text", "duration_seconds": None}, "asset_inputs": [],
+            "execution": {"owner": "content", "provider_route": None, "capability": "writing", "fallback": None, "status": "ready"},
+            "authenticity": {"disclosure_requirements": [], "rights_requirements": [], "provenance": {"source": "owned", "recipe_sha256": "sha256:" + "b" * 64}, "rights_clearance": {"license": "owned", "consent": "documented", "territory": "global", "expires_at": None}},
+            "review": {"criteria": ["reviewed"], "status": "approved", "decision_by": "owner", "decision_at": "2026-08-13T00:00:00Z"},
+            "experiment": {"experiment_id": "e1", "hypothesis": "test"}, "lifecycle": {"status": "approved", "status_evidence": ["reviewed"]},
+            "outputs": [{"path": "creative/post.txt", "sha256": digest, "media_type": "text/plain"}],
+        }), encoding="utf-8")
+        self.queue = self.root / "queue.sh"
+        self.queue.write_text("#!/usr/bin/env bash\nprintf '%s\\n' '{\"operation_id\":\"ignored\",\"state\":\"draft\"}'\n", encoding="utf-8")
+        self.queue.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _command(self, action: str, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["python3", str(HELPER), action, "--campaign-dir", str(self.campaign), "--manifest", str(self.manifest), "--connection-id", "conn", "--account-id", "account", "--scheduled-at", "2000000000", "--queue-helper", str(self.queue), *extra], text=True, capture_output=True, check=False)
+
+    def test_preview_is_dry_run_and_stable(self) -> None:
+        first = self._command("preview")
+        second = self._command("preview")
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(json.loads(first.stdout)["operation_id"], json.loads(second.stdout)["operation_id"])
+        self.assertFalse((self.campaign / "distribution").exists())
+
+    def test_enqueue_is_idempotent_and_projects_calendar_state(self) -> None:
+        database = self.root / "calendar.db"
+        connection = sqlite3.connect(database)
+        connection.execute("CREATE TABLE schedule (id INTEGER PRIMARY KEY, distribution_id TEXT, operation_id TEXT, operation_state TEXT, remote_id TEXT)")
+        connection.execute("INSERT INTO schedule VALUES (1, '', '', '', '')")
+        connection.commit()
+        connection.close()
+        first = self._command("enqueue", "--calendar-db", str(database), "--calendar-schedule-id", "1")
+        second = self._command("enqueue", "--calendar-db", str(database), "--calendar-schedule-id", "1")
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(json.loads(first.stdout)["operation_id"], json.loads(second.stdout)["operation_id"])
+        record = next((self.campaign / "distribution").glob("*.json"))
+        self.assertEqual(json.loads(record.read_text(encoding="utf-8"))["status"], "draft")
+        connection = sqlite3.connect(database)
+        state = connection.execute("SELECT operation_state FROM schedule WHERE id=1").fetchone()[0]
+        connection.close()
+        self.assertEqual(state, "draft")
+
+    def test_unreviewed_manifest_cannot_enqueue(self) -> None:
+        document = json.loads(self.manifest.read_text(encoding="utf-8"))
+        document["review"]["status"] = "required"
+        self.manifest.write_text(json.dumps(document), encoding="utf-8")
+        result = self._command("enqueue")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("approved review", result.stderr)
+
+    def test_unknown_queue_receipt_is_preserved(self) -> None:
+        self.queue.write_text("#!/usr/bin/env bash\nprintf '%s\\n' '{\"operation_id\":\"ignored\",\"state\":\"unknown\"}'\n", encoding="utf-8")
+        result = self._command("enqueue")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["status"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-campaign-distribution-bridge.py
+++ b/.agents/scripts/tests/test-campaign-distribution-bridge.py
@@ -10,6 +10,7 @@ import json
 import os
 import sqlite3
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -47,7 +48,12 @@ class CampaignDistributionBridgeTests(unittest.TestCase):
         self.temp.cleanup()
 
     def _command(self, action: str, *extra: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(["python3", str(HELPER), action, "--campaign-dir", str(self.campaign), "--manifest", str(self.manifest), "--connection-id", "conn", "--account-id", "account", "--scheduled-at", "2000000000", "--queue-helper", str(self.queue), *extra], text=True, capture_output=True, check=False)
+        return subprocess.run(  # nosec B603
+            [sys.executable, str(HELPER), action, "--campaign-dir", str(self.campaign), "--manifest", str(self.manifest), "--connection-id", "conn", "--account-id", "account", "--scheduled-at", "2000000000", "--queue-helper", str(self.queue), *extra],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
 
     def test_preview_is_dry_run_and_stable(self) -> None:
         first = self._command("preview")

--- a/.agents/scripts/tests/test-campaign-production-manifest.sh
+++ b/.agents/scripts/tests/test-campaign-production-manifest.sh
@@ -72,14 +72,14 @@ test_unsupported_capability_and_invalid_promotion() {
 }
 
 test_fanout_manifest_ready_job_is_not_an_asset() {
-	local root brief plan output job
+	local root brief plan output job reference
 	root="$(mktemp -d "${TMPDIR:-/tmp}/campaign-production.XXXXXX")"
 	brief="$root/story.md"
 	cat > "$brief" <<'BRIEF'
 topic: Evidence-led campaign production
 angle: Truthful lifecycle status
 audience: Marketing owners
-channels: social-linkedin
+channels: social-linkedin, social-x
 tone: practical
 cta: Review the manifest
 notes: Contract fixture
@@ -87,10 +87,16 @@ BRIEF
 	plan="$(bash "$FANOUT_HELPER" plan "$brief" 2>&1 | grep 'Plan written:' | sed 's/.*Plan written: //')"
 	output="$(bash "$FANOUT_HELPER" run "$plan" 2>&1 | grep 'Output dir:' | sed 's/.*Output dir: *//')"
 	job="$output/social-linkedin/manifest-ready.job"
+	reference="$output/social-x/distribution-reference.json"
 	if [[ -f "$job" ]] && grep -q '^status: prompts_ready$' "$job" && grep -q '^outputs: \[\]$' "$job" && grep -q 'no asset has been generated' "$job"; then
 		_pass "fan-out exports manifest-ready prompts without claiming assets"
 	else
 		_fail "fan-out manifest-ready job overstated lifecycle status"
+	fi
+	if [[ -f "$reference" ]] && jq -e '.channel == "x" and .status == "prompts_ready" and (.requires | index("queue approval"))' "$reference" >/dev/null; then
+		_pass "fan-out exposes a non-executing X distribution reference"
+	else
+		_fail "fan-out did not expose a safe distribution reference"
 	fi
 	rm -rf "$root"
 	return 0

--- a/.agents/scripts/tests/test-content-calendar-safety.sh
+++ b/.agents/scripts/tests/test-content-calendar-safety.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+HELPER="${REPO_ROOT}/.agents/scripts/content-calendar-helper.sh"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/calendar-safety.XXXXXX")"
+trap 'rm -rf "${TEST_HOME}"' EXIT
+
+HOME="${TEST_HOME}" bash "${HELPER}" add "Safety fixture" >/dev/null
+HOME="${TEST_HOME}" bash "${HELPER}" schedule 1 2026-08-20 x --time 12:30 >/dev/null
+if HOME="${TEST_HOME}" bash "${HELPER}" schedule 1 2026-08-20 x --time 12:30 >/dev/null 2>&1; then
+	printf 'FAIL: duplicate schedule was accepted\n' >&2
+	exit 1
+fi
+if HOME="${TEST_HOME}" bash "${HELPER}" schedule 1 2026-02-30 x >/dev/null 2>&1; then
+	printf 'FAIL: invalid calendar date was accepted\n' >&2
+	exit 1
+fi
+if HOME="${TEST_HOME}" bash "${HELPER}" schedule 1 2026-08-20 x --time 25:00 >/dev/null 2>&1; then
+	printf 'FAIL: invalid time was accepted\n' >&2
+	exit 1
+fi
+DB="${TEST_HOME}/.aidevops/.agent-workspace/work/content-calendar/calendar.db"
+sqlite3 "${DB}" 'PRAGMA table_info(schedule);' | grep -q '|operation_state|'
+printf 'PASS: content calendar validates dates, times, duplicate schedules, and bridge migration\n'


### PR DESCRIPTION
## Summary

Recovers the prior bridge implementation and hardens subprocess execution so campaign enqueue calls only a resolved executable queue helper through an argument vector.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/configs/campaign-channel-specs.json, .agents/schemas/campaign-distribution.schema.json, .agents/schemas/campaign-intake.schema.json, .agents/schemas/content-production-manifest.schema.json, .agents/scripts/campaign-distribution-helper.py, .agents/scripts/campaign-helper.sh, .agents/scripts/campaign_production_contract.py, .agents/scripts/content-calendar-helper.sh, .agents/scripts/content-fanout-helper.sh, .agents/scripts/tests/test-campaign-distribution-bridge.py, .agents/scripts/tests/test-campaign-production-manifest.sh, .agents/scripts/tests/test-content-calendar-safety.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-campaign-distribution-bridge.py; bash .agents/scripts/tests/test-content-calendar-safety.sh; bash .agents/scripts/tests/test-campaign-status-routing.sh; shellcheck .agents/scripts/campaign-helper.sh .agents/scripts/content-calendar-helper.sh .agents/scripts/content-fanout-helper.sh .agents/scripts/tests/test-content-calendar-safety.sh; .agents/scripts/linters-local.sh --changed

Resolves #30138


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 3m and 80,001 tokens on this as a headless worker.