### PR TITLE
GH#30201: aggregate release for CodeFactor clustering fix

### DIFF
--- a/.agents/reference/release-publication-controls/controls-and-history.md
+++ b/.agents/reference/release-publication-controls/controls-and-history.md
@@ -289,10 +289,7 @@ receipts are irreversible publication boundaries. The exact branch base is
 - Aggregation PR #29867 reviews authorized OpenCode session metadata PR #29862
   at `31bd4c803423a14b7fb05713cb96c8fe7437dae5` and Tabby dry-run PR #29863 at
   `a716c1b61a139f89d964a00e0ad9a37737a3a7d7`; exact base is `ae4179a6e6bfbb4051f2434570cc36a26e9946b9`.
-- Aggregation PR #30195 reviews authorized PR #30188 at `21df5823366d2672c7c1a11f625828b3077e78b3` and PR #30191 at `5529ec3b8274a36c958add1cb421d82c7c755de0`; exact base is `5529ec3b8274a36c958add1cb421d82c7c755de0`.
-- Aggregation PR #30203 reviews the otherwise-unreleased merged sources after
-  v3.32.257: PRs #30169, #30188, #30191, #30194, #30195, #30196, #30198,
-  #30199, and #30200; exact base is `8f75d375c4ee7a499fb8582d04bbbc60bd4a5a6a`.
+- Aggregation PR #30195 reviews authorized PR #30188 at `21df5823366d2672c7c1a11f625828b3077e78b3` and PR #30191 at `5529ec3b8274a36c958add1cb421d82c7c755de0`; exact base is `5529ec3b8274a36c958add1cb421d82c7c755de0`. Aggregation PR #30203 reviews otherwise-unreleased PRs #30169, #30188, #30191, #30194, #30195, #30196, #30198, #30199, and #30200 after v3.32.257; exact base is `8f75d375c4ee7a499fb8582d04bbbc60bd4a5a6a`.
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls/controls-and-history.md
+++ b/.agents/reference/release-publication-controls/controls-and-history.md
@@ -290,6 +290,9 @@ receipts are irreversible publication boundaries. The exact branch base is
   at `31bd4c803423a14b7fb05713cb96c8fe7437dae5` and Tabby dry-run PR #29863 at
   `a716c1b61a139f89d964a00e0ad9a37737a3a7d7`; exact base is `ae4179a6e6bfbb4051f2434570cc36a26e9946b9`.
 - Aggregation PR #30195 reviews authorized PR #30188 at `21df5823366d2672c7c1a11f625828b3077e78b3` and PR #30191 at `5529ec3b8274a36c958add1cb421d82c7c755de0`; exact base is `5529ec3b8274a36c958add1cb421d82c7c755de0`.
+- Aggregation PR #30201 reviews the otherwise-unreleased merged sources after
+  v3.32.257: PRs #30169, #30188, #30191, #30194, #30195, #30196, #30198,
+  #30199, and #30200; exact base is `8f75d375c4ee7a499fb8582d04bbbc60bd4a5a6a`.
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls/controls-and-history.md
+++ b/.agents/reference/release-publication-controls/controls-and-history.md
@@ -290,7 +290,7 @@ receipts are irreversible publication boundaries. The exact branch base is
   at `31bd4c803423a14b7fb05713cb96c8fe7437dae5` and Tabby dry-run PR #29863 at
   `a716c1b61a139f89d964a00e0ad9a37737a3a7d7`; exact base is `ae4179a6e6bfbb4051f2434570cc36a26e9946b9`.
 - Aggregation PR #30195 reviews authorized PR #30188 at `21df5823366d2672c7c1a11f625828b3077e78b3` and PR #30191 at `5529ec3b8274a36c958add1cb421d82c7c755de0`; exact base is `5529ec3b8274a36c958add1cb421d82c7c755de0`.
-- Aggregation PR #30201 reviews the otherwise-unreleased merged sources after
+- Aggregation PR #30203 reviews the otherwise-unreleased merged sources after
   v3.32.257: PRs #30169, #30188, #30191, #30194, #30195, #30196, #30198,
   #30199, and #30200; exact base is `8f75d375c4ee7a499fb8582d04bbbc60bd4a5a6a`.
 Manual arbitrary-version package publication is intentionally unsupported. A


### PR DESCRIPTION
## Summary

Create the reviewed exact-tip aggregation manifest for every otherwise-unreleased PR merged after v3.32.257, including the false CodeFactor clustering fix.

## Files Changed

.agents/reference/release-publication-controls/controls-and-history.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — git diff --check; bun run typecheck

Resolves #30201


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 7m and 152,559 tokens on this with the user in an interactive session.