### PR TITLE
GH#30201: fix authorized no-release reconciliation

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -1037,6 +1037,7 @@ _full_loop_release_existing_command() {
 	local protected_tag_state_rc=0
 	local receipt_path=""
 	local receipt_status=""
+	local source_json=""
 
 	[[ "$mode" == "status" || "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || return 1
 	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
@@ -1046,10 +1047,7 @@ _full_loop_release_existing_command() {
 	printf 'RELEASE_RECEIPT=%s\n' "${receipt_status:-missing}"
 	case "$receipt_status" in
 	"" | "$_FULL_LOOP_PHASE_FAILED" | "$_FULL_LOOP_RELEASE_PUBLISHED" | "$_FULL_LOOP_RELEASE_SUPERSEDED") ;;
-	"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
-		printf 'Cannot reconcile terminal release:not-requested evidence for PR #%s\n' "$requested_pr" >&2
-		return 1
-		;;
+	"$_FULL_LOOP_RELEASE_NOT_REQUESTED") ;;
 	*)
 		printf 'Cannot reconcile unknown release:%s evidence for PR #%s\n' "$receipt_status" "$requested_pr" >&2
 		return 1
@@ -1057,6 +1055,19 @@ _full_loop_release_existing_command() {
 	esac
 	_full_loop_release_find_tag_for_pr "$repo" "$requested_pr" || return $?
 	tag_name="$_FULL_LOOP_RELEASE_FOUND_TAG"
+	if [[ "$receipt_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]; then
+		[[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || {
+			printf 'Cannot reconcile terminal release:not-requested evidence for PR #%s\n' "$requested_pr" >&2
+			return 1
+		}
+		source_json=$(_full_loop_release_source_json_from_tag "$tag_name") || return 1
+		_full_loop_release_validate_published_reconciliation_intent \
+			"$repo" "$requested_pr" "$tag_name" "$source_json" || {
+			printf 'Cannot reconcile release:not-requested without matching explicit publication intent for PR #%s\n' \
+				"$requested_pr" >&2
+			return 1
+		}
+	fi
 	latest_tag=$(_full_loop_release_latest_tag) || return 1
 	if [[ "$tag_name" != "$latest_tag" ]]; then
 		printf 'STALE_RELEASE_TAG=%s\nLATEST_RELEASE_TAG=%s\n' "$tag_name" "$latest_tag"

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -1488,6 +1488,7 @@ fi
 printf 'PASS published reconciliation is idempotent\n'
 
 printf 'not-requested\n' >"${TEST_ROOT}/receipts/test_repo-90.status"
+lane_expected_sources='91'
 terminal_rc=0
 AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
 	>/dev/null 2>&1 || terminal_rc=$?
@@ -1496,7 +1497,15 @@ if [[ "$terminal_rc" -ne 1 ]]; then
 	exit 1
 fi
 printf 'PASS reconciliation cannot replace the explicit release command as publication intent\n'
-rm -f "${TEST_ROOT}/receipts/test_repo-90.status"
+lane_expected_sources='90@1111111111111111111111111111111111111111'
+rm -f "${TEST_ROOT}/finalize.log"
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 >/dev/null
+if ! grep -qx 'test/repo 90 v1.2.3' "${TEST_ROOT}/finalize.log"; then
+	printf 'FAIL matching explicit publication intent did not transition not-requested evidence\n'
+	exit 1
+fi
+printf 'PASS matching explicit publication intent may transition not-requested evidence\n'
+rm -f "${TEST_ROOT}/receipts/test_repo-90.status" "${TEST_ROOT}/finalize.log"
 
 _full_loop_release_latest_tag() {
 	printf 'v1.2.4\n'


### PR DESCRIPTION
## Summary

Allow release reconciliation to transition an earlier `release:not-requested` receipt only when the active release lane and persisted authorization exactly match the signed tag provenance.

## Evidence

The authorized v3.32.259 lane for source PR #30199 reached protected-main merge, but `aidevops release reconcile 30199` stopped before publishing the preserved tag because the source had historical `release:not-requested` evidence. The release workflow explicitly permits a later authorized release to transition that state.

## Implementation

- Keep read-only `status` and mismatched-lane reconciliation fail-closed.
- Permit `reconcile` only after `_full_loop_release_validate_published_reconciliation_intent` verifies the source, signed tag, persisted authorization, and active lane.
- Add regression coverage for mismatched and exactly matching publication intent.

## Verification

- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `shellcheck .agents/scripts/full-loop-release-reconcile.sh .agents/scripts/tests/test-full-loop-release-reconcile.sh`

Ref #30201

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 32m and 543,017 tokens on this with the user in an interactive session.
