### PR TITLE
t18235: feat: add LinkedIn and YouTube outbound adapters

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -3,8 +3,8 @@
 
 # Social Provider Account-Knowledge Capabilities
 
-This matrix is the planning contract for authenticated, read-only social corpus
-collection. It distinguishes implemented routes from candidate official APIs,
+This matrix is the planning contract for authenticated social corpus collection
+and approval-bound outbound distribution. It distinguishes implemented routes from candidate official APIs,
 account exports, permission-gated access, explicit browser gaps, and categories
 for which no safe route has been verified. It does not authorize scraping or a
 platform mutation.
@@ -32,8 +32,8 @@ a claim that the route is enabled.
 |---|---|---|---|---|---|---|
 | X | **Live** posts | **Live** likes and bookmarks | **Live** mentions | **Live** followers and following | **Live** owned/followed Lists and account memberships; **No** List timelines | Nine guarded `xurl` streams; bounded List snapshots rescan without inferring deletion. |
 | Reddit | **Live** submissions and comments | **Live** saved, votes, and hidden | **Live** mentions, replies, inbox, and sent | **Live** subreddit and account relationships | **Live** multireddits and membership | PRAW 8, bounded one-page reads, independent cursors, and provider-window coverage. |
-| YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | `youtube.readonly` user OAuth, identity recheck per page, bounded list quota, 30-day refresh/delete boundary, and explicit gap rows. |
-| LinkedIn | **Live/Gate/Export** posts and articles | **Live/Gate/Export** comments, reactions, and saved items | **Live/Gate/Export** messages | **Live/Gate/Export** follows, connections, company follows, and groups | **No** newsletter subscriptions | Ten GET-only Member Snapshot streams for eligible EEA/Swiss members; account download remains an unwired export fallback. |
+| YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | Read collector uses `youtube.readonly`; approved outbound video uploads are separately **Live/Gate**, exact-channel-bound, private-by-default, resumable-route only, and require upload authorization. |
+| LinkedIn | **Live/Gate/Export** posts and articles | **Live/Gate/Export** comments, reactions, and saved items | **Live/Gate/Export** messages | **Live/Gate/Export** follows, connections, company follows, and groups | **No** newsletter subscriptions | Ten GET-only Member Snapshot streams for eligible EEA/Swiss members; separately, approved member text posting is **Live/Gate** through the official Posts route after exact identity and product eligibility verification. |
 | Facebook | **Live/Gate/Export** managed Page posts; **No/Export** personal profile | **No/Export** curated activity and per-post comments | **No/Export** | **No/Export** personal relationships | **No** | One managed-Page `/posts` stream; app review and Page authority remain explicit, with all personal-account categories excluded. |
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |

--- a/.agents/configs/campaign-channel-specs.json
+++ b/.agents/configs/campaign-channel-specs.json
@@ -24,6 +24,8 @@
     "linkedin": {
       "canonical_id": "linkedin",
       "fanout_aliases": ["social-linkedin"],
+      "outbound_channel": "linkedin",
+      "outbound_provider": "linkedin",
       "display_name": "LinkedIn",
       "max_words": 500,
       "format": "thought-leadership",
@@ -64,6 +66,18 @@
       "cta_style": "discussion",
       "sections": ["title", "body", "disclosure"],
       "guidelines": "Use a reviewed title and body. Name the destination subreddit at enqueue time; follow community rules and required disclosures."
+    },
+    "youtube": {
+      "canonical_id": "youtube",
+      "fanout_aliases": ["social-youtube"],
+      "outbound_channel": "youtube",
+      "outbound_provider": "youtube",
+      "display_name": "YouTube",
+      "max_words": 5000,
+      "format": "video",
+      "cta_style": "spoken-and-description",
+      "sections": ["title", "description", "disclosure"],
+      "guidelines": "Queue only an approved private video file with a reviewed title and description. Upload is private by default; channel identity, OAuth authorization, and provider quota must be ready before remote mutation."
     },
     "blog": {
       "canonical_id": "blog",

--- a/.agents/configs/capability-registry.json
+++ b/.agents/configs/capability-registry.json
@@ -73,6 +73,28 @@
       "probes": {"deployed": {"path": "scripts/campaign-research-helper.py"}, "tool_visible": {"tool": "python3"}}
     },
     {
+      "name": "linkedin-approved-posting",
+      "aliases": ["linkedin-publish", "linkedin-outbound"],
+      "owner": "Social",
+      "description": "Approval-bound official LinkedIn member text posts",
+      "runtimes": ["opencode", "claude-code"],
+      "entry_points": ["content/social-linkedin.md", "scripts/_knowledge_social_linkedin_outbound_provider.py"],
+      "fallback": "gated-no-mutation",
+      "required": ["deployed", "configured", "authenticated", "authorized", "reachable"],
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_linkedin_outbound_provider.py"}, "configured": {"env_pattern": "LINKEDIN_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires Posts product eligibility and exact member binding"}, "reachable": {"live": "requires official LinkedIn API request"}}
+    },
+    {
+      "name": "youtube-approved-upload",
+      "aliases": ["youtube-publish", "youtube-outbound"],
+      "owner": "Social",
+      "description": "Approval-bound official YouTube private video uploads",
+      "runtimes": ["opencode", "claude-code"],
+      "entry_points": ["content/social-youtube.md", "scripts/_knowledge_social_youtube_outbound_provider.py"],
+      "fallback": "gated-no-mutation",
+      "required": ["deployed", "configured", "authenticated", "authorized", "reachable"],
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_youtube_outbound_provider.py"}, "configured": {"env_pattern": "YOUTUBE_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires youtube.upload scope and exact channel binding"}, "reachable": {"live": "requires official YouTube Data API request"}}
+    },
+    {
       "name": "vault-operations",
       "aliases": ["vault", "protected-data", "encrypted-memory"],
       "owner": "Vault",

--- a/.agents/configs/rate-limits.json.txt
+++ b/.agents/configs/rate-limits.json.txt
@@ -75,6 +75,24 @@
       "input_tokens_per_min": 0,
       "output_tokens_per_min": 0,
       "billing_type": "token"
+    },
+    "linkedin": {
+      "_comment": "LinkedIn API capacity is product and application gated; do not infer a quota from read access.",
+      "_docs": "https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/rate-limits",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-gated"
+    },
+    "youtube": {
+      "_comment": "YouTube Data API v3 default daily quota is project-specific; uploads are quota-expensive and must retain provider 403/quota responses.",
+      "_docs": "https://developers.google.com/youtube/v3/determine_quota_cost",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-quota"
     }
   }
 }

