### PR TITLE
t18237: feat: add Meta and TikTok publishing adapters

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -3,8 +3,8 @@
 
 # Social Provider Account-Knowledge Capabilities
 
-This matrix is the planning contract for authenticated, read-only social corpus
-collection. It distinguishes implemented routes from candidate official APIs,
+This matrix is the planning contract for authenticated social corpus collection
+and approval-bound publishing. It distinguishes implemented routes from candidate official APIs,
 account exports, permission-gated access, explicit browser gaps, and categories
 for which no safe route has been verified. It does not authorize scraping or a
 platform mutation.
@@ -37,6 +37,7 @@ a claim that the route is enabled.
 | Facebook | **Live/Gate/Export** managed Page posts; **No/Export** personal profile | **No/Export** curated activity and per-post comments | **No/Export** | **No/Export** personal relationships | **No** | One managed-Page `/posts` stream; app review and Page authority remain explicit, with all personal-account categories excluded. |
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
+| TikTok | **Gate** selected-account video publishing | **No** | **No** messages/comments | **No** follows | **No** | Catalogued fixture-backed outbound post adapter; official transport, identity, media rights, and publish authority are runtime gates. |
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
 | Patreon | **Live/Gate** creator campaign posts | **No** patron curation or creator-side interaction history | **No** messages, comments, or mentions | **Live/Gate** minimized current creator memberships; **No** patron-owned memberships or subscriptions | **Live** creator campaigns, tiers, and benefits | Creator-owned campaign allowlist, exact read scopes, identity and ownership recheck, 99-request cap, opaque cursors, and a membership-services purpose gate; no patron-account collection. |
 | beehiiv | **Gate/Live/Partial/Export** confirmed posts and paywall-enforced free web content; **Export** drafts and archives | **No** subscriber-derived engagement statistics | **No** | **Gate/Export/No** subscriber records are excluded pending an explicit PII need and authorization | **Gate/No** segments and newsletter-list membership expose audience structure and are not collected | Explicit creator-ownership attestation plus one expected, singly visible publication; exact GET-only API-v2 routes, bounded page replay, 100-page cap, and no subscriber PII, premium expansion, remote media, dashboard automation, or mutation reachability. |
@@ -140,7 +141,15 @@ separate provider family.
   enables posts, authored replies, and mentions. `.agents/content/social-meta.md`
   records the official SDK/sample versions, account/app-review gates, scopes,
   pagination, retention boundary, export dispositions, and unsupported
-  categories checked on 2026-07-27.
+   categories checked on 2026-07-27.
+- **Approval-bound Meta/TikTok publishing:**
+  `.agents/scripts/_knowledge_social_{meta,tiktok}_outbound_provider.py` and
+  `.agents/scripts/tests/test-social-meta-tiktok-outbound.py` prove allowlisted
+  actions, identity binding, opaque idempotency keys, unavailable-by-default
+  operation, and unknown accepted-job recovery without campaign content or
+  credentials in receipts. `.agents/content/social-meta.md` and
+  `.agents/content/social-tiktok.md` define the product gates and unsupported
+  browser fallback.
 - **Live Medium export:** `.agents/scripts/knowledge_social_medium.py`,
   `.agents/scripts/_knowledge_social_medium*.py`, and
   `.agents/tests/test-knowledge-social-medium.sh` prove selected-account

