### PR TITLE
GH#30197: prevent false CodeFactor systemic clusters

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -402,8 +402,16 @@ resolve_source_from_subject() {
 	if [[ -n "$pr_number" ]]; then
 		local pr_json
 		pr_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null || printf '{}')
-		local head_sha
+		local head_sha pr_state
 		head_sha=$(printf '%s\n' "$pr_json" | jq -r '.head.sha // empty')
+		pr_state=$(printf '%s\n' "$pr_json" | jq -r '.state // empty')
+		# A notification can remain unread after its PR was superseded, closed, or
+		# merged. Mining that stale check cannot identify a currently actionable
+		# systemic failure and can combine several abandoned iterations into a
+		# false cluster (GH#30197).
+		if [[ "$pr_state" != "open" ]] || [[ -z "$head_sha" ]]; then
+			return 1
+		fi
 		printf '%s\n' "pr|#${pr_number}|https://github.com/${repo_slug}/pull/${pr_number}|${pr_number}||${head_sha}"
 		return 0
 	fi
@@ -494,6 +502,33 @@ fetch_check_run_annotations_summary_json() {
 	fi
 
 	printf '%s\n' "$annotations" | jq -s -c '[.[] | select(((.path // "") | length) > 0 or ((.message // "") | length) > 0)][0:5]' 2>/dev/null || printf '%s\n' '[]'
+	return 0
+}
+
+codefactor_signature_from_annotations() {
+	local annotations_json="$1"
+	local finding_signature
+	finding_signature=$(printf '%s\n' "$annotations_json" | jq -r '
+		[
+			.[]
+			| {
+				severity: ({failure: 3, warning: 2, notice: 1}[.annotation_level] // 0),
+				finding: ((.message // .title // empty)
+				| gsub("[\\r\\n\\t]+"; " ")
+				| gsub("[[:space:]]+"; " ")
+				| sub("^[[:space:]]+"; "")
+				| sub("[[:space:]]+$"; ""))
+			}
+			| select(.finding | length > 0)
+		]
+		| sort_by([-.severity, .finding])
+		| .[0].finding // empty
+	' 2>/dev/null || printf '')
+	if [[ -n "$finding_signature" ]]; then
+		printf 'failure:codefactor.io:%s' "$finding_signature"
+	else
+		printf 'failure:codefactor.io'
+	fi
 	return 0
 }
 
@@ -682,6 +717,7 @@ process_failed_runs() {
 			fi
 			run_affected_paths="$affected_paths_json"
 			run_annotations=$(fetch_check_run_annotations_summary_json "$repo_slug" "$(printf '%s\n' "$run_json" | jq -r '.id // empty')")
+			signature=$(codefactor_signature_from_annotations "$run_annotations")
 		fi
 		if [[ "$source_kind" == "pr" ]] && [[ -n "$pr_number" ]] &&
 			{ [[ "$check_name" =~ [Cc]ode[Ff]actor ]] || [[ "$signature" == "failure:codefactor.io" ]]; }; then

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -74,10 +74,19 @@ gh() {
 		printf '%s\n' '{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}'
 		return 0
 	fi
+	if [[ "$_api" == "api" && "$_paginate" == "repos/marcusquinn/aidevops/pulls/25324" ]]; then
+		printf '%s\n' '{"state":"open","head":{"sha":"abc123"}}'
+		return 0
+	fi
+	if [[ "$_api" == "api" && "$_paginate" == "repos/marcusquinn/aidevops/pulls/25319" ]]; then
+		printf '%s\n' '{"state":"closed","head":{"sha":"def456"}}'
+		return 0
+	fi
 	return 1
 }
 
-cluster_json=$(cat <<'JSON'
+cluster_json=$(
+	cat <<'JSON'
 {
   "repo": "marcusquinn/aidevops",
   "check_name": "CodeFactor",
@@ -172,7 +181,8 @@ qlty_decorated_empty_sarif_cluster_json='{
   ]
 }'
 
-empty_evidence_cluster_json=$(cat <<'JSON'
+empty_evidence_cluster_json=$(
+	cat <<'JSON'
 {
   "repo": "marcusquinn/aidevops",
   "check_name": "ShellCheck",
@@ -185,7 +195,8 @@ empty_evidence_cluster_json=$(cat <<'JSON'
 JSON
 )
 
-events_json=$(cat <<'JSON'
+events_json=$(
+	cat <<'JSON'
 [
   {
     "repo": "marcusquinn/aidevops",
@@ -217,12 +228,20 @@ else
 fi
 paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
 annotations_json=$(fetch_check_run_annotations_summary_json "marcusquinn/aidevops" "123")
+mixed_annotation_signature=$(codefactor_signature_from_annotations '[{"annotation_level":"notice","message":"Starting a process with a partial executable path (B607)"},{"annotation_level":"warning","message":"subprocess call - check for execution of untrusted input. (B603)"}]')
 GH_MODE=fail
 failed_paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
 failed_annotations_json=$(fetch_check_run_annotations_summary_json "marcusquinn/aidevops" "123")
 GH_MODE=success
+open_source=$(resolve_source_from_subject "https://api.github.com/repos/marcusquinn/aidevops/pulls/25324" "marcusquinn/aidevops" "false")
+if closed_source=$(resolve_source_from_subject "https://api.github.com/repos/marcusquinn/aidevops/pulls/25319" "marcusquinn/aidevops" "false"); then
+	closed_source_status=0
+else
+	closed_source_status=$?
+fi
 
-failed_runs_json=$(cat <<'JSON'
+failed_runs_json=$(
+	cat <<'JSON'
 [
   {
     "name": "CodeFactor",
@@ -244,7 +263,8 @@ failed_runs_json=$(cat <<'JSON'
 ]
 JSON
 )
-checks_json=$(cat <<'JSON'
+checks_json=$(
+	cat <<'JSON'
 {"check_runs":[]}
 JSON
 )
@@ -283,8 +303,12 @@ assert_contains "fetch_pr_changed_paths_json returns unique sorted paths" '[".ag
 assert_equals "fetch_pr_changed_paths_json emits one JSON array on gh failure" '[]' "$failed_paths_json"
 assert_equals "fetch_check_run_annotations_summary_json returns provider annotations" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$annotations_json"
 assert_equals "fetch_check_run_annotations_summary_json emits one JSON array on gh failure" '[]' "$failed_annotations_json"
+assert_equals "CodeFactor signature selects the highest-severity finding" 'failure:codefactor.io:subprocess call - check for execution of untrusted input. (B603)' "$mixed_annotation_signature"
+assert_equals "resolve_source_from_subject retains open PR failures" 'pr|#25324|https://github.com/marcusquinn/aidevops/pull/25324|25324||abc123' "$open_source"
+assert_equals "resolve_source_from_subject rejects stale closed PR failures" "1" "$closed_source_status"
 assert_equals "process_failed_runs attaches paths to CodeFactor failure" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$codefactor_paths_json"
 assert_equals "process_failed_runs attaches annotations to CodeFactor failure" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$codefactor_annotations_json"
+assert_equals "process_failed_runs fingerprints CodeFactor findings" 'failure:codefactor.io:subprocess call: check for execution of untrusted input' "$(printf '%s\n' "$mined_events_json" | jq -r '.[0].signature')"
 assert_equals "process_failed_runs does not leak CodeFactor paths to later checks" '[]' "$shellcheck_paths_json"
 
 printf '\nTests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Filter stale closed-PR notifications and fingerprint CodeFactor events by their highest-severity annotation so unrelated findings cannot form one systemic cluster.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh, .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 33 focused miner tests, 28 signature-noise tests, 82 CI-pattern tests, ShellCheck, and linters-local --changed all pass

Resolves #30197


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.257 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 10m and 151,693 tokens on this with the user in an interactive session.