--- a/.agents/content/distribution-social.md
+++ b/.agents/content/distribution-social.md
@@ -1,6 +1,6 @@
 ---
 name: social
-description: Social media distribution - X, LinkedIn, Reddit platform-native content
+description: Social media distribution - X, LinkedIn, Reddit, and YouTube platform-native content
 mode: subagent
 model: standard
 ---
@@ -8,13 +8,13 @@ model: standard
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Social - X, LinkedIn, and Reddit Distribution
+# Social - X, LinkedIn, Reddit, and YouTube Distribution
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
-- **Purpose**: Distribute content across X, LinkedIn, Reddit with platform-native tone and format
+- **Purpose**: Distribute content across X, LinkedIn, Reddit, and YouTube with platform-native tone and format
 - **Key Principle**: Same story, different delivery — adapt voice and format per platform
 - **Metrics**: Engagement rate, shares, profile visits, link clicks
 
@@ -26,7 +26,7 @@ model: standard
 - **Professional framing on LinkedIn** — thought leadership, not sales pitch
 - **One idea per post** — clarity beats comprehensiveness
 
-**Platform Tools**: `content/social-xurl.md` (official X API), `content/social-bird.md` (X browser-cookie fallback), `content/social-linkedin.md`, `content/social-reddit.md`
+**Platform Tools**: `content/social-xurl.md` (official X API), `content/social-bird.md` (X browser-cookie fallback), `content/social-linkedin.md`, `content/social-reddit.md`, `content/social-youtube.md`
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/content/social-linkedin.md
+++ b/.agents/content/social-linkedin.md
@@ -152,6 +152,17 @@ knowledge-social-helper.sh sync-linkedin \
 Python 3.14.3 and the local `urllib.request` exports (`Request`, `urlopen`) were
 verified before implementation; no LinkedIn SDK was installed or imported.
 
+### Approved outbound posts
+
+The outbound queue can prepare an approved text `post` for the selected member
+only. It verifies the configured member through `memberAuthorizations` before
+the write boundary, then uses the official REST Posts route. This is a
+capability-gated route: absent write-product eligibility, token scope, or exact
+member binding fails closed before mutation. The queue does not emulate a write
+through browser automation, support organization posting, or infer access from
+the read-only Member Portability product. Receipts retain only operation and
+remote post IDs; post body and authorization values remain private.
+
 ## Content Best Practices
 
 **Structure**: Hook (1-2 lines, ~210 chars) → Body (`\n` breaks) → CTA → Hashtags (3-5 at end). Bold/italic via Unicode. Emoji 1-3 per post. Limit: 3k chars.

--- a/.agents/content/social-youtube.md
+++ b/.agents/content/social-youtube.md
@@ -65,6 +65,19 @@ The boundary serializes only allowlisted text, IDs, timestamps, direction, count
 position, and privacy-status fields. It never downloads audiovisual media and has
 no write endpoint or mutation action.
 
+## Approved outbound video uploads
+
+The approval-bound outbound queue can upload one reviewed private video to an
+exactly verified owned channel. It requires a named OAuth profile with the
+official upload scope, a private media file bound by SHA-256 before approval, a
+non-empty title (at most 100 characters), and a private description. The provider
+first calls `channels.list(mine=true)` and fails closed on a different channel or
+unready authorization. It initiates the official resumable `videos.insert`
+upload route and maps any transport ambiguity to `unknown`; executors never
+blindly create a second video. The initial implementation publishes as `private`
+only—thumbnail, captions, scheduling, and changing a video's visibility require
+separate approved capabilities. Receipts contain only operation and video IDs.
+
 ## Explicit gaps and retention
 
 Every successful page also records unavailable coverage for:

