### PR TITLE
GH#30201: permit reviewed release recovery aggregation

### DIFF
--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -382,6 +382,41 @@ release_lane_finalize() {
 	return $?
 }
 
+#aidevops:trust-boundary
+_release_lane_pr_is_metadata_only_aggregate() {
+	local repo="$1"
+	local pr_number="$2"
+	local pr_json=""
+	local body=""
+	local identity_count=0
+	local aggregate_count=0
+	local files_count=""
+	command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1 || return 1
+	pr_json=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || return 1
+	jq -e --argjson pr "$pr_number" '
+		.state == "open" and .base.ref == "main"
+		and (.number == $pr)
+		and (.head.sha | test("^[0-9a-f]{40}$"))
+		and (.base.sha | test("^[0-9a-f]{40}$"))
+	' <<<"$pr_json" >/dev/null || return 1
+	body=$(jq -er '.body // ""' <<<"$pr_json") || return 1
+	identity_count=$(awk -v expected="Aidevops-Release-Aggregator-PR: ${pr_number}" \
+		'$0 == expected { count++ } END { print count + 0 }' <<<"$body") || return 1
+	[[ "$identity_count" -eq 1 ]] || return 1
+	aggregate_count=$(awk '
+		/^Aidevops-Release-Aggregates: / {
+			value = substr($0, index($0, ": ") + 2)
+			if (value !~ /^[0-9]+@[0-9a-f]{40}$/) exit 2
+			count++
+		}
+		END { print count + 0 }
+	' <<<"$body") || return 1
+	[[ "$aggregate_count" -gt 0 ]] || return 1
+	files_count=$(gh api "repos/${repo}/pulls/${pr_number}/files?per_page=1" --jq 'length' 2>/dev/null) || return 1
+	[[ "$files_count" == "0" ]]
+	return $?
+}
+
 release_lane_merge_guard() {
 	local repo="$1"
 	local pr_number="$2"
@@ -420,6 +455,9 @@ release_lane_merge_guard() {
 	source_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	tag_name=$(jq -r '.tag // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	if [[ "$pr_number" == "$source_pr" || (-n "$tag_name" && "$head_ref" == "chore/release-${tag_name}-provenance") ]]; then
+		return 0
+	fi
+	if _release_lane_pr_is_metadata_only_aggregate "$repo" "$pr_number"; then
 		return 0
 	fi
 	printf 'ACTIVE_RELEASE_LANE_MERGE_BLOCKED source_pr=%s phase=%s tag=%s\n' \

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -96,6 +96,21 @@ run_merge_guard_test() (
 		_AIDEVOPS_RELEASE_LANE_JSON="$state"
 		return 0
 	}
+	gh() {
+		local endpoint="${2:-}"
+		case "$endpoint" in
+		"repos/test/repo/pulls/404")
+			jq -cn '{number:404,state:"open",base:{ref:"main",sha:("4" * 40)},
+				head:{sha:("5" * 40)},body:(
+				"Aidevops-Release-Aggregator-PR: 404\n"
+				+ "Aidevops-Release-Aggregates: 101@" + ("1" * 40)
+			)}'
+			;;
+		"repos/test/repo/pulls/404/files?per_page=1") printf '0\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
 	output=$(AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 202 main feature/ordinary 2>&1) || rc=$?
 	[[ "$rc" -eq 75 && "$output" == *"source_pr=101"* && "$output" == *"phase=remote-publication"* ]] || return 1
@@ -103,6 +118,8 @@ run_merge_guard_test() (
 		release_lane_merge_guard test/repo 101 main feature/release-owner || return 1
 	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 303 main chore/release-v1.2.3-provenance || return 1
+	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 404 main release/aggregate-recovery || return 1
 	state='{"schema_version":1,"repository":"test/repo","active":false,"source_pr":101,"phase":"terminal","tag":"v1.2.3","operation_token":"token-old","terminal_receipt":"superseded"}'
 	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 202 main feature/ordinary || return 1


### PR DESCRIPTION
## Summary

Permit a verified metadata-only release aggregation PR to merge while an active release lane blocks unrelated changes.

## Evidence

The v3.32.259 protected release PR merged correctly, but later reconciliation detected that `main` had advanced to a different tree. Recovery requires a new reviewed exact-tip aggregation PR; the active release-lane merge guard currently blocks that required recovery PR unless it uses the protected release branch name.

## Implementation

- Fetch the candidate PR through the GitHub API and require an open PR against `main` with valid base/head SHAs.
- Require exactly one matching `Aidevops-Release-Aggregator-PR` identity and at least one well-formed immutable source trailer.
- Require the PR to have zero changed files before bypassing the active-lane merge block.
- Keep ordinary and malformed PRs blocked.

## Verification

- `bash .agents/scripts/tests/test-release-lane.sh`
- `shellcheck .agents/scripts/release-lane-helper.sh .agents/scripts/tests/test-release-lane.sh`

Ref #30201

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 46m and 601,000 tokens on this with the user in an interactive session.
