### PR TITLE
GH#30202: fix conversation lock verification race

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -236,6 +236,44 @@ check_dispatch_dedup() {
 }
 
 #######################################
+# Verify an issue conversation lock after GitHub accepts the lock mutation.
+# The issue REST read can briefly lag the mutation, so retry boundedly while
+# preserving the fail-closed trust boundary.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repository slug
+# Returns:
+#   0 when a read confirms locked=true, 1 after bounded exhaustion
+#######################################
+_verify_issue_conversation_lock() {
+	local issue_num="$1"
+	local slug="$2"
+	local attempts="${AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS:-3}"
+	local retry_delay="${AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY:-2}"
+	local attempt=1
+	local locked_state=""
+
+	[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || attempts=3
+	[[ "$attempts" -le 3 ]] || attempts=3
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=2
+	[[ "$retry_delay" -le 5 ]] || retry_delay=2
+
+	while [[ "$attempt" -le "$attempts" ]]; do
+		locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked == true' 2>/dev/null) || locked_state=""
+		if [[ "$locked_state" == "true" ]]; then
+			return 0
+		fi
+		if [[ "$attempt" -lt "$attempts" ]]; then
+			sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+
+	return 1
+}
+
+#######################################
 # Lock an issue (and any linked PRs) to prevent prompt injection
 # (t1894, t1934, GH#30180). Auto-dispatch is the authorization boundary,
 # so the issue must be frozen before it enters worker-readable context.
@@ -251,13 +289,11 @@ lock_issue_for_worker() {
 
 	# aidevops:trust-boundary — never launch a worker when the mutable public
 	# instruction surface could not be frozen and independently re-read.
-	local locked_state=""
 	if ! gh issue lock "$issue_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
 		return 1
 	fi
-	locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked == true' 2>/dev/null) || locked_state=""
-	if [[ "$locked_state" != "true" ]]; then
+	if ! _verify_issue_conversation_lock "$issue_num" "$slug"; then
 		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
+++ b/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
@@ -12,7 +12,8 @@ trap 'rm -rf "$TMP"' EXIT
 LOGFILE="${TMP}/pulse.log"
 GH_CALLS="${TMP}/gh-calls.log"
 AIDEVOPS_AUTO_DISPATCH_LOCK_DIR="${TMP}/locks"
-export LOGFILE GH_CALLS AIDEVOPS_AUTO_DISPATCH_LOCK_DIR
+AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=0
+export LOGFILE GH_CALLS AIDEVOPS_AUTO_DISPATCH_LOCK_DIR AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -34,13 +35,23 @@ fail() {
 
 GH_LOCKED=true
 GH_LOCK_RC=0
+GH_API_RC=0
 gh() {
 	printf '%s\n' "$*" >>"$GH_CALLS"
 	if [[ "$1" == "issue" && "$2" == "lock" ]]; then
 		return "$GH_LOCK_RC"
 	fi
 	if [[ "$1" == "api" ]]; then
-		printf '%s\n' "$GH_LOCKED"
+		local api_count
+		api_count=$(grep -c -- '^api ' "$GH_CALLS" 2>/dev/null || true)
+		if [[ "$GH_API_RC" -ne 0 ]]; then
+			return "$GH_API_RC"
+		fi
+		if [[ "$GH_LOCKED" == *,* ]]; then
+			printf '%s\n' "$GH_LOCKED" | cut -d, -f"$api_count"
+		else
+			printf '%s\n' "$GH_LOCKED"
+		fi
 		return 0
 	fi
 	return 0
@@ -66,8 +77,9 @@ else
 fi
 
 : >"$GH_CALLS"
-GH_LOCKED=false
+GH_LOCKED=false,false,false
 if ! lock_issue_for_worker 42 owner/repo &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
 	grep -q -- 'dispatch remains blocked' "$LOGFILE"; then
 	pass "unverified issue lock fails closed"
 else
@@ -75,6 +87,41 @@ else
 fi
 
 : >"$GH_CALLS"
+GH_LOCKED=false,true
+if lock_issue_for_worker 43 owner/repo &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 2 ]] &&
+	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-43" ]]; then
+	pass "stale lock read retries and then succeeds"
+else
+	fail "stale lock read retries and then succeeds"
+fi
+
+: >"$GH_CALLS"
+GH_LOCKED=false
+GH_API_RC=1
+if ! lock_issue_for_worker 44 owner/repo &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
+	[[ ! -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-44" ]]; then
+	pass "lock verification API errors exhaust retries and fail closed"
+else
+	fail "lock verification API errors exhaust retries and fail closed"
+fi
+
+: >"$GH_CALLS"
+GH_LOCKED=false,false,false
+AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS=999
+AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=999
+if ! lock_issue_for_worker 45 owner/repo &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]]; then
+	pass "oversized verification controls remain capped"
+else
+	fail "oversized verification controls remain capped"
+fi
+unset AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS
+AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=0
+
+: >"$GH_CALLS"
+GH_API_RC=0
 GH_LOCKED=true
 snapshot='[
   {"number":51,"labels":[{"name":"auto-dispatch"},{"name":"status:blocked"}]},


### PR DESCRIPTION
## Summary

Retry stale post-lock reads within hard bounds while preserving fail-closed worker launch semantics.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-auto-dispatch-conversation-lock.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with 7 focused lock scenarios, 48 precreation tests, 79 manual-dispatch tests, ShellCheck, changed-file linters, and independent high-risk review.

Resolves #30202


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 33m and 506,234 tokens on this with the user in an interactive session.