--- a/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Official, capability-gated LinkedIn text-post adapter for approved intents."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from _knowledge_social_linkedin import API_VERSION
+from _knowledge_social_linkedin_provider import PROFILE_NAME, _access_token
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import ProviderAdapterError, ProviderIdentityError
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+API_BASE = "https://api.linkedin.com/rest"
+POST_ENDPOINT = "posts"
+IDENTITY_ENDPOINT = "memberAuthorizations"
+MAX_RESPONSE_BYTES = 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+UrlOpen = Callable[..., Any]
+
+
+def _profile(claimed: ClaimedOperation) -> str:
+    if claimed.app_profile is None or PROFILE_NAME.fullmatch(claimed.app_profile) is None:
+        raise ProviderAdapterError("LinkedIn outbound operations require a named OAuth profile")
+    return claimed.app_profile
+
+
+def _decode_response(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise ProviderAdapterError("LinkedIn write response exceeds the safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8")) if payload else {}
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProviderAdapterError("LinkedIn write response is not valid JSON") from error
+    if not isinstance(decoded, dict):
+        raise ProviderAdapterError("LinkedIn write response root must be an object")
+    reject_credentials(decoded)
+    return decoded
+
+
+def _request(token: str, endpoint: str, *, method: str, data: bytes | None = None) -> Request:
+    endpoint_name = endpoint.split("?", 1)[0]
+    if endpoint_name not in (IDENTITY_ENDPOINT, POST_ENDPOINT):
+        raise ProviderAdapterError("LinkedIn write endpoint is not allowlisted")
+    return Request(
+        f"{API_BASE}/{endpoint}",
+        data=data,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Linkedin-Version": API_VERSION,
+            "User-Agent": "aidevops-linkedin-outbound/1",
+            "X-Restli-Protocol-Version": "2.0.0",
+        },
+        method=method,
+    )
+
+
+def _member_id(payload: dict[str, Any]) -> str:
+    elements = payload.get("elements")
+    if not isinstance(elements, list) or len(elements) != 1:
+        raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable")
+    member_id = elements[0].get("member") if isinstance(elements[0], dict) else None
+    if not isinstance(member_id, str):
+        raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable")
+    return validate_opaque(member_id, "provider_remote_id")
+
+
+@dataclass(frozen=True)
+class LinkedInPreparedProvider:
+    """Prepared official LinkedIn post route with exact member binding."""
+
+    claimed: ClaimedOperation
+    opener: UrlOpen = urlopen
+
+    def verify_identity(self) -> None:
+        try:
+            token = _access_token(_profile(self.claimed))
+            request = _request(
+                token, f"{IDENTITY_ENDPOINT}?q=memberAndApplication", method="GET"
+            )
+            with self.opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                if getattr(response, "status", 200) != 200:
+                    raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable")
+                member_id = _member_id(
+                    _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+                )
+            if member_id != self.claimed.remote_account_id:
+                raise ProviderIdentityError(
+                    "selected LinkedIn member does not match the approved account"
+                )
+        except ProviderIdentityError:
+            raise
+        except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
+            raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable") from None
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        if self.claimed.action != "post" or self.claimed.payload is None:
+            return None, "validation"
+        try:
+            token = _access_token(_profile(self.claimed))
+            body = json.dumps(
+                {
+                    "author": self.claimed.remote_account_id,
+                    "commentary": self.claimed.payload,
+                    "visibility": "PUBLIC",
+                    "distribution": {
+                        "feedDistribution": "MAIN_FEED",
+                        "targetEntities": [],
+                        "thirdPartyDistributionChannels": [],
+                    },
+                    "lifecycleState": "PUBLISHED",
+                    "isReshareDisabledByAuthor": False,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            with self.opener(
+                _request(token, POST_ENDPOINT, method="POST", data=body),
+                timeout=HTTP_TIMEOUT_SECONDS,
+            ) as response:
+                if getattr(response, "status", 201) not in (200, 201):
+                    return None, "provider_unavailable"
+                remote_id = response.headers.get("x-restli-id")
+                if not isinstance(remote_id, str) or not remote_id:
+                    payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+                    remote_id = payload.get("id")
+                if not isinstance(remote_id, str):
+                    return None, "validation"
+                return validate_opaque(remote_id, "provider_remote_id"), None
+        except (HTTPError, URLError, OSError):
+            return None, "provider_unavailable"
+        except (SocialStoreError, ProviderAdapterError, UnicodeError):
+            return None, "validation"

--- a/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
@@ -102,40 +102,43 @@ class LinkedInPreparedProvider:
         except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
             raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable") from None
 
-    def invoke(self) -> tuple[str | None, str | None]:
+    def _post(self) -> tuple[str | None, str | None]:
         if self.claimed.action != "post" or self.claimed.payload is None:
             return None, "validation"
-        try:
-            token = _access_token(_profile(self.claimed))
-            body = json.dumps(
-                {
-                    "author": self.claimed.remote_account_id,
-                    "commentary": self.claimed.payload,
-                    "visibility": "PUBLIC",
-                    "distribution": {
-                        "feedDistribution": "MAIN_FEED",
-                        "targetEntities": [],
-                        "thirdPartyDistributionChannels": [],
-                    },
-                    "lifecycleState": "PUBLISHED",
-                    "isReshareDisabledByAuthor": False,
+        token = _access_token(_profile(self.claimed))
+        body = json.dumps(
+            {
+                "author": self.claimed.remote_account_id,
+                "commentary": self.claimed.payload,
+                "visibility": "PUBLIC",
+                "distribution": {
+                    "feedDistribution": "MAIN_FEED",
+                    "targetEntities": [],
+                    "thirdPartyDistributionChannels": [],
                 },
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ).encode("utf-8")
-            with self.opener(
-                _request(token, POST_ENDPOINT, method="POST", data=body),
-                timeout=HTTP_TIMEOUT_SECONDS,
-            ) as response:
-                if getattr(response, "status", 201) not in (200, 201):
-                    return None, "provider_unavailable"
-                remote_id = response.headers.get("x-restli-id")
-                if not isinstance(remote_id, str) or not remote_id:
-                    payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
-                    remote_id = payload.get("id")
-                if not isinstance(remote_id, str):
-                    return None, "validation"
-                return validate_opaque(remote_id, "provider_remote_id"), None
+                "lifecycleState": "PUBLISHED",
+                "isReshareDisabledByAuthor": False,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        with self.opener(
+            _request(token, POST_ENDPOINT, method="POST", data=body),
+            timeout=HTTP_TIMEOUT_SECONDS,
+        ) as response:
+            if getattr(response, "status", 201) not in (200, 201):
+                return None, "provider_unavailable"
+            remote_id = response.headers.get("x-restli-id")
+            if not isinstance(remote_id, str) or not remote_id:
+                payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+                remote_id = payload.get("id")
+            if not isinstance(remote_id, str):
+                return None, "validation"
+            return validate_opaque(remote_id, "provider_remote_id"), None
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        try:
+            return self._post()
         except (HTTPError, URLError, OSError):
             return None, "provider_unavailable"
         except (SocialStoreError, ProviderAdapterError, UnicodeError):

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -18,8 +18,10 @@ from knowledge_social_store import SocialStoreError, validate_opaque
 
 ACTIONS = ("post", "reply", "like", "bookmark")
 OUTBOUND_PROVIDER_ACTIONS = {
+    "linkedin": ("post",),
     "reddit": ACTIONS,
     "xapi": ACTIONS,
+    "youtube": ("post",),
 }
 TERMINAL_STATES = ("succeeded", "failed", "unknown", "cancelled")
 FAILURE_CLASSES = (
@@ -36,7 +38,7 @@ MAX_SUBJECT_BYTES = 4 * 1024
 MAX_REDDIT_SUBJECT_CHARS = 300
 MAX_SELECTOR_BYTES = 256
 MAX_APPROVAL_SECONDS = 31 * 24 * 60 * 60
-CURRENT_INTENT_VERSION = 2
+CURRENT_INTENT_VERSION = 3
 REDDIT_TARGET_ID = re.compile(r"^t[13]_[A-Za-z0-9]+$")
 REDDIT_PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
 REDDIT_DESTINATION_ID = re.compile(r"^[A-Za-z0-9_]{3,21}$")
@@ -57,6 +59,8 @@ class OperationIntent:
     created_by: str
     destination_remote_id: str | None = None
     subject: str | None = None
+    media_path: str | None = None
+    media_sha256: str | None = None
     operation_id: str | None = None
     created_at: int | None = None
 
@@ -97,6 +101,8 @@ class ClaimedOperation:
     username: str | None
     claim_token: int
     attempt_id: str
+    media_path: str | None = None
+    media_sha256: str | None = None
 
 
 def now_epoch() -> int:
@@ -151,9 +157,34 @@ def _validated_subject(provider: str, action: str, subject: str | None) -> str |
         if len(subject.encode("utf-8")) > MAX_SUBJECT_BYTES:
             raise SocialStoreError("outbound subject exceeds the private subject limit")
         return subject
+    if provider == "youtube" and action == "post":
+        if subject is None or not subject.strip():
+            raise SocialStoreError("YouTube uploads require a non-empty private title file")
+        if any(marker in subject for marker in ("\x00", "\n", "\r")):
+            raise SocialStoreError("YouTube upload title must be one non-empty line")
+        if len(subject) > 100:
+            raise SocialStoreError("YouTube upload title exceeds the 100-character limit")
+        return subject
     if subject is not None:
         raise SocialStoreError("this outbound operation does not accept a subject")
     return None
+
+
+def _validated_media(
+    provider: str, action: str, media_path: str | None, media_sha256: str | None
+) -> tuple[str | None, str | None]:
+    if provider == "youtube" and action == "post":
+        if media_path is None or media_sha256 is None:
+            raise SocialStoreError("YouTube uploads require a verified private media file")
+        media_path = _optional_selector(media_path, "media_path")
+        if media_path is None or not media_path.startswith("/"):
+            raise SocialStoreError("YouTube media path must be an absolute private path")
+        if re.fullmatch(r"[0-9a-f]{64}", media_sha256) is None:
+            raise SocialStoreError("YouTube media integrity digest is invalid")
+        return media_path, media_sha256
+    if media_path is not None or media_sha256 is not None:
+        raise SocialStoreError("this outbound operation does not accept media")
+    return None, None
 
 
 def _validated_destination(
@@ -200,14 +231,21 @@ def _intent_document(values: dict[str, Any]) -> dict[str, Any]:
         "scheduled_at": values["scheduled_at"],
         "created_by": values["created_by"],
     }
-    if version == 2:
+    if version in (2, 3):
         document.update(
             {
                 "destination_remote_id": values["destination_remote_id"],
                 "subject_sha256": values["subject_sha256"],
             }
         )
-    elif version != 1:
+    if version == 3:
+        document.update(
+            {
+                "media_path": values["media_path"],
+                "media_sha256": values["media_sha256"],
+            }
+        )
+    elif version not in (1, 2):
         raise SocialStoreError("unsupported outbound intent version")
     return document
 
@@ -227,10 +265,18 @@ def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
             for field in ("destination_remote_id", "subject", "subject_sha256")
         ):
             raise SocialStoreError("legacy outbound operation has unbound provider fields")
-    elif intent_version == 2:
+    elif intent_version in (2, 3):
         subject_sha256 = _digest(row["subject"] or "")
         if subject_sha256 != row["subject_sha256"]:
             raise SocialStoreError("outbound operation subject integrity check failed")
+        if intent_version == 3 and (
+            (row["media_path"] is None) != (row["media_sha256"] is None)
+            or (
+                row["media_sha256"] is not None
+                and re.fullmatch(r"[0-9a-f]{64}", str(row["media_sha256"])) is None
+            )
+        ):
+            raise SocialStoreError("outbound operation media integrity check failed")
     else:
         raise SocialStoreError("unsupported outbound intent version")
     values = dict(row)
@@ -293,6 +339,9 @@ def _operation_values(
         if username is not None:
             raise SocialStoreError("Reddit identity is selected only by its auth profile")
     subject = _validated_subject(provider, intent.action, intent.subject)
+    media_path, media_sha256 = _validated_media(
+        provider, intent.action, intent.media_path, intent.media_sha256
+    )
     return {
         "operation_id": validate_opaque(operation_id, "operation_id"),
         "provider": provider,
@@ -309,6 +358,8 @@ def _operation_values(
         "payload_sha256": _digest(payload or ""),
         "subject": subject,
         "subject_sha256": _digest(subject or ""),
+        "media_path": media_path,
+        "media_sha256": media_sha256,
         "intent_version": CURRENT_INTENT_VERSION,
         "app_profile": app_profile,
         "username": username,
@@ -349,9 +400,9 @@ def _insert_operation(
         """INSERT INTO outbound_operations(
             operation_id,provider,connection_id,remote_account_id,action,
             target_remote_id,destination_remote_id,payload,payload_sha256,
-            subject,subject_sha256,intent_version,intent_sha256,app_profile,
+            subject,subject_sha256,media_path,media_sha256,intent_version,intent_sha256,app_profile,
             username,scheduled_at,state,created_by,created_at,updated_at)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
             values["operation_id"],
             values["provider"],
@@ -364,6 +415,8 @@ def _insert_operation(
             values["payload_sha256"],
             values["subject"],
             values["subject_sha256"],
+            values["media_path"],
+            values["media_sha256"],
             values["intent_version"],
             values["intent_sha256"],
             values["app_profile"],

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -325,9 +325,23 @@ def _prepare_reddit(claimed: ClaimedOperation) -> PreparedProvider:
     )
 
 
+def _prepare_linkedin(claimed: ClaimedOperation) -> PreparedProvider:
+    from _knowledge_social_linkedin_outbound_provider import LinkedInPreparedProvider
+
+    return LinkedInPreparedProvider(claimed)
+
+
+def _prepare_youtube(claimed: ClaimedOperation) -> PreparedProvider:
+    from _knowledge_social_youtube_outbound_provider import YouTubePreparedProvider
+
+    return YouTubePreparedProvider(claimed)
+
+
 PROVIDER_FACTORIES: dict[str, Callable[[ClaimedOperation], PreparedProvider]] = {
+    "linkedin": _prepare_linkedin,
     "reddit": _prepare_reddit,
     "xapi": _prepare_x,
+    "youtube": _prepare_youtube,
 }
 
 

--- a/.agents/scripts/_knowledge_social_outbound_reconciliation.py
+++ b/.agents/scripts/_knowledge_social_outbound_reconciliation.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from typing import Any

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -49,6 +49,31 @@ class AttemptOutcome:
     finished_at: int | None = None
 
 
+def record_provider_checkpoint(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    checkpoint_id: str,
+) -> None:
+    """Persist an opaque resumable provider ID before remote continuation."""
+    executor_id = validate_opaque(executor_id, "executor_id")
+    checkpoint_id = validate_opaque(checkpoint_id, "provider_checkpoint_id")
+    changed = database.execute(
+        """UPDATE outbound_attempts SET diagnostics=?
+             WHERE attempt_id=? AND operation_id=? AND claim_token=? AND executor_id=?
+               AND status='running' AND provider_started_at IS NOT NULL""",
+        (
+            canonical_json({"phase": "provider", "checkpoint": checkpoint_id}),
+            claimed.attempt_id,
+            claimed.operation_id,
+            claimed.claim_token,
+            executor_id,
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("outbound provider checkpoint is stale")
+
+
 def due_operation_ids(
     database: sqlite3.Connection,
     principal_id: str,
@@ -166,6 +191,8 @@ def claim_operation(
         username=row["username"],
         claim_token=claim_token,
         attempt_id=attempt_id,
+        media_path=row["media_path"],
+        media_sha256=row["media_sha256"],
     )
 
 

--- a/.agents/scripts/_knowledge_social_store_schema.py
+++ b/.agents/scripts/_knowledge_social_store_schema.py
@@ -57,6 +57,21 @@ def add_outbound_v4_columns(connection: sqlite3.Connection) -> None:
             connection.execute(statement)
 
 
+def add_outbound_v7_columns(connection: sqlite3.Connection) -> None:
+    """Add private, hash-bound video source selectors without rewriting intents."""
+    columns = {
+        str(row["name"])
+        for row in connection.execute("PRAGMA table_info(outbound_operations)").fetchall()
+    }
+    additions = (
+        ("media_path", "ALTER TABLE outbound_operations ADD COLUMN media_path TEXT"),
+        ("media_sha256", "ALTER TABLE outbound_operations ADD COLUMN media_sha256 TEXT"),
+    )
+    for column, statement in additions:
+        if column not in columns:
+            connection.execute(statement)
+
+
 def add_source_v5_columns(connection: sqlite3.Connection) -> None:
     table = connection.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='fetch_batches'"

--- a/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
@@ -120,62 +120,67 @@ class YouTubePreparedProvider:
         except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
             raise ProviderIdentityError("YouTube upload capability or identity is unavailable") from None
 
-    def invoke(
-        self, checkpoint: Callable[[str], None] | None = None
+    def _upload(
+        self, checkpoint: Callable[[str], None] | None
     ) -> tuple[str | None, str | None]:
         if self.claimed.action != "post" or self.claimed.payload is None or self.claimed.subject is None:
             return None, "validation"
-        try:
-            media, size = _verified_media(self.claimed)
-            media_type = _media_type(media)
-            token = _access_token(_profile(self.claimed))
-            metadata = json.dumps(
-                {
-                    "snippet": {
-                        "title": self.claimed.subject,
-                        "description": self.claimed.payload,
-                    },
-                    "status": {"privacyStatus": "private"},
+        media, size = _verified_media(self.claimed)
+        media_type = _media_type(media)
+        token = _access_token(_profile(self.claimed))
+        metadata = json.dumps(
+            {
+                "snippet": {
+                    "title": self.claimed.subject,
+                    "description": self.claimed.payload,
                 },
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ).encode("utf-8")
-            initiate = Request(
-                f"{UPLOAD_BASE}/videos?{urlencode({'uploadType': 'resumable', 'part': 'snippet,status'})}",
-                data=metadata,
+                "status": {"privacyStatus": "private"},
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        initiate = Request(
+            f"{UPLOAD_BASE}/videos?{urlencode({'uploadType': 'resumable', 'part': 'snippet,status'})}",
+            data=metadata,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json; charset=UTF-8",
+                "Content-Length": str(len(metadata)),
+                "X-Upload-Content-Length": str(size),
+                "X-Upload-Content-Type": media_type,
+                "User-Agent": "aidevops-youtube-outbound/1",
+            },
+            method="POST",
+        )
+        with self.opener(initiate, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            location = response.headers.get("Location")
+        if not isinstance(location, str) or not location.startswith("https://www.googleapis.com/"):
+            return None, "validation"
+        if checkpoint is not None:
+            checkpoint(location)
+        with media.open("rb") as handle:
+            upload = Request(
+                location,
+                data=handle.read(),
                 headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json; charset=UTF-8",
-                    "Content-Length": str(len(metadata)),
-                    "X-Upload-Content-Length": str(size),
-                    "X-Upload-Content-Type": media_type,
+                    "Content-Type": media_type,
+                    "Content-Length": str(size),
                     "User-Agent": "aidevops-youtube-outbound/1",
                 },
-                method="POST",
+                method="PUT",
             )
-            with self.opener(initiate, timeout=HTTP_TIMEOUT_SECONDS) as response:
-                location = response.headers.get("Location")
-            if not isinstance(location, str) or not location.startswith("https://www.googleapis.com/"):
-                return None, "validation"
-            if checkpoint is not None:
-                checkpoint(location)
-            with media.open("rb") as handle:
-                upload = Request(
-                    location,
-                    data=handle.read(),
-                    headers={
-                        "Content-Type": media_type,
-                        "Content-Length": str(size),
-                        "User-Agent": "aidevops-youtube-outbound/1",
-                    },
-                    method="PUT",
-                )
-                with self.opener(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
-                    payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
-            remote_id = payload.get("id")
-            if not isinstance(remote_id, str):
-                return None, "validation"
-            return validate_opaque(remote_id, "provider_remote_id"), None
+            with self.opener(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+        remote_id = payload.get("id")
+        if not isinstance(remote_id, str):
+            return None, "validation"
+        return validate_opaque(remote_id, "provider_remote_id"), None
+
+    def invoke(
+        self, checkpoint: Callable[[str], None] | None = None
+    ) -> tuple[str | None, str | None]:
+        try:
+            return self._upload(checkpoint)
         except (HTTPError, URLError, OSError):
             return None, "provider_unavailable"
         except (SocialStoreError, ProviderAdapterError, UnicodeError):

--- a/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Official, resumable YouTube upload adapter for approved video intents."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from _knowledge_social_youtube_provider import PROFILE_NAME, _access_token
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import ProviderAdapterError, ProviderIdentityError
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+API_BASE = "https://www.googleapis.com/youtube/v3"
+UPLOAD_BASE = "https://www.googleapis.com/upload/youtube/v3"
+MAX_RESPONSE_BYTES = 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 120
+MAX_UPLOAD_BYTES = 2 * 1024**3
+UrlOpen = Callable[..., Any]
+
+
+def _profile(claimed: ClaimedOperation) -> str:
+    if claimed.app_profile is None or PROFILE_NAME.fullmatch(claimed.app_profile) is None:
+        raise ProviderAdapterError("YouTube outbound operations require a named OAuth profile")
+    return claimed.app_profile
+
+
+def _decode_response(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise ProviderAdapterError("YouTube write response exceeds the safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8")) if payload else {}
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProviderAdapterError("YouTube write response is not valid JSON") from error
+    if not isinstance(decoded, dict):
+        raise ProviderAdapterError("YouTube write response root must be an object")
+    reject_credentials(decoded)
+    return decoded
+
+
+def _api_request(token: str, endpoint: str, params: dict[str, str]) -> Request:
+    return Request(
+        f"{API_BASE}/{endpoint}?{urlencode(params)}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "aidevops-youtube-outbound/1",
+        },
+        method="GET",
+    )
+
+
+def _verified_media(claimed: ClaimedOperation) -> tuple[Path, int]:
+    if claimed.media_path is None or claimed.media_sha256 is None:
+        raise ProviderAdapterError("YouTube upload has no bound media")
+    path = Path(claimed.media_path)
+    stat = path.stat()
+    if not path.is_file() or stat.st_size < 1 or stat.st_size > MAX_UPLOAD_BYTES:
+        raise ProviderAdapterError("YouTube media is unavailable or outside the size limit")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    if digest.hexdigest() != claimed.media_sha256:
+        raise ProviderAdapterError("YouTube media changed after approval")
+    return path, stat.st_size
+
+
+def _media_type(path: Path) -> str:
+    media_type, _encoding = mimetypes.guess_type(path.name)
+    if media_type not in {"video/mp4", "video/quicktime", "video/webm"}:
+        raise ProviderAdapterError("YouTube media type is unsupported")
+    return media_type
+
+
+@dataclass(frozen=True)
+class YouTubePreparedProvider:
+    """Prepared YouTube video upload with exact owned-channel verification."""
+
+    claimed: ClaimedOperation
+    opener: UrlOpen = urlopen
+
+    def verify_identity(self) -> None:
+        try:
+            token = _access_token(_profile(self.claimed))
+            with self.opener(
+                _api_request(
+                    token,
+                    "channels",
+                    {"part": "id", "mine": "true", "maxResults": "1"},
+                ),
+                timeout=HTTP_TIMEOUT_SECONDS,
+            ) as response:
+                if getattr(response, "status", 200) != 200:
+                    raise ProviderIdentityError("YouTube upload capability or identity is unavailable")
+                payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+            items = payload.get("items")
+            channel_id = (
+                items[0].get("id")
+                if isinstance(items, list)
+                and len(items) == 1
+                and isinstance(items[0], dict)
+                else None
+            )
+            if channel_id != self.claimed.remote_account_id:
+                raise ProviderIdentityError("selected YouTube channel does not match the approved account")
+            _verified_media(self.claimed)
+        except ProviderIdentityError:
+            raise
+        except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
+            raise ProviderIdentityError("YouTube upload capability or identity is unavailable") from None
+
+    def invoke(
+        self, checkpoint: Callable[[str], None] | None = None
+    ) -> tuple[str | None, str | None]:
+        if self.claimed.action != "post" or self.claimed.payload is None or self.claimed.subject is None:
+            return None, "validation"
+        try:
+            media, size = _verified_media(self.claimed)
+            media_type = _media_type(media)
+            token = _access_token(_profile(self.claimed))
+            metadata = json.dumps(
+                {
+                    "snippet": {
+                        "title": self.claimed.subject,
+                        "description": self.claimed.payload,
+                    },
+                    "status": {"privacyStatus": "private"},
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            initiate = Request(
+                f"{UPLOAD_BASE}/videos?{urlencode({'uploadType': 'resumable', 'part': 'snippet,status'})}",
+                data=metadata,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json; charset=UTF-8",
+                    "Content-Length": str(len(metadata)),
+                    "X-Upload-Content-Length": str(size),
+                    "X-Upload-Content-Type": media_type,
+                    "User-Agent": "aidevops-youtube-outbound/1",
+                },
+                method="POST",
+            )
+            with self.opener(initiate, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                location = response.headers.get("Location")
+            if not isinstance(location, str) or not location.startswith("https://www.googleapis.com/"):
+                return None, "validation"
+            if checkpoint is not None:
+                checkpoint(location)
+            with media.open("rb") as handle:
+                upload = Request(
+                    location,
+                    data=handle.read(),
+                    headers={
+                        "Content-Type": media_type,
+                        "Content-Length": str(size),
+                        "User-Agent": "aidevops-youtube-outbound/1",
+                    },
+                    method="PUT",
+                )
+                with self.opener(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                    payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
+            remote_id = payload.get("id")
+            if not isinstance(remote_id, str):
+                return None, "validation"
+            return validate_opaque(remote_id, "provider_remote_id"), None
+        except (HTTPError, URLError, OSError):
+            return None, "provider_unavailable"
+        except (SocialStoreError, ProviderAdapterError, UnicodeError):
+            return None, "validation"

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sqlite3
@@ -50,6 +51,7 @@ from _knowledge_social_outbound_runtime import (
     expire_claims,
     finalize_operation,
     mark_provider_started,
+    record_provider_checkpoint,
 )
 from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
 from knowledge_corpus_context import CatalogError, validate_private_file
@@ -133,6 +135,30 @@ def _read_private_subject(path: Path) -> str:
     return subject
 
 
+def _private_media_digest(path: Path) -> tuple[str, str]:
+    """Return an absolute private media path and a bounded streaming digest."""
+    try:
+        validate_private_file(path, "outbound media", repair=False)
+        resolved = path.resolve(strict=True)
+        before = resolved.stat()
+        if not resolved.is_file() or before.st_size < 1 or before.st_size > 2 * 1024**3:
+            raise OperationsError("outbound media is unavailable or outside the size limit")
+        digest = hashlib.sha256()
+        with resolved.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+        after = resolved.stat()
+        if (before.st_dev, before.st_ino, before.st_size) != (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+        ):
+            raise OperationsError("outbound media replacement detected")
+    except (CatalogError, OSError) as error:
+        raise OperationsError("outbound media is unavailable or unsafe") from error
+    return str(resolved), digest.hexdigest()
+
+
 def _managed_context(args: argparse.Namespace) -> tuple[str, Path]:
     principal_id, corpora = authorized_scope(
         args.base or DEFAULT_BASE, "knowledge.manage", args.alias
@@ -202,7 +228,13 @@ def _execute_claimed(
             database, claimed, executor_id, "authorization", args
         )
 
-    provider_remote_id, failure_class = provider.invoke()
+    if claimed.provider == "youtube":
+        checkpoint = lambda checkpoint_id: record_provider_checkpoint(
+            database, claimed, executor_id, checkpoint_id
+        )
+        provider_remote_id, failure_class = provider.invoke(checkpoint)
+    else:
+        provider_remote_id, failure_class = provider.invoke()
     if failure_class is not None:
         return _unknown_provider_outcome(
             database, claimed, executor_id, failure_class, args
@@ -285,6 +317,9 @@ def _handle_operation_create(
     created_at = _required_now(current_time)
     payload = _read_private_body(args.body_file) if args.body_file else None
     subject = _read_private_subject(args.subject_file) if args.subject_file else None
+    media_path, media_sha256 = (
+        _private_media_digest(args.media_file) if args.media_file else (None, None)
+    )
     if subject is not None and len(subject.encode("utf-8")) > MAX_SUBJECT_BYTES:
         raise OperationsError("outbound subject exceeds the private subject limit")
     return create_operation(
@@ -305,6 +340,8 @@ def _handle_operation_create(
             created_by=principal_id,
             destination_remote_id=args.destination_id,
             subject=subject,
+            media_path=media_path,
+            media_sha256=media_sha256,
             operation_id=args.operation_id,
             created_at=created_at,
         ),
@@ -500,6 +537,7 @@ def _add_create_command(commands: Any) -> None:
     create.add_argument("--destination-id")
     create.add_argument("--body-file", type=Path)
     create.add_argument("--subject-file", type=Path)
+    create.add_argument("--media-file", type=Path)
     create.add_argument("--app", "--profile", dest="app")
     create.add_argument("--username")
     create.add_argument("--scheduled-at", type=int)

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -20,6 +20,7 @@ from _knowledge_social_store_migration import (
     recover_orphaned_fetch_batches_v6 as _recover_orphaned_fetch_batches_v6,
 )
 from _knowledge_social_store_schema import (
+    add_outbound_v7_columns as _add_outbound_v7_columns,
     add_outbound_v4_columns as _add_outbound_v4_columns,
     add_source_v5_columns as _add_source_v5_columns,
     add_sync_run_v2_columns as _add_sync_run_v2_columns,
@@ -41,8 +42,8 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 6
-SCHEMA_VERSION_SQL = "PRAGMA user_version=6"
+SCHEMA_VERSION = 7
+SCHEMA_VERSION_SQL = "PRAGMA user_version=7"
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
 
@@ -200,7 +201,8 @@ def _tables() -> tuple[str, ...]:
             target_remote_id TEXT, destination_remote_id TEXT,
             payload TEXT, payload_sha256 TEXT NOT NULL,
             subject TEXT, subject_sha256 TEXT,
-            intent_version INTEGER NOT NULL DEFAULT 2 CHECK(intent_version IN (1,2)),
+            media_path TEXT, media_sha256 TEXT,
+            intent_version INTEGER NOT NULL DEFAULT 3 CHECK(intent_version IN (1,2,3)),
             intent_sha256 TEXT NOT NULL UNIQUE, app_profile TEXT, username TEXT,
             scheduled_at INTEGER NOT NULL, state TEXT NOT NULL
                 CHECK(state IN ('draft','approved','claimed','succeeded','failed','unknown','cancelled')),
@@ -341,6 +343,7 @@ def migrate(connection: sqlite3.Connection) -> None:
             connection.execute(statement)
         _add_sync_run_v2_columns(connection)
         _add_outbound_v4_columns(connection)
+        _add_outbound_v7_columns(connection)
         if current in range(1, SCHEMA_VERSION):
             _migrate_fetch_batches_v6(connection)
             _recover_orphaned_fetch_batches_v6(connection)

--- a/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
+++ b/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import secrets
 import tempfile
 import unittest
 from email.message import Message
@@ -16,6 +17,8 @@ from unittest.mock import patch
 from _knowledge_social_linkedin_outbound_provider import LinkedInPreparedProvider
 from _knowledge_social_outbound import ClaimedOperation
 from _knowledge_social_youtube_outbound_provider import YouTubePreparedProvider
+
+FIXTURE_ACCESS_TOKEN = secrets.token_hex(24)
 
 
 class Response:
@@ -56,7 +59,7 @@ def claimed(provider: str, **values: str | None) -> ClaimedOperation:
 
 
 class OutboundProviderTests(unittest.TestCase):
-    @patch.dict(os.environ, {"LINKEDIN_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    @patch.dict(os.environ, {"LINKEDIN_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_linkedin_identity_mismatch_prevents_post(self) -> None:
         calls: list[str] = []
 
@@ -69,7 +72,7 @@ class OutboundProviderTests(unittest.TestCase):
             provider.verify_identity()
         self.assertEqual(calls, ["GET"])
 
-    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_youtube_upload_requires_exact_channel_and_bound_media(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
             media.write(b"fixture video")
@@ -87,7 +90,7 @@ class OutboundProviderTests(unittest.TestCase):
             with self.assertRaisesRegex(Exception, "does not match"):
                 provider.verify_identity()
 
-    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_youtube_successful_private_upload_returns_stable_id(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
             media.write(b"fixture video")
@@ -114,7 +117,7 @@ class OutboundProviderTests(unittest.TestCase):
                 ["https://www.googleapis.com/upload/session_fixture"],
             )
 
-    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_youtube_rejects_unsupported_media_before_mutation(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".txt") as media:
             media.write(b"fixture video")

--- a/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
+++ b/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixture tests for capability-gated LinkedIn and YouTube outbound adapters."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import unittest
+from email.message import Message
+from pathlib import Path
+from unittest.mock import patch
+
+from _knowledge_social_linkedin_outbound_provider import LinkedInPreparedProvider
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_youtube_outbound_provider import YouTubePreparedProvider
+
+
+class Response:
+    def __init__(self, status: int, body: bytes, headers: dict[str, str] | None = None):
+        self.status = status
+        self._body = body
+        self.headers = Message()
+        for key, value in (headers or {}).items():
+            self.headers[key] = value
+
+    def read(self, _limit: int = -1) -> bytes:
+        return self._body
+
+    def __enter__(self) -> Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def claimed(provider: str, **values: str | None) -> ClaimedOperation:
+    return ClaimedOperation(
+        operation_id="op_fixture",
+        provider=provider,
+        action="post",
+        remote_account_id=values.get("account") or "channel_fixture",
+        target_remote_id=None,
+        destination_remote_id=None,
+        payload="private description",
+        subject=values.get("subject"),
+        app_profile="fixture",
+        username=None,
+        claim_token=1,
+        attempt_id="att_fixture",
+        media_path=values.get("media_path"),
+        media_sha256=values.get("media_sha256"),
+    )
+
+
+class OutboundProviderTests(unittest.TestCase):
+    @patch.dict(os.environ, {"LINKEDIN_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    def test_linkedin_identity_mismatch_prevents_post(self) -> None:
+        calls: list[str] = []
+
+        def opener(request: object, **_kwargs: object) -> Response:
+            calls.append(getattr(request, "method"))
+            return Response(200, b'{"elements":[{"member":"member_other"}]}')
+
+        provider = LinkedInPreparedProvider(claimed("linkedin", account="member_fixture"), opener)
+        with self.assertRaisesRegex(Exception, "does not match"):
+            provider.verify_identity()
+        self.assertEqual(calls, ["GET"])
+
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    def test_youtube_upload_requires_exact_channel_and_bound_media(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
+            media.write(b"fixture video")
+            media.flush()
+            digest = hashlib.sha256(b"fixture video").hexdigest()
+            provider = YouTubePreparedProvider(
+                claimed(
+                    "youtube",
+                    media_path=media.name,
+                    media_sha256=digest,
+                    subject="Fixture video",
+                ),
+                lambda _request, **_kwargs: Response(200, b'{"items":[{"id":"channel_other"}]}'),
+            )
+            with self.assertRaisesRegex(Exception, "does not match"):
+                provider.verify_identity()
+
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    def test_youtube_successful_private_upload_returns_stable_id(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
+            media.write(b"fixture video")
+            media.flush()
+            digest = hashlib.sha256(b"fixture video").hexdigest()
+            responses = iter(
+                [
+                    Response(200, b'{"items":[{"id":"channel_fixture"}]}'),
+                    Response(200, b"", {"Location": "https://www.googleapis.com/upload/session_fixture"}),
+                    Response(200, b'{"id":"video_fixture"}'),
+                ]
+            )
+            provider = YouTubePreparedProvider(
+                claimed("youtube", media_path=media.name, media_sha256=digest, subject="Fixture video"),
+                lambda _request, **_kwargs: next(responses),
+            )
+            provider.verify_identity()
+            checkpoints: list[str] = []
+            self.assertEqual(
+                provider.invoke(checkpoints.append), ("video_fixture", None)
+            )
+            self.assertEqual(
+                checkpoints,
+                ["https://www.googleapis.com/upload/session_fixture"],
+            )
+
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": "fixture-token"})
+    def test_youtube_rejects_unsupported_media_before_mutation(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".txt") as media:
+            media.write(b"fixture video")
+            media.flush()
+            digest = hashlib.sha256(b"fixture video").hexdigest()
+            provider = YouTubePreparedProvider(
+                claimed("youtube", media_path=media.name, media_sha256=digest, subject="Fixture"),
+                lambda _request, **_kwargs: Response(200, b'{"items":[{"id":"channel_fixture"}]}'),
+            )
+            provider.verify_identity()
+            self.assertEqual(provider.invoke(), (None, "validation"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -431,7 +431,7 @@ PY
 "$HELPER" provision --base "$MIGRATION_BASE" >/dev/null
 assert_eq "schema v2 migrates additively to all local operation tables" \
 	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT (SELECT user_version FROM pragma_user_version) || ':' || count(*) FROM sqlite_master WHERE name IN ('outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" \
-	"6:4"
+	"7:4"
 assert_eq "schema v4 adds provider-neutral subject and destination fields" \
 	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT count(*) FROM pragma_table_info('outbound_operations') WHERE name IN ('destination_remote_id','subject','subject_sha256','intent_version')")" \
 	"4"
@@ -557,7 +557,7 @@ assert_eq "Reddit post mapping binds destination, subject, and private body" \
 	"$(reddit_log_count 'post aidevops Reddit subject fixture private reddit post fixture marker')" "1"
 assert_eq "Reddit provider fields use the versioned immutable intent" \
 	"$(sql_value "$ROOT/index/social.db" "SELECT provider || ':' || intent_version || ':' || destination_remote_id FROM outbound_operations WHERE operation_id='op_reddit_post'")" \
-	"reddit:2:aidevops"
+	"reddit:3:aidevops"
 
 expect_failure "Reddit post titles reject more than 300 characters" \
 	"300-character title limit" "$HELPER" operation-create --base "$BASE" \


### PR DESCRIPTION
## Summary

Adds approval-bound, identity-verified LinkedIn member posts and private YouTube video uploads with immutable media binding, resumable-session checkpoints, capability gates, and documentation.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/configs/campaign-channel-specs.json, .agents/configs/capability-registry.json, .agents/configs/rate-limits.json.txt, .agents/content/distribution-social.md, .agents/content/social-linkedin.md, .agents/content/social-youtube.md, .agents/scripts/_knowledge_social_linkedin_outbound_provider.py, .agents/scripts/_knowledge_social_outbound.py, .agents/scripts/_knowledge_social_outbound_provider.py, .agents/scripts/_knowledge_social_outbound_reconciliation.py, .agents/scripts/_knowledge_social_outbound_runtime.py, .agents/scripts/_knowledge_social_store_schema.py, .agents/scripts/_knowledge_social_youtube_outbound_provider.py, .agents/scripts/knowledge_social_operations.py, .agents/scripts/knowledge_social_store.py, .agents/scripts/tests/test-social-linkedin-youtube-outbound.py, .agents/tests/test-knowledge-social-operations.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: hermetic provider adapter execution verified exact identity rejection, media binding and type rejection, persisted resumable upload-session checkpoint, and stable content-free receipts; bash .agents/tests/test-knowledge-social-operations.sh passed 56 tests; .agents/scripts/linters-local.sh --changed passed

Resolves #30141


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 23m and 185,558 tokens on this as a headless worker.