--- a/.agents/configs/capability-registry.json
+++ b/.agents/configs/capability-registry.json
@@ -73,6 +73,17 @@
       "probes": {"deployed": {"path": "scripts/campaign-research-helper.py"}, "tool_visible": {"tool": "python3"}}
     },
     {
+      "name": "approval-bound-social-publishing",
+      "aliases": ["meta-publishing", "tiktok-publishing", "social-outbound"],
+      "owner": "Social",
+      "description": "Approved Meta and TikTok publishing through identity-bound official transports",
+      "runtimes": ["opencode", "claude-code"],
+      "entry_points": ["content/social-meta.md", "content/social-tiktok.md", "scripts/knowledge_social_operations.py"],
+      "fallback": "approval-required-manual-handoff",
+      "required": ["deployed", "configured", "authenticated", "authorized", "reachable", "usable"],
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_meta_outbound_provider.py"}, "configured": {"live": "requires selected official provider transport"}, "authenticated": {"live": "requires selected product token"}, "authorized": {"live": "requires exact identity and publish permission check"}, "reachable": {"live": "requires official provider health request"}, "usable": {"live": "requires approved intent and preflight"}}
+    },
+    {
       "name": "vault-operations",
       "aliases": ["vault", "protected-data", "encrypted-memory"],
       "owner": "Vault",

--- a/.agents/content/distribution-social.md
+++ b/.agents/content/distribution-social.md
@@ -1,6 +1,6 @@
 ---
 name: social
-description: Social media distribution - X, LinkedIn, Reddit platform-native content
+description: Social media distribution - approval-bound platform-native content
 mode: subagent
 model: standard
 ---
@@ -8,7 +8,7 @@ model: standard
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Social - X, LinkedIn, and Reddit Distribution
+# Social Distribution
 
 <!-- AI-CONTEXT-START -->
 
@@ -26,7 +26,10 @@ model: standard
 - **Professional framing on LinkedIn** — thought leadership, not sales pitch
 - **One idea per post** — clarity beats comprehensiveness
 
-**Platform Tools**: `content/social-xurl.md` (official X API), `content/social-bird.md` (X browser-cookie fallback), `content/social-linkedin.md`, `content/social-reddit.md`
+**Platform Tools**: `content/social-xurl.md` (official X API),
+`content/social-linkedin.md`, `content/social-reddit.md`, `content/social-meta.md`,
+and `content/social-tiktok.md`. Meta/TikTok writes require the approved outbound
+queue; unavailable capability states do not permit browser fallbacks.
 
 <!-- AI-CONTEXT-END -->
 
@@ -205,3 +208,5 @@ Happy to share more details on the research methodology if anyone's interested.
 **Distribution**: `content/distribution/youtube/`, `content/distribution/short-form.md`, `content/distribution/blog.md`, `content/distribution/email.md`, `content/distribution/podcast.md`
 
 **Tools**: `content/social-xurl.md` (official X API), `content/social-bird.md` (fallback), `content/social-linkedin.md`, `content/social-reddit.md`, `content/humanise.md` (AI pattern removal)
+
+**Approval-bound publishing**: `content/social-meta.md`, `content/social-tiktok.md`, and the outbound queue. Verify capability readiness, product identity, media rights, and an unexpired exact-intent approval before scheduling.

--- a/.agents/content/social-meta.md
+++ b/.agents/content/social-meta.md
@@ -1,5 +1,5 @@
 ---
-description: Bounded Facebook, Instagram, and Threads account knowledge ingestion
+description: Bounded Facebook, Instagram, and Threads account knowledge and approval-bound publishing
 mode: subagent
 tools:
   read: true
@@ -25,7 +25,9 @@ tools:
   and Threads posts, authored replies, or mentions
 - **Isolation**: one filtered token, stable identity, provider namespace, stream
   registry, checkpoint, and coverage record per product
-- **Mutation boundary**: collector modules issue only allowlisted `GET` requests
+- **Mutation boundary**: collectors issue only allowlisted `GET` requests; the
+  separate outbound queue exposes only approved, identity-rechecked publish
+  intents through fixture-backed official-provider adapters.
 
 <!-- AI-CONTEXT-END -->
 
@@ -174,3 +176,17 @@ separate approved browser-gap workflow.
 - The provider module has no mutation endpoint registry and every constructed
   HTTP request fixes `method="GET"`. It does not import browser or outbound
   operations modules.
+
+## Approval-bound publishing
+
+Facebook Page posts and replies, Instagram Professional media posts, and Threads
+posts/replies are catalogued outbound routes. They are unavailable until a
+product-specific official transport, exact managed identity, applicable publish
+permissions/app review, and approved queue intent are all ready. Personal
+profiles, messages, follower actions, and browser automation remain unsupported.
+
+The outbound adapter rechecks the selected identity before the provider boundary,
+binds each request to its immutable operation ID, and returns only opaque post or
+job IDs. Accepted-but-ambiguous provider results become `unknown`; reconcile by
+that stable ID rather than replaying a publish. Fixtures never contain tokens or
+campaign bodies, and the default adapter cannot perform a live mutation.

--- a/.agents/content/social-tiktok.md
+++ b/.agents/content/social-tiktok.md
@@ -1,0 +1,45 @@
+---
+description: Approval-bound TikTok publishing capability and identity gates
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# TikTok Publishing
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Route**: approval-bound outbound queue only
+- **Supported intent**: one selected-account video post with approved caption and
+  opaque media reference
+- **Required gates**: official transport, exact account identity, product write
+  authority, approved immutable intent, and immediate identity recheck
+- **Default state**: catalogued/deployed but unavailable without operator-configured
+  official credentials and transport
+
+<!-- AI-CONTEXT-END -->
+
+The adapter never uses browser automation, cookies, or a personal-account
+workaround. It receives no credential values from the queue. Operators provision
+any official token outside git through `aidevops secret set`; account scopes,
+app review, media rights, disclosure requirements, and product eligibility stay
+runtime gates.
+
+The queue binds every request to one operation ID for idempotency. Identity must
+match the approved account before a publish request. A stable accepted publish ID
+with an ambiguous result is recorded as `unknown` and must reconcile before any
+operator-approved follow-up; it is never blindly replayed. Receipts, diagnostics,
+and test fixtures retain opaque IDs and failure classes only, not captions,
+media, or credentials.
+
+Unsupported: comments, messages, likes, follows, browser/persona automation,
+and any account or media type not explicitly available through the official
+operator-configured transport.

--- a/.agents/scripts/_knowledge_social_meta_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_meta_outbound_provider.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixture-backed, approval-bound Meta outbound provider adapter.
+
+The production boundary intentionally stays unavailable until an operator wires
+an official transport.  Tests inject a small transport instead, keeping tokens,
+campaign bodies, and undocumented endpoint guesses outside this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import (
+    PreparedProvider,
+    ProviderAdapterError,
+    ProviderIdentityError,
+)
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+META_PRODUCTS = {
+    "meta_facebook": "facebook",
+    "meta_instagram": "instagram",
+    "meta_threads": "threads",
+}
+Transport = Callable[[dict[str, str]], dict[str, str]]
+
+
+def _product(claimed: ClaimedOperation) -> str:
+    product = META_PRODUCTS.get(claimed.provider)
+    if product is None:
+        raise ProviderAdapterError("Meta provider is not allowlisted")
+    return product
+
+
+def _request(claimed: ClaimedOperation) -> dict[str, str]:
+    product = _product(claimed)
+    if claimed.payload is None:
+        raise ProviderAdapterError("Meta write requires an approved private body")
+    request = {
+        "operation": "publish",
+        "product": product,
+        "action": claimed.action,
+        "account_id": claimed.remote_account_id,
+        "body": claimed.payload,
+        "idempotency_key": claimed.operation_id,
+    }
+    if claimed.target_remote_id is not None:
+        request["target_id"] = claimed.target_remote_id
+    if claimed.destination_remote_id is not None:
+        request["media_ref"] = claimed.destination_remote_id
+    return request
+
+
+@dataclass(frozen=True)
+class MetaPreparedProvider(PreparedProvider):
+    """Validate one selected Meta product before its official write transport."""
+
+    claimed: ClaimedOperation
+    transport: Transport | None = None
+
+    def verify_identity(self) -> None:
+        product = _product(self.claimed)
+        if self.transport is None:
+            raise ProviderIdentityError("Meta official outbound transport is unavailable")
+        try:
+            result = self.transport(
+                {
+                    "operation": "identity",
+                    "product": product,
+                    "account_id": self.claimed.remote_account_id,
+                }
+            )
+            actual = validate_opaque(str(result.get("id", "")), "Meta identity ID")
+        except (SocialStoreError, TypeError, ValueError) as error:
+            raise ProviderIdentityError("selected Meta identity could not be verified") from error
+        if actual != self.claimed.remote_account_id:
+            raise ProviderIdentityError("selected Meta identity does not match approved account")
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        if self.transport is None:
+            return None, "provider_unavailable"
+        try:
+            result = self.transport(_request(self.claimed))
+            state = result.get("state")
+            remote_id = result.get("id") or result.get("job_id")
+            if state == "succeeded" and isinstance(remote_id, str):
+                return validate_opaque(remote_id, "provider_remote_id"), None
+            if state in ("accepted", "unknown") and isinstance(remote_id, str):
+                return validate_opaque(remote_id, "provider_remote_id"), "runtime"
+            if state == "rate_limited":
+                return None, "provider_unavailable"
+        except (SocialStoreError, TypeError, ValueError):
+            return None, "validation"
+        return None, "provider_unavailable"

--- a/.agents/scripts/_knowledge_social_meta_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_meta_outbound_provider.py
@@ -27,6 +27,7 @@ META_PRODUCTS = {
     "meta_threads": "threads",
 }
 Transport = Callable[[dict[str, str]], dict[str, str]]
+ProviderOutcome = tuple[str | None, str | None]
 
 
 def _product(claimed: ClaimedOperation) -> str:
@@ -55,6 +56,17 @@ def _request(claimed: ClaimedOperation) -> dict[str, str]:
     return request
 
 
+def _provider_outcome(result: dict[str, str]) -> ProviderOutcome:
+    outcome: ProviderOutcome = (None, "provider_unavailable")
+    state = result.get("state")
+    remote_id = result.get("id") or result.get("job_id")
+    if state == "succeeded" and isinstance(remote_id, str):
+        outcome = (validate_opaque(remote_id, "provider_remote_id"), None)
+    elif state in ("accepted", "unknown") and isinstance(remote_id, str):
+        outcome = (validate_opaque(remote_id, "provider_remote_id"), "runtime")
+    return outcome
+
+
 @dataclass(frozen=True)
 class MetaPreparedProvider(PreparedProvider):
     """Validate one selected Meta product before its official write transport."""
@@ -81,18 +93,10 @@ class MetaPreparedProvider(PreparedProvider):
             raise ProviderIdentityError("selected Meta identity does not match approved account")
 
     def invoke(self) -> tuple[str | None, str | None]:
-        if self.transport is None:
-            return None, "provider_unavailable"
-        try:
-            result = self.transport(_request(self.claimed))
-            state = result.get("state")
-            remote_id = result.get("id") or result.get("job_id")
-            if state == "succeeded" and isinstance(remote_id, str):
-                return validate_opaque(remote_id, "provider_remote_id"), None
-            if state in ("accepted", "unknown") and isinstance(remote_id, str):
-                return validate_opaque(remote_id, "provider_remote_id"), "runtime"
-            if state == "rate_limited":
-                return None, "provider_unavailable"
-        except (SocialStoreError, TypeError, ValueError):
-            return None, "validation"
-        return None, "provider_unavailable"
+        outcome: ProviderOutcome = (None, "provider_unavailable")
+        if self.transport is not None:
+            try:
+                outcome = _provider_outcome(self.transport(_request(self.claimed)))
+            except (SocialStoreError, TypeError, ValueError):
+                outcome = (None, "validation")
+        return outcome

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -18,7 +18,11 @@ from knowledge_social_store import SocialStoreError, validate_opaque
 
 ACTIONS = ("post", "reply", "like", "bookmark")
 OUTBOUND_PROVIDER_ACTIONS = {
+    "meta_facebook": ("post", "reply"),
+    "meta_instagram": ("post",),
+    "meta_threads": ("post", "reply"),
     "reddit": ACTIONS,
+    "tiktok": ("post",),
     "xapi": ACTIONS,
 }
 TERMINAL_STATES = ("succeeded", "failed", "unknown", "cancelled")
@@ -166,6 +170,12 @@ def _validated_destination(
         if REDDIT_DESTINATION_ID.fullmatch(destination) is None:
             raise SocialStoreError("Reddit destination subreddit ID is invalid")
         return destination
+    if provider in ("meta_instagram", "tiktok") and action == "post":
+        if destination is None:
+            raise SocialStoreError(
+                "visual outbound posts require an approved opaque media reference"
+            )
+        return validate_opaque(destination, "destination_remote_id")
     if destination is not None:
         raise SocialStoreError("this outbound operation does not accept a destination")
     return None

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -325,8 +325,24 @@ def _prepare_reddit(claimed: ClaimedOperation) -> PreparedProvider:
     )
 
 
+def _prepare_meta(claimed: ClaimedOperation) -> PreparedProvider:
+    from _knowledge_social_meta_outbound_provider import MetaPreparedProvider
+
+    return MetaPreparedProvider(claimed)
+
+
+def _prepare_tiktok(claimed: ClaimedOperation) -> PreparedProvider:
+    from _knowledge_social_tiktok_outbound_provider import TikTokPreparedProvider
+
+    return TikTokPreparedProvider(claimed)
+
+
 PROVIDER_FACTORIES: dict[str, Callable[[ClaimedOperation], PreparedProvider]] = {
+    "meta_facebook": _prepare_meta,
+    "meta_instagram": _prepare_meta,
+    "meta_threads": _prepare_meta,
     "reddit": _prepare_reddit,
+    "tiktok": _prepare_tiktok,
     "xapi": _prepare_x,
 }
 

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -214,8 +214,11 @@ def _assert_outcome_fields(
     if status == "succeeded":
         if provider_remote_id is None or failure_class is not None:
             raise SocialStoreError("successful outbound receipt requires only a provider ID")
-    elif provider_remote_id is not None or failure_class is None:
-        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
+    elif status == "failed":
+        if provider_remote_id is not None or failure_class is None:
+            raise SocialStoreError("failed outbound receipt requires only a failure class")
+    elif failure_class is None:
+        raise SocialStoreError("unknown outbound receipt requires a failure class")
 
 
 def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:

--- a/.agents/scripts/_knowledge_social_tiktok_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_tiktok_outbound_provider.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixture-backed, approval-bound TikTok outbound provider adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import (
+    PreparedProvider,
+    ProviderAdapterError,
+    ProviderIdentityError,
+)
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+Transport = Callable[[dict[str, str]], dict[str, str]]
+
+
+@dataclass(frozen=True)
+class TikTokPreparedProvider(PreparedProvider):
+    """Validate the selected TikTok account and one video publish request."""
+
+    claimed: ClaimedOperation
+    transport: Transport | None = None
+
+    def _request(self) -> dict[str, str]:
+        if self.claimed.provider != "tiktok" or self.claimed.action != "post":
+            raise ProviderAdapterError("TikTok action is not allowlisted")
+        if self.claimed.payload is None or self.claimed.destination_remote_id is None:
+            raise ProviderAdapterError("TikTok post requires caption and media reference")
+        return {
+            "operation": "publish",
+            "account_id": self.claimed.remote_account_id,
+            "caption": self.claimed.payload,
+            "media_ref": self.claimed.destination_remote_id,
+            "idempotency_key": self.claimed.operation_id,
+        }
+
+    def verify_identity(self) -> None:
+        if self.transport is None:
+            raise ProviderIdentityError("TikTok official outbound transport is unavailable")
+        try:
+            result = self.transport(
+                {"operation": "identity", "account_id": self.claimed.remote_account_id}
+            )
+            actual = validate_opaque(str(result.get("id", "")), "TikTok identity ID")
+        except (SocialStoreError, TypeError, ValueError) as error:
+            raise ProviderIdentityError("selected TikTok identity could not be verified") from error
+        if actual != self.claimed.remote_account_id:
+            raise ProviderIdentityError("selected TikTok identity does not match approved account")
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        if self.transport is None:
+            return None, "provider_unavailable"
+        try:
+            result = self.transport(self._request())
+            state = result.get("state")
+            remote_id = result.get("id") or result.get("publish_id")
+            if state == "succeeded" and isinstance(remote_id, str):
+                return validate_opaque(remote_id, "provider_remote_id"), None
+            if state in ("accepted", "unknown") and isinstance(remote_id, str):
+                return validate_opaque(remote_id, "provider_remote_id"), "runtime"
+            if state == "rate_limited":
+                return None, "provider_unavailable"
+        except (ProviderAdapterError, SocialStoreError, TypeError, ValueError):
+            return None, "validation"
+        return None, "provider_unavailable"

--- a/.agents/scripts/_knowledge_social_tiktok_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_tiktok_outbound_provider.py
@@ -17,6 +17,18 @@ from _knowledge_social_outbound_provider import (
 from knowledge_social_store import SocialStoreError, validate_opaque
 
 Transport = Callable[[dict[str, str]], dict[str, str]]
+ProviderOutcome = tuple[str | None, str | None]
+
+
+def _provider_outcome(result: dict[str, str]) -> ProviderOutcome:
+    outcome: ProviderOutcome = (None, "provider_unavailable")
+    state = result.get("state")
+    remote_id = result.get("id") or result.get("publish_id")
+    if state == "succeeded" and isinstance(remote_id, str):
+        outcome = (validate_opaque(remote_id, "provider_remote_id"), None)
+    elif state in ("accepted", "unknown") and isinstance(remote_id, str):
+        outcome = (validate_opaque(remote_id, "provider_remote_id"), "runtime")
+    return outcome
 
 
 @dataclass(frozen=True)
@@ -53,18 +65,10 @@ class TikTokPreparedProvider(PreparedProvider):
             raise ProviderIdentityError("selected TikTok identity does not match approved account")
 
     def invoke(self) -> tuple[str | None, str | None]:
-        if self.transport is None:
-            return None, "provider_unavailable"
-        try:
-            result = self.transport(self._request())
-            state = result.get("state")
-            remote_id = result.get("id") or result.get("publish_id")
-            if state == "succeeded" and isinstance(remote_id, str):
-                return validate_opaque(remote_id, "provider_remote_id"), None
-            if state in ("accepted", "unknown") and isinstance(remote_id, str):
-                return validate_opaque(remote_id, "provider_remote_id"), "runtime"
-            if state == "rate_limited":
-                return None, "provider_unavailable"
-        except (ProviderAdapterError, SocialStoreError, TypeError, ValueError):
-            return None, "validation"
-        return None, "provider_unavailable"
+        outcome: ProviderOutcome = (None, "provider_unavailable")
+        if self.transport is not None:
+            try:
+                outcome = _provider_outcome(self.transport(self._request()))
+            except (ProviderAdapterError, SocialStoreError, TypeError, ValueError):
+                outcome = (None, "validation")
+        return outcome

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -163,13 +163,17 @@ def _unknown_provider_outcome(
     executor_id: str,
     failure_class: str,
     args: argparse.Namespace,
+    provider_remote_id: str | None = None,
 ) -> dict[str, Any]:
     return finalize_operation(
         database,
         claimed,
         executor_id,
         AttemptOutcome(
-            "unknown", failure_class=failure_class, finished_at=_clock(args)
+            "unknown",
+            provider_remote_id=provider_remote_id,
+            failure_class=failure_class,
+            finished_at=_clock(args),
         ),
     )
 
@@ -205,7 +209,7 @@ def _execute_claimed(
     provider_remote_id, failure_class = provider.invoke()
     if failure_class is not None:
         return _unknown_provider_outcome(
-            database, claimed, executor_id, failure_class, args
+            database, claimed, executor_id, failure_class, args, provider_remote_id
         )
     if provider_remote_id is None:
         raise OperationsError("successful provider outcome has no remote ID")

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -161,10 +161,10 @@ def _unknown_provider_outcome(
     database: sqlite3.Connection,
     claimed: ClaimedOperation,
     executor_id: str,
-    failure_class: str,
+    provider_outcome: tuple[str | None, str],
     args: argparse.Namespace,
-    provider_remote_id: str | None = None,
 ) -> dict[str, Any]:
+    provider_remote_id, failure_class = provider_outcome
     return finalize_operation(
         database,
         claimed,
@@ -209,7 +209,11 @@ def _execute_claimed(
     provider_remote_id, failure_class = provider.invoke()
     if failure_class is not None:
         return _unknown_provider_outcome(
-            database, claimed, executor_id, failure_class, args, provider_remote_id
+            database,
+            claimed,
+            executor_id,
+            (provider_remote_id, failure_class),
+            args,
         )
     if provider_remote_id is None:
         raise OperationsError("successful provider outcome has no remote ID")

--- a/.agents/scripts/tests/test-social-meta-tiktok-outbound.py
+++ b/.agents/scripts/tests/test-social-meta-tiktok-outbound.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic contract tests for approval-bound Meta and TikTok writes."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from _knowledge_social_meta_outbound_provider import MetaPreparedProvider
+from _knowledge_social_outbound import ClaimedOperation, OUTBOUND_PROVIDER_ACTIONS
+from _knowledge_social_outbound_provider import prepare_provider
+from _knowledge_social_tiktok_outbound_provider import TikTokPreparedProvider
+
+
+def claimed(
+    provider: str, *, account: str = "acct_approved", media_ref: str | None = None
+) -> ClaimedOperation:
+    """Build a private, already-approved publish claim for one fixture."""
+    return ClaimedOperation(
+        operation_id="op_idempotent",
+        provider=provider,
+        action="post",
+        remote_account_id=account,
+        target_remote_id=None,
+        destination_remote_id=media_ref,
+        payload="private campaign body",
+        subject=None,
+        app_profile=None,
+        username=None,
+        claim_token=1,
+        attempt_id="att_fixture",
+    )
+
+
+class MetaTikTokOutboundTests(unittest.TestCase):
+    """Prove identity, idempotency, unknown, and redaction boundaries."""
+
+    def test_registry_allows_only_documented_actions(self) -> None:
+        self.assertEqual(OUTBOUND_PROVIDER_ACTIONS["meta_facebook"], ("post", "reply"))
+        self.assertEqual(OUTBOUND_PROVIDER_ACTIONS["meta_instagram"], ("post",))
+        self.assertEqual(OUTBOUND_PROVIDER_ACTIONS["meta_threads"], ("post", "reply"))
+        self.assertEqual(OUTBOUND_PROVIDER_ACTIONS["tiktok"], ("post",))
+
+    def test_unconfigured_registry_adapter_cannot_reach_write_boundary(self) -> None:
+        adapter = prepare_provider(claimed("tiktok", media_ref="media_approved"))
+        with self.assertRaisesRegex(Exception, "transport is unavailable"):
+            adapter.verify_identity()
+        self.assertEqual(adapter.invoke(), (None, "provider_unavailable"))
+
+    def test_meta_publishes_after_exact_identity_and_returns_only_remote_id(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def transport(request: dict[str, str]) -> dict[str, str]:
+            calls.append(request)
+            if request["operation"] == "identity":
+                return {"id": "acct_approved"}
+            return {"state": "succeeded", "id": "post_opaque"}
+
+        adapter = MetaPreparedProvider(claimed("meta_threads"), transport)
+        adapter.verify_identity()
+        receipt = adapter.invoke()
+        self.assertEqual(receipt, ("post_opaque", None))
+        self.assertEqual(calls[1]["idempotency_key"], "op_idempotent")
+        self.assertNotIn("private campaign body", str(receipt))
+        self.assertEqual(len(calls), 2)
+
+    def test_identity_mismatch_makes_zero_publish_requests(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def transport(request: dict[str, str]) -> dict[str, str]:
+            calls.append(request)
+            return {"id": "acct_other"}
+
+        adapter = MetaPreparedProvider(claimed("meta_facebook"), transport)
+        with self.assertRaisesRegex(Exception, "does not match"):
+            adapter.verify_identity()
+        self.assertEqual([call["operation"] for call in calls], ["identity"])
+
+    def test_tiktok_accepted_publish_is_unknown_with_stable_publish_id(self) -> None:
+        def transport(request: dict[str, str]) -> dict[str, str]:
+            if request["operation"] == "identity":
+                return {"id": "acct_approved"}
+            return {"state": "accepted", "publish_id": "job_stable"}
+
+        adapter = TikTokPreparedProvider(
+            claimed("tiktok", media_ref="media_approved"), transport
+        )
+        adapter.verify_identity()
+        self.assertEqual(adapter.invoke(), ("job_stable", "runtime"))
+
+    def test_tiktok_requires_an_approved_media_reference(self) -> None:
+        adapter = TikTokPreparedProvider(
+            claimed("tiktok"), lambda _: {"id": "acct_approved"}
+        )
+        adapter.verify_identity()
+        self.assertEqual(adapter.invoke(), (None, "validation"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Added approval-bound Meta and TikTok outbound adapters with identity rechecks, immutable idempotency keys, opaque unknown-job receipts, provider readiness documentation, and hermetic tests.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/configs/capability-registry.json, .agents/content/distribution-social.md, .agents/content/social-meta.md, .agents/content/social-tiktok.md, .agents/scripts/_knowledge_social_meta_outbound_provider.py, .agents/scripts/_knowledge_social_outbound.py, .agents/scripts/_knowledge_social_outbound_provider.py, .agents/scripts/_knowledge_social_outbound_runtime.py, .agents/scripts/_knowledge_social_tiktok_outbound_provider.py, .agents/scripts/knowledge_social_operations.py, .agents/scripts/tests/test-social-meta-tiktok-outbound.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-social-meta-tiktok-outbound.py; bash .agents/tests/test-knowledge-social-operations.sh; .agents/scripts/linters-local.sh --changed; python3 -m json.tool .agents/configs/capability-registry.json

Resolves #30143


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 15m and 113,718 tokens on this as a headless worker.