### PR TITLE
GH#30213: fix: authorize no-release aggregate recovery

### DIFF
--- a/.agents/reference/release-aggregation-recovery.md
+++ b/.agents/reference/release-aggregation-recovery.md
@@ -29,7 +29,10 @@ must appear once in the aggregate commit trailers at its verified merge SHA.
   descendant.
 - The persisted authorization is an exact subset of the reviewed aggregate.
 - The lane is in `remote-publication` or `reconcile-required` for the same source
-  and tag.
+  and tag, or it contains one valid interrupted `aggregation-recovery` or
+  `aggregation-recovery-refresh` transaction, or an owned
+  `aggregate-publication-committing` transaction whose provisional tag and exact
+  snapshots remain unchanged.
 
 Any unavailable channel read is uncertainty, not absence, and blocks recovery.
 
@@ -37,31 +40,66 @@ Any unavailable channel read is uncertainty, not absence, and blocks recovery.
 
 1. Verify the provisional tag and all channel-absence evidence.
 2. Resolve the exact aggregate and normalize every source to `PR@MERGE_SHA`.
-3. Persist the expanded authorization and rotate the release-lane token into
-   `aggregation-recovery`, fencing the prior process. Both records embed their
-   exact pre-transaction JSON for compare-and-swap restoration.
-4. Create an empty `chore(release): bump version to X.Y.Z` commit whose parent is
+3. Rotate the release-lane token into `aggregation-recovery-refresh`, fencing the
+   prior process before authorization broadens. Persist the expanded
+   authorization, then advance the same owned lane to `aggregation-recovery`.
+   Both records embed their exact pre-transaction JSON for compare-and-swap
+   restoration.
+4. Claim `aggregate-publication-committing` with the same token, then create an
+   empty `chore(release): bump version to X.Y.Z` commit whose parent is
    the exact aggregate. The tree and semantic version do not change.
 5. Replace only the local tag with a newly signed aggregate-bound tag and run the
    ordinary protected-main publication queue.
-6. Record `.aggregate-recovery.json` evidence and return the lane to
-   `remote-publication` for normal reconciliation.
+6. Record `.aggregate-recovery.json` evidence and retain the committing phase
+   while a protected-main PR is open. Only after the exact release commit is
+   reachable from `origin/main` may the lane enter `remote-publication` for
+   normal reconciliation.
 
-## Rollback and interruption
+The earlier side-effect-free reserved-lane normalization uses the same ordering:
+rotate into `reserved-authorization-refresh`, persist the exact authorization,
+then return to `reserved`. A retry must inspect this phase even when the requested
+and persisted PR sets already match, because the authorization write may have
+completed before the prior process finished the lane transition.
 
-Before a durable queue exists, any failure restores the exact original tag
-object, authorization manifest, and release-lane JSON. Recovery uses compare-and-
-swap lane writes, so a concurrent owner change fails closed rather than being
-overwritten.
+## Failure and interruption
+
+An initial failure before authorization changes may restore the exact prior lane
+snapshot. Once authorization has expanded, recovery does not independently
+restore the authorization and lane records: that two-write rollback would expose
+another crash window. It retains the fenced transaction for an idempotent retry.
+A refreshed aggregate first rotates the lane into
+`aggregation-recovery-refresh`, then writes authorization, and finally returns to
+`aggregation-recovery`. If a provisional-tag attempt fails after claiming the
+committing phase, a retry may rotate that unchanged, unpublished transaction into
+a newer reviewed refresh. Recovery uses compare-and-swap lane writes, so a
+concurrent owner change fails closed rather than being overwritten.
+
+Before local tag replacement or any direct push, protected recovery-branch push,
+PR mutation, merge queue request, or final tag push, version-manager rereads the
+remote lane and requires the exact repository, source, tag, manifest, operation
+token, and `aggregate-publication-committing` phase. A stale process cannot
+publish after its token is rotated; ambiguous claim writes are accepted only
+after an exact remote reread.
 
 Once the protected release PR or remote tag is durable, do not restore or mutate
-the provisional state. Resume with `aidevops release reconcile <source-pr>`; the
-normal verifier and channel convergence gates own completion.
+the provisional state. While the PR remains open, rerun the same
+`recover-aggregate` command to repair or observe its exact queue; generic
+reconciliation leaves the committing fence unchanged. After the release commit
+reaches `main`, recovery transitions to `remote-publication` and the normal
+reconciliation and channel convergence gates own completion.
 
 Rerunning `recover-aggregate` after an interruption reloads the persisted
 snapshots. If the replacement aggregate-bound tag already exists, the command
-enters normal reconciliation without replacing the tag or creating another bump
-commit. Inconsistent or incomplete recovery state fails closed.
+resumes its exact protected queue from the persisted aggregate before resolving
+the newer `main`; it does not replace the tag or create another bump commit. The
+recovered-tag validator checks the tag's direct aggregate parent and immutable
+source manifest rather than requiring that parent to remain the current main tip.
+Once that release commit reaches `main`, recovery enters normal reconciliation.
+If `main` advanced before the provisional tag changed, a newer reviewed exact-tip
+aggregate may refresh the fenced transaction. The refresh must be a strict
+authorization superset, preserve the original snapshots, and rotate the lane
+token without nesting recovery state. Ordinary merges remain blocked during
+every recovery and committing phase. Inconsistent state fails closed.
 
 The recovery command never force-pushes, rewrites a remote tag, increments the
 version, or infers publication authority from commit ancestry.

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -11,6 +11,12 @@ _FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED=""
 _FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=""
 _FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT=""
 _FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON=""
+_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT="none"
+_FULL_LOOP_AGGREGATE_RECOVERY_MANIFEST_JQ='sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")'
+_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX='^[0-9a-f]{40}$'
+_FULL_LOOP_AGGREGATE_RECOVERY_PHASE="aggregation-recovery"
+_FULL_LOOP_AGGREGATE_COMMIT_PHASE="aggregate-publication-committing"
+_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX="refs/tags/"
 
 _full_loop_recovery_http_status() {
 	local endpoint="$1"
@@ -67,7 +73,7 @@ _full_loop_recovery_verify_homebrew_absent() {
 
 _full_loop_recovery_verify_all_remote_tags_absent() {
 	local tag_name="$1"
-	local tag_ref="refs/tags/${tag_name}"
+	local tag_ref="${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}"
 	local remotes=""
 	local remote=""
 	local remote_rc=0
@@ -92,6 +98,126 @@ _full_loop_recovery_verify_channels_absent() {
 	return 0
 }
 
+_full_loop_recovery_source_matches_authorization() {
+	local authorization="$1"
+	local source_json="$2"
+	local authorization_json=""
+	local observed_json=""
+	local observed_sources=""
+	authorization_json=$(release_authorization_manifest_json "$authorization") || return 1
+	observed_json=$(release_authorization_observed_sources_json "$authorization_json" "$source_json") || return 1
+	observed_sources=$(jq -r "$_FULL_LOOP_AGGREGATE_RECOVERY_MANIFEST_JQ" \
+		<<<"$observed_json") || return 1
+	release_authorization_compare "$authorization" "$observed_sources"
+	return $?
+}
+
+_full_loop_recovery_record_authorization() {
+	local record="$1"
+	local expected_json=""
+	expected_json=$(jq -ce '.expected_sources | sort_by(.pr)' <<<"$record") || return 1
+	jq -r "$_FULL_LOOP_AGGREGATE_RECOVERY_MANIFEST_JQ" <<<"$expected_json"
+	return $?
+}
+
+_full_loop_recovery_lane_intent_matches_authorization() {
+	local lane_sources="$1"
+	local authorization="$2"
+	local lane_intent_json=""
+	local authorization_json=""
+	[[ "$lane_sources" == "$authorization" ]] && return 0
+	lane_intent_json=$(release_authorization_intent_json "$lane_sources") || return 1
+	authorization_json=$(release_authorization_manifest_json "$authorization") || return 1
+	jq -e --argjson lane_intent "$lane_intent_json" --argjson authorized "$authorization_json" '
+		all($lane_intent[]; .merge == null)
+		and ([$lane_intent[].pr] | sort) == ([$authorized[].pr] | sort)
+	' <<<"$authorization_json" >/dev/null
+	return $?
+}
+
+#aidevops:trust-boundary
+_full_loop_recovery_validate_interrupted_publication_intent() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local source_json="$4"
+	local current_authorization=""
+	local previous_record=""
+	local previous_authorization=""
+	local lane_previous=""
+	local lane_previous_sources=""
+	local provisional_tag_object=""
+	local phase=""
+	local lane_expected=""
+	local refresh_previous=""
+	local refresh_pending=""
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	[[ -n "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	current_authorization=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	previous_record=$(_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr") || return 1
+	jq -e '((.aggregate_recovery // null) == null)' <<<"$previous_record" >/dev/null || return 1
+	previous_authorization=$(_full_loop_recovery_record_authorization "$previous_record") || return 1
+	release_authorization_subset "$previous_authorization" "$current_authorization" || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and ((.terminal_receipt // null) == null)
+		and ((.phase | type) == "string") and ((.expected_sources | type) == "string")
+		and (.aggregate_recovery.provisional_tag_object | test($sha40))
+		and (.aggregate_recovery.previous_state.schema_version == 1)
+		and (.aggregate_recovery.previous_state.repository == .repository)
+		and (.aggregate_recovery.previous_state.active == true)
+		and (.aggregate_recovery.previous_state.source_pr == $source_pr)
+		and (.aggregate_recovery.previous_state.tag == $tag)
+		and ((.aggregate_recovery.previous_state.phase == "remote-publication")
+			or (.aggregate_recovery.previous_state.phase == "reconcile-required"))
+		and ((.aggregate_recovery.previous_state.terminal_receipt // null) == null)
+		and ((.aggregate_recovery.previous_state.aggregate_recovery // null) == null)
+		and ((.aggregate_recovery.previous_state.expected_sources | type) == "string")
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	lane_expected=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	case "$phase" in
+	aggregation-recovery | aggregate-publication-committing)
+		[[ "$lane_expected" == "$current_authorization" ]] || return 1
+		release_authorization_subset "$current_authorization" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		;;
+	aggregation-recovery-refresh)
+		refresh_previous=$(jq -er '.aggregate_recovery.refresh.previous_expected_sources' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		refresh_pending=$(jq -er '.aggregate_recovery.refresh.pending_expected_sources' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		[[ "$lane_expected" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
+			"$refresh_pending" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+		[[ "$current_authorization" == "$refresh_previous" ||
+			"$current_authorization" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+		release_authorization_subset "$previous_authorization" "$refresh_previous" || return 1
+		release_authorization_subset "$refresh_previous" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		;;
+	*) return 1 ;;
+	esac
+	lane_previous=$(jq -ce '.aggregate_recovery.previous_state' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	lane_previous_sources=$(jq -er '.expected_sources' <<<"$lane_previous") || return 1
+	_full_loop_recovery_lane_intent_matches_authorization \
+		"$lane_previous_sources" "$previous_authorization" || return 1
+	provisional_tag_object=$(jq -er '.aggregate_recovery.provisional_tag_object' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" == "$provisional_tag_object" ]]; then
+		_full_loop_recovery_source_matches_authorization "$previous_authorization" "$source_json"
+		return $?
+	fi
+	[[ "$phase" == "$_FULL_LOOP_AGGREGATE_RECOVERY_PHASE" ||
+		"$phase" == "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE" ]] || return 1
+	[[ "$current_authorization" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	_full_loop_recovery_source_matches_authorization "$current_authorization" "$source_json" || return 1
+	_full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name"
+	return $?
+}
+
 #aidevops:trust-boundary
 _full_loop_recovery_validate_receipt() {
 	local repo="$1"
@@ -108,6 +234,11 @@ _full_loop_recovery_validate_receipt() {
 		if [[ -n "$tag_name" && -n "$source_json" ]] &&
 			declare -F _full_loop_release_validate_published_reconciliation_intent >/dev/null 2>&1 &&
 			_full_loop_release_validate_published_reconciliation_intent \
+				"$repo" "$source_pr" "$tag_name" "$source_json"; then
+			return 0
+		fi
+		if [[ -n "$tag_name" && -n "$source_json" ]] &&
+			_full_loop_recovery_validate_interrupted_publication_intent \
 				"$repo" "$source_pr" "$tag_name" "$source_json"; then
 			return 0
 		fi
@@ -131,9 +262,50 @@ _full_loop_recovery_validate_existing_tag() {
 		'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
 	[[ "$requested_present" == "true" ]] || return 1
 	_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON="$source_json"
-	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
 	_full_loop_release_reset_tag_worktree || return 1
 	return 0
+}
+
+_full_loop_recovery_prepare_existing_context() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local requested_sources="$4"
+	local current_authorization=""
+	local current_json=""
+	local requested_json=""
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT="none"
+	if ! _full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" >/dev/null 2>&1; then
+		return 0
+	fi
+	current_authorization=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	current_json=$(release_authorization_manifest_json "$current_authorization") || return 1
+	requested_json=$(release_authorization_intent_json "$requested_sources") || return 1
+	jq -e --argjson current "$current_json" --argjson requested "$requested_json" '
+		($current | length) == ($requested | length)
+		and all($requested[]; . as $entry
+			| any($current[]; .pr == $entry.pr and ($entry.merge == null or .merge == $entry.merge)))
+	' <<<"null" >/dev/null || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$current_authorization"
+	_FULL_LOOP_RESOLVED_SOURCE_JSON="$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON"
+	_FULL_LOOP_RESOLVED_SOURCE_PR=$(jq -er '.source_pr' \
+		<<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON") || return 1
+	_FULL_LOOP_RESOLVED_SOURCE_MERGE=$(jq -er '.source_merge' \
+		<<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON") || return 1
+	[[ "$_FULL_LOOP_RESOLVED_SOURCE_MERGE" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	_full_loop_recovery_validate_receipt "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
+	if _full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name"; then
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT="transaction"
+		return 0
+	fi
+	if _full_loop_recovery_load_remote_publication_state "$repo" "$source_pr" "$tag_name"; then
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT="remote-publication"
+		return 0
+	fi
+	return 1
 }
 
 _full_loop_recovery_tag_sources() {
@@ -142,7 +314,7 @@ _full_loop_recovery_tag_sources() {
 	expected_json=$(release_authorization_manifest_json "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || return 1
 	observed_json=$(release_authorization_observed_sources_json "$expected_json" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON") || return 1
-	jq -r 'map("\(.pr)@\(.merge)") | join(",")' <<<"$observed_json"
+	jq -r "$_FULL_LOOP_AGGREGATE_RECOVERY_MANIFEST_JQ" <<<"$observed_json"
 	return $?
 }
 
@@ -150,7 +322,7 @@ _full_loop_recovery_tag_is_bound_to_current_aggregate() {
 	local tag_name="$1"
 	local tag_parent=""
 	local aggregate_merge="${_FULL_LOOP_RESOLVED_SOURCE_MERGE:-}"
-	[[ "$aggregate_merge" =~ ^[0-9a-f]{40}$ ]] || return 1
+	[[ "$aggregate_merge" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
 	tag_parent=$(git -C "$REPO_ROOT" rev-parse "${tag_name}^{commit}^" 2>/dev/null) || return 1
 	[[ "$tag_parent" == "$aggregate_merge" ]]
 	return $?
@@ -164,20 +336,24 @@ _full_loop_recovery_load_existing_state_transaction() {
 	local previous_record=""
 	existing=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
 	[[ "$existing" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	_full_loop_recovery_validate_interrupted_publication_intent "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
 	previous_record=$(_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr") || return 1
-	_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=$(jq -r '
-		.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")
-	' <<<"$previous_record") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=$(
+		_full_loop_recovery_record_authorization "$previous_record"
+	) || return 1
 	release_authorization_subset "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
-		--arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" '
+		--arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+		--arg recovery "$_FULL_LOOP_AGGREGATE_RECOVERY_PHASE" \
+		--arg committing "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE" \
+		--arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" '
 		.active == true and .source_pr == $source_pr and .tag == $tag
 		and .expected_sources == $expected
-		and (.phase == "aggregation-recovery" or .phase == "remote-publication")
+		and (.phase == $recovery or .phase == $committing)
 		and ((.terminal_receipt // null) == null)
-		and (.aggregate_recovery.provisional_tag_object | test("^[0-9a-f]{40}$"))
+		and (.aggregate_recovery.provisional_tag_object | test($sha40))
 		and (.aggregate_recovery.previous_state.schema_version == 1)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT=$(jq -ce '.aggregate_recovery.previous_state' \
@@ -185,6 +361,56 @@ _full_loop_recovery_load_existing_state_transaction() {
 	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=$(jq -er '.aggregate_recovery.provisional_tag_object' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	return 0
+}
+
+_full_loop_recovery_refresh_state_transaction() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local existing=""
+	local existing_record=""
+	local latest_record=""
+	local previous_record=""
+	local previous_authorization=""
+	local lane_snapshot=""
+	local phase=""
+	local refresh_previous=""
+	existing=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	_full_loop_recovery_validate_interrupted_publication_intent "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
+	existing_record=$(_full_loop_read_release_authorization_record "$repo" "$source_pr") || return 1
+	previous_record=$(_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr") || return 1
+	previous_authorization=$(_full_loop_recovery_record_authorization "$previous_record") || return 1
+	lane_snapshot=$(jq -ce '.aggregate_recovery.previous_state' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	case "$phase" in
+	aggregation-recovery | aggregate-publication-committing)
+		[[ "$existing" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+		refresh_previous="$existing"
+		release_lane_begin_aggregate_refresh "$repo" "$source_pr" "$tag_name" "$refresh_previous" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" || return 1
+		;;
+	aggregation-recovery-refresh)
+		refresh_previous=$(jq -er '.aggregate_recovery.refresh.previous_expected_sources' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		;;
+	*) return 1 ;;
+	esac
+	if [[ "$existing" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		latest_record=$(_full_loop_read_release_authorization_record "$repo" "$source_pr") || return 1
+		[[ "$latest_record" == "$existing_record" ]] || return 1
+		_full_loop_write_release_authorization_record "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_record" || return 1
+	fi
+	[[ "$(_full_loop_read_release_authorization "$repo" "$source_pr")" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	release_lane_finish_aggregate_refresh "$repo" "$source_pr" "$tag_name" "$refresh_previous" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$previous_authorization"
+	_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT="$lane_snapshot"
 	return 0
 }
 
@@ -221,8 +447,61 @@ _full_loop_recovery_resolve_lane_authorization() {
 				then $matches[0]
 				else error("reserved lane intent does not match reviewed aggregate")
 			  end)
-		| map("\(.pr)@\(.merge)") | join(",")
+		| map([.pr, .merge] | join("@")) | join(",")
 	' 2>/dev/null
+	return $?
+}
+
+_full_loop_recovery_reserved_base_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local current_authorization="$3"
+	local lane_sources="$4"
+	local expected_sources="$5"
+	local normalized_lane_sources=""
+	local previous_record=""
+	local previous_authorization=""
+	normalized_lane_sources=$(_full_loop_recovery_resolve_lane_authorization \
+		"$lane_sources" "$expected_sources") || return 1
+	if [[ "$normalized_lane_sources" == "$current_authorization" ]]; then
+		printf '%s\n' "$normalized_lane_sources"
+		return 0
+	fi
+	[[ "$current_authorization" == "$expected_sources" ]] || return 1
+	previous_record=$(_full_loop_read_release_authorization_recovery_snapshot \
+		"$repo" "$source_pr") || return 1
+	previous_authorization=$(_full_loop_recovery_record_authorization "$previous_record") || return 1
+	[[ "$normalized_lane_sources" == "$previous_authorization" ]] || return 1
+	printf '%s\n' "$previous_authorization"
+	return 0
+}
+
+_full_loop_recovery_reserved_lane_requires_migration() {
+	local repo="$1"
+	local source_pr="$2"
+	local persisted_sources="$3"
+	local read_rc=0
+	local lane_sources=""
+	local lane_prs=""
+	local persisted_prs=""
+	release_lane_read "$repo" || read_rc=$?
+	case "$read_rc" in
+	2) return 1 ;;
+	0) ;;
+	*) return 2 ;;
+	esac
+	jq -e --argjson source_pr "$source_pr" '
+		.active == true and .source_pr == $source_pr and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	if [[ "$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" ]]; then
+		return 0
+	fi
+	jq -e '.phase == "reserved" and .tag == null and (.expected_sources | type) == "string"' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 2
+	lane_prs=$(release_authorization_intent_json "$lane_sources" | jq -c 'map(.pr)') || return 2
+	persisted_prs=$(release_authorization_intent_json "$persisted_sources" | jq -c 'map(.pr)') || return 2
+	[[ "$lane_prs" != "$persisted_prs" ]]
 	return $?
 }
 
@@ -232,8 +511,9 @@ _full_loop_recovery_expand_reserved_authorization() {
 	local expected_sources="$3"
 	local previous_auth=""
 	local lane_sources=""
-	local normalized_lane_sources=""
-	local authorization_expanded=false
+	local phase=""
+	local current_auth=""
+	local observed_auth=""
 	local existing_tag_rc=0
 	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
 	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
@@ -241,48 +521,60 @@ _full_loop_recovery_expand_reserved_authorization() {
 	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
 	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
 	_full_loop_release_reset_tag_worktree || return 1
-	previous_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
-	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	current_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" '
-		.active == true and .source_pr == $source_pr and .phase == "reserved"
-		and .tag == null and (.expected_sources | type) == "string"
+		.active == true and .source_pr == $source_pr and .tag == null
+		and (.expected_sources | type) == "string" and (.phase | type) == "string"
 		and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || {
 		printf 'Reserved release lane is not eligible for legacy authorization normalization for PR #%s\n' "$source_pr" >&2
 		return 1
 	}
-	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	normalized_lane_sources=$(_full_loop_recovery_resolve_lane_authorization \
-		"$lane_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	case "$phase" in
+	reserved)
+		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		;;
+	"$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH")
+		[[ "$(jq -r '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+		lane_sources=$(jq -er '.reserved_authorization_refresh.previous_expected_sources' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		;;
+	*) return 1 ;;
+	esac
+	previous_auth=$(_full_loop_recovery_reserved_base_authorization "$repo" "$source_pr" \
+		"$current_auth" "$lane_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
 		printf 'Reserved release lane authorization cannot be normalized against reviewed aggregate PR #%s\n' "$source_pr" >&2
 		return 1
 	}
-	if ! release_authorization_compare "$normalized_lane_sources" "$previous_auth"; then
-		printf 'Reserved release lane and persisted authorization identify different sources for PR #%s\n' "$source_pr" >&2
-		return 1
-	fi
-	release_lane_acquire "$repo" "$source_pr" "$lane_sources" || return $?
-	[[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "acquired" ]] || return 1
-	if [[ "$previous_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
-		"$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	if [[ "$phase" == "reserved" && "$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
+		"$current_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		_AIDEVOPS_RELEASE_LANE_RESULT="adopted"
 		printf 'Reserved release authorization already matches the reviewed aggregate for PR #%s\n' "$source_pr"
 		return 0
 	fi
-	if [[ "$previous_auth" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+	release_lane_acquire "$repo" "$source_pr" "$lane_sources" || return $?
+	case "$_AIDEVOPS_RELEASE_LANE_RESULT" in acquired | adopted) ;; *) return 1 ;; esac
+	release_lane_expand_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	if [[ "$current_auth" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
 		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
-			"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-		authorization_expanded=true
+			"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || {
+			observed_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+			if [[ "$observed_auth" == "$previous_auth" ]]; then
+				release_lane_restore_reserved_authorization "$repo" "$source_pr" \
+					"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+					"$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT" || true
+			fi
+			[[ "$observed_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+		}
 	fi
-	if ! release_lane_expand_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
+	if ! release_lane_finish_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
-		release_lane_restore_reserved_authorization "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT" || true
-		if [[ "$authorization_expanded" == "true" ]]; then
-			_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-				"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_auth" || return 1
-		fi
-		printf 'Reserved release lane authorization migration failed for PR #%s; prior state was restored\n' "$source_pr" >&2
+		printf 'Reserved release lane authorization migration remains fenced for retry for PR #%s\n' "$source_pr" >&2
 		return 1
 	fi
 	printf 'Expanded side-effect-free reserved release authorization for reviewed aggregate PR #%s\n' "$source_pr"
@@ -299,40 +591,125 @@ _full_loop_recovery_begin_state_transaction() {
 	if [[ "$existing" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
 		_full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name" && return 0
 		if _full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" >/dev/null 2>&1; then
-			_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=$(
-				_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" |
-					jq -r '.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")'
-			) || return 1
-		else
-			_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$existing"
-			_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
-				"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+			_full_loop_recovery_refresh_state_transaction "$repo" "$source_pr" "$tag_name"
+			return $?
 		fi
 	else
+		if _full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" >/dev/null 2>&1; then
+			_full_loop_recovery_refresh_state_transaction "$repo" "$source_pr" "$tag_name"
+			return $?
+		fi
 		_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$existing"
 		release_authorization_subset "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" \
 			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
 	fi
-	if ! release_lane_read "$repo"; then
-		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
-		return 1
-	fi
-	if ! lane_expected=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON"); then
-		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
-		return 1
-	fi
+	_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$existing"
+	release_lane_read "$repo" || return 1
+	lane_expected=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	if ! release_lane_begin_aggregate_recovery "$repo" "$source_pr" "$tag_name" "$lane_expected" \
-		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT"; then
-		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT"; then
 		return 1
 	fi
 	_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
+	if ! _full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
+		release_lane_restore_aggregate_recovery "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT" || true
+		return 1
+	fi
+	release_lane_finish_aggregate_refresh "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" || return 1
 	return 0
+}
+
+_full_loop_recovery_load_remote_publication_state() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local provisional_tag_object=""
+	_full_loop_release_validate_published_reconciliation_intent "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+		--arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .phase == "remote-publication" and .expected_sources == $expected
+		and ((.terminal_receipt // null) == null)
+		and (.aggregate_recovery.provisional_tag_object | test($sha40))
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	provisional_tag_object=$(jq -er '.aggregate_recovery.provisional_tag_object' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$provisional_tag_object"
+	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	return 0
+}
+
+_full_loop_recovery_transition_durable_publication() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local current_tag_object=""
+	local reachability_rc=0
+	local update_rc=0
+	current_tag_object=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
+	[[ "$current_tag_object" != "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]] || return 1
+	_full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name" || return 1
+	[[ "$(_full_loop_read_release_authorization "$repo" "$source_pr")" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+		--arg committing "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .operation_token == $token and .phase == $committing
+		and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+		and ((.aggregate_recovery.refresh // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	_full_loop_recovery_release_commit_main_reachability "$tag_name" || reachability_rc=$?
+	case "$reachability_rc" in
+	0) ;;
+	2) return 8 ;;
+	*) return 1 ;;
+	esac
+	release_lane_update "$repo" "$source_pr" remote-publication "$tag_name" || update_rc=$?
+	if [[ "$update_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$update_rc"
+		jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+			--arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" '
+			.active == true and .source_pr == $source_pr and .tag == $tag
+			and .phase == "remote-publication" and .expected_sources == $expected
+			and ((.terminal_receipt // null) == null)
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$update_rc"
+		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return "$update_rc"
+	fi
+	return 0
+}
+
+_full_loop_recovery_release_commit_main_reachability() {
+	local tag_name="$1"
+	local release_commit=""
+	local ancestry_rc=0
+	git -C "$REPO_ROOT" fetch origin main >/dev/null || return 1
+	release_commit=$(git -C "$REPO_ROOT" rev-parse "${tag_name}^{commit}") || return 1
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$release_commit" origin/main || ancestry_rc=$?
+	case "$ancestry_rc" in
+	0) return 0 ;;
+	1) return 2 ;;
+	*) return 1 ;;
+	esac
+}
+
+_full_loop_recovery_report_pending_commit() {
+	local source_pr="$1"
+	local tag_name="$2"
+	printf 'release:aggregate-recovery queued tag=%s source_pr=%s\n' "$tag_name" "$source_pr"
+	printf 'The exact protected-main publication remains fenced until its release commit reaches main.\n'
+	printf 'Resume with: aidevops release status %s\n' "$source_pr"
+	printf 'Then rerun the same recover-aggregate command after the protected PR merges.\n'
+	return 8
 }
 
 _full_loop_recovery_resume_publication() {
@@ -341,25 +718,14 @@ _full_loop_recovery_resume_publication() {
 	local tag_name="$3"
 	local new_tag_object=""
 	local reconcile_rc=0
-	new_tag_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
+	new_tag_object=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
 	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$new_tag_object" || return 1
 	_full_loop_release_existing_with_lane reconcile "$source_pr" || reconcile_rc=$?
 	case "$reconcile_rc" in
 	0 | 8) return "$reconcile_rc" ;;
 	esac
 	return 1
-}
-
-_full_loop_recovery_restore_state_transaction() {
-	local repo="$1"
-	local source_pr="$2"
-	local restored=0
-	release_lane_restore_aggregate_recovery "$repo" "$source_pr" \
-		"$_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT" || restored=1
-	_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || restored=1
-	[[ "$restored" -eq 0 ]]
-	return $?
 }
 
 _full_loop_recovery_write_evidence() {
@@ -382,13 +748,20 @@ _full_loop_recovery_write_evidence() {
 }
 
 _full_loop_recovery_run_version_manager() {
-	local source_pr="$1"
-	local tag_name="$2"
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
 	local version_manager="$_FULL_LOOP_RELEASE_PATH/.agents/scripts/version-manager.sh"
 	local recovery_rc=0
 	(
 		cd "$_FULL_LOOP_RELEASE_PATH" || exit 1
-		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 bash "$version_manager" recover-aggregate \
+		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
+			AIDEVOPS_RELEASE_LANE_REPOSITORY="$repo" \
+			AIDEVOPS_RELEASE_LANE_SOURCE_PR="$source_pr" \
+			AIDEVOPS_RELEASE_LANE_TAG="$tag_name" \
+			AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES="$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+			AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN="$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+			bash "$version_manager" recover-aggregate \
 			--tag "$tag_name" --source-pr "$source_pr" \
 			--expected-sources "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
 			--old-tag-object "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT"
@@ -399,45 +772,78 @@ _full_loop_recovery_run_version_manager() {
 	return 1
 }
 
+_full_loop_recovery_resume_committing_queue() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local current_tag_object=""
+	local recovery_rc=0
+	local transition_rc=0
+	current_tag_object=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
+	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
+	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$current_tag_object" || return 1
+	_full_loop_recovery_run_version_manager "$repo" "$source_pr" "$tag_name" || recovery_rc=$?
+	case "$recovery_rc" in
+	0 | 8) ;;
+	*) return 1 ;;
+	esac
+	_full_loop_recovery_transition_durable_publication "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+	case "$transition_rc" in
+	0 | 8) return "$transition_rc" ;;
+	*) return 1 ;;
+	esac
+}
+
 _full_loop_recovery_tag_rollback_safe() {
 	local repo="$1"
 	local tag_name="$2"
 	local current_object=""
-	current_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}" 2>/dev/null) || return 1
+	current_object=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}" 2>/dev/null) || return 1
 	[[ "$current_object" == "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]] || return 1
 	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
 	return 0
 }
 
-_full_loop_release_recover_aggregate() {
+_full_loop_recovery_resume_prepared_state() {
 	local repo="$1"
 	local source_pr="$2"
 	local tag_name="$3"
-	local expected_sources="$4"
-	local recovery_rc=0
-	local resume_rc=0
-	local new_tag_object=""
-	local tag_sources=""
-	_full_loop_recovery_validate_existing_tag "$repo" "$source_pr" "$tag_name" || return 1
-	_full_loop_recovery_validate_receipt "$repo" "$source_pr" "$tag_name" \
-		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
-	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
-	tag_sources=$(_full_loop_recovery_tag_sources) || return 1
-	if [[ "$tag_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
-		if _full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name"; then
-			_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
-			return $?
+	local tag_sources="$4"
+	local transition_rc=0
+	[[ "$tag_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 2
+	if _full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name"; then
+		_full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name" || return 2
+		_full_loop_recovery_transition_durable_publication "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+		if [[ "$transition_rc" -eq 8 ]]; then
+			transition_rc=0
+			_full_loop_recovery_resume_committing_queue "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+			if [[ "$transition_rc" -eq 8 ]]; then
+				_full_loop_recovery_report_pending_commit "$source_pr" "$tag_name"
+				return $?
+			fi
 		fi
-		_full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name" && return 1
+		[[ "$transition_rc" -eq 0 ]] || return 1
+		_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+		return $?
 	fi
-	release_authorization_subset "$tag_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
-	_full_loop_recovery_begin_state_transaction "$repo" "$source_pr" "$tag_name" || return 1
-	_full_loop_recovery_run_version_manager "$source_pr" "$tag_name" || recovery_rc=$?
-	if [[ "$recovery_rc" -ne 0 && "$recovery_rc" -ne 8 ]]; then
-		# A protected-main PR can be created after the replacement tag is durable
-		# but before version-manager reports its normal queued exit. Reconcile the
-		# exact tag before treating that post-mutation state as a failure.
+	if _full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name"; then
+		_full_loop_recovery_load_remote_publication_state "$repo" "$source_pr" "$tag_name" || return 1
+		_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+		return $?
+	fi
+	return 2
+}
+
+_full_loop_recovery_handle_failed_version_manager() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local resume_rc=0
+	local transition_rc=0
+	_full_loop_recovery_transition_durable_publication "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+	if [[ "$transition_rc" -eq 0 ]]; then
 		_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name" || resume_rc=$?
 		case "$resume_rc" in
 		0) return 0 ;;
@@ -448,18 +854,110 @@ _full_loop_release_recover_aggregate() {
 			return 8
 			;;
 		esac
-		if _full_loop_recovery_tag_rollback_safe "$repo" "$tag_name"; then
-			_full_loop_recovery_restore_state_transaction "$repo" "$source_pr" || true
-		else
-			printf 'Aggregate recovery failed after tag state changed; expanded recovery state was retained for reconciliation\n' >&2
-		fi
+	elif [[ "$transition_rc" -eq 8 ]]; then
+		_full_loop_recovery_report_pending_commit "$source_pr" "$tag_name"
+		return $?
+	fi
+	if _full_loop_recovery_tag_rollback_safe "$repo" "$tag_name"; then
+		printf 'Aggregate recovery failed before durable publication; the fenced transaction was retained for idempotent retry\n' >&2
+	else
+		printf 'Aggregate recovery failed after tag state changed; expanded recovery state was retained for reconciliation\n' >&2
+	fi
+	return 1
+}
+
+_full_loop_recovery_finish_version_manager() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local new_tag_object=""
+	local transition_rc=0
+	new_tag_object=$(git -C "$REPO_ROOT" rev-parse \
+		"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
+	if [[ "$new_tag_object" == "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]] ||
+		! _full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name"; then
+		printf 'Aggregate recovery did not produce the exact replacement tag; the fenced transaction was retained for retry\n' >&2
 		return 1
 	fi
-	new_tag_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
 	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$new_tag_object" || return 1
-	release_lane_update "$repo" "$source_pr" remote-publication "$tag_name" || return 1
+	_full_loop_recovery_transition_durable_publication "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+	if [[ "$transition_rc" -eq 8 ]]; then
+		_full_loop_recovery_report_pending_commit "$source_pr" "$tag_name"
+		return $?
+	fi
+	[[ "$transition_rc" -eq 0 ]] || return 1
 	printf 'release:aggregate-recovery queued tag=%s source_pr=%s\n' "$tag_name" "$source_pr"
 	printf 'Resume with: aidevops release status %s\n' "$source_pr"
 	printf 'Resume with: aidevops release reconcile %s\n' "$source_pr"
 	return 8
+}
+
+_full_loop_release_recover_aggregate() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local expected_sources="$4"
+	local prepared_rc=0
+	local recovery_rc=0
+	local transition_rc=0
+	local current_tag_object=""
+	local tag_sources=""
+	_full_loop_recovery_validate_existing_tag "$repo" "$source_pr" "$tag_name" || return 1
+	_full_loop_recovery_prepare_existing_context "$repo" "$source_pr" "$tag_name" "$expected_sources" || return 1
+	case "$_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT" in
+	remote-publication)
+		_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+		return $?
+		;;
+	transaction)
+		if _full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name"; then
+			transition_rc=0
+			_full_loop_recovery_transition_durable_publication "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+			if [[ "$transition_rc" -eq 0 ]]; then
+				_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+				return $?
+			fi
+			[[ "$transition_rc" -eq 8 ]] || return 1
+			current_tag_object=$(git -C "$REPO_ROOT" rev-parse \
+				"${_FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX}${tag_name}") || return 1
+			if [[ "$current_tag_object" != "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]]; then
+				transition_rc=0
+				_full_loop_recovery_resume_committing_queue "$repo" "$source_pr" "$tag_name" || transition_rc=$?
+				case "$transition_rc" in
+				0)
+					_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+					return $?
+					;;
+				8)
+					_full_loop_recovery_report_pending_commit "$source_pr" "$tag_name"
+					return $?
+					;;
+				*) return 1 ;;
+				esac
+			fi
+		fi
+		;;
+	none) ;;
+	*) return 1 ;;
+	esac
+	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
+	_full_loop_recovery_validate_receipt "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
+	tag_sources=$(_full_loop_recovery_tag_sources) || return 1
+	_full_loop_recovery_resume_prepared_state "$repo" "$source_pr" "$tag_name" "$tag_sources" || prepared_rc=$?
+	case "$prepared_rc" in
+	0 | 8) return "$prepared_rc" ;;
+	2) ;;
+	*) return 1 ;;
+	esac
+	release_authorization_subset "$tag_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
+	_full_loop_recovery_begin_state_transaction "$repo" "$source_pr" "$tag_name" || return 1
+	_full_loop_recovery_run_version_manager "$repo" "$source_pr" "$tag_name" || recovery_rc=$?
+	if [[ "$recovery_rc" -ne 0 && "$recovery_rc" -ne 8 ]]; then
+		_full_loop_recovery_handle_failed_version_manager "$repo" "$source_pr" "$tag_name"
+		return $?
+	fi
+	_full_loop_recovery_finish_version_manager "$repo" "$source_pr" "$tag_name"
+	return $?
 }

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -92,15 +92,28 @@ _full_loop_recovery_verify_channels_absent() {
 	return 0
 }
 
+#aidevops:trust-boundary
 _full_loop_recovery_validate_receipt() {
 	local repo="$1"
 	local source_pr="$2"
+	local tag_name="${3:-}"
+	local source_json="${4:-}"
 	local receipt_path=""
 	local status=""
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$source_pr") || return 1
 	[[ -f "$receipt_path" ]] && IFS= read -r status <"$receipt_path" || true
 	case "$status" in
 	"" | "$_FULL_LOOP_PHASE_FAILED") return 0 ;;
+	"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+		if [[ -n "$tag_name" && -n "$source_json" ]] &&
+			declare -F _full_loop_release_validate_published_reconciliation_intent >/dev/null 2>&1 &&
+			_full_loop_release_validate_published_reconciliation_intent \
+				"$repo" "$source_pr" "$tag_name" "$source_json"; then
+			return 0
+		fi
+		printf 'Aggregate recovery refused: release:not-requested lacks matching explicit publication intent\n' >&2
+		return 1
+		;;
 	esac
 	printf 'Aggregate recovery refused: release receipt is terminal (%s)\n' "$status" >&2
 	return 1
@@ -405,8 +418,9 @@ _full_loop_release_recover_aggregate() {
 	local resume_rc=0
 	local new_tag_object=""
 	local tag_sources=""
-	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
 	_full_loop_recovery_validate_existing_tag "$repo" "$source_pr" "$tag_name" || return 1
+	_full_loop_recovery_validate_receipt "$repo" "$source_pr" "$tag_name" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON" || return 1
 	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
 	tag_sources=$(_full_loop_recovery_tag_sources) || return 1
 	if [[ "$tag_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -102,6 +102,8 @@ _FULL_LOOP_RESOLVED_SOURCE_PR=""
 _FULL_LOOP_RESOLVED_SOURCE_MERGE=""
 _FULL_LOOP_RESOLVED_REQUESTED_MERGE=""
 _FULL_LOOP_RESOLVED_EXPECTED_SOURCES=""
+_FULL_LOOP_RELEASE_ACTION_RECONCILE="reconcile"
+_FULL_LOOP_RELEASE_BOOL_TRUE="true"
 
 _full_loop_capture_release_authorization() {
 	local repo="$1"
@@ -314,6 +316,7 @@ _full_loop_release_existing_with_lane() {
 	local existing_rc=0
 	local lane_read_rc=0
 	local lane_owned=false
+	local lane_phase=""
 	existing_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
 	release_lane_read "$existing_repo" || lane_read_rc=$?
 	case "$lane_read_rc" in
@@ -322,9 +325,10 @@ _full_loop_release_existing_with_lane() {
 		if jq -e --argjson source_pr "$source_pr" '.active == true and .source_pr == $source_pr' \
 			<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
 			lane_owned=true
+			lane_phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 			_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -r '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		fi
-		if [[ "$release_type" == "reconcile" ]] &&
+		if [[ "$release_type" == "$_FULL_LOOP_RELEASE_ACTION_RECONCILE" ]] &&
 			! jq -e --argjson source_pr "$source_pr" '.active != true or .source_pr == $source_pr' \
 				<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
 			printf 'A different source owns the active release lane\n' >&2
@@ -337,8 +341,18 @@ _full_loop_release_existing_with_lane() {
 		return 1
 		;;
 	esac
+	if [[ "$release_type" == "$_FULL_LOOP_RELEASE_ACTION_RECONCILE" &&
+		"$lane_owned" == "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]]; then
+		case "$lane_phase" in
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_PHASE" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE")
+			printf 'Aggregate recovery transaction remains fenced in phase %s; rerun recover-aggregate to resume it\n' "$lane_phase"
+			return 8
+			;;
+		esac
+	fi
 	_full_loop_release_existing_command "$release_type" "$source_pr" || existing_rc=$?
-	if [[ "$release_type" == "reconcile" && "$lane_owned" == "true" ]]; then
+	if [[ "$release_type" == "$_FULL_LOOP_RELEASE_ACTION_RECONCILE" &&
+		"$lane_owned" == "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]]; then
 		if [[ "$existing_rc" -eq 0 ]]; then
 			local receipt_path=""
 			local receipt_status=""
@@ -350,7 +364,12 @@ _full_loop_release_existing_with_lane() {
 			esac
 			release_lane_finalize "$existing_repo" "$source_pr" "$receipt_status" || return 1
 		elif [[ "$existing_rc" -eq 8 ]]; then
-			release_lane_update "$existing_repo" "$source_pr" "remote-publication" || return 1
+			case "$lane_phase" in
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_PHASE" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE")
+				printf 'Aggregate recovery transaction remains fenced in phase %s\n' "$lane_phase"
+				;;
+			*) release_lane_update "$existing_repo" "$source_pr" "remote-publication" || return 1 ;;
+			esac
 		fi
 	fi
 	return "$existing_rc"
@@ -388,6 +407,7 @@ _full_loop_release_resolve_persisted_intent() {
 	local persisted_sources="$4"
 	local persisted_prs=""
 	local requested_prs=""
+	local migration_rc=0
 	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$requested_sources"
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
 	if [[ -z "$requested_sources" ]]; then
@@ -396,7 +416,15 @@ _full_loop_release_resolve_persisted_intent() {
 	fi
 	requested_prs=$(release_authorization_intent_json "$requested_sources" | jq -c 'map(.pr)') || return 1
 	persisted_prs=$(release_authorization_intent_json "$persisted_sources" | jq -c 'map(.pr)') || return 1
-	[[ "$requested_prs" != "$persisted_prs" ]] || return 0
+	if [[ "$requested_prs" == "$persisted_prs" ]]; then
+		_full_loop_recovery_reserved_lane_requires_migration "$repo" "$source_pr" \
+			"$persisted_sources" || migration_rc=$?
+		case "$migration_rc" in
+		0) ;;
+		1) return 0 ;;
+		*) return 1 ;;
+		esac
+	fi
 	_full_loop_recovery_expand_reserved_authorization "$repo" "$source_pr" "$requested_sources" || return $?
 	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=true
@@ -423,7 +451,7 @@ _full_loop_release_start_new() {
 	2) ;;
 	*) return "$existing_state_rc" ;;
 	esac
-	if [[ "$_FULL_LOOP_RESERVED_RECOVERY_COMPLETED" == "true" ]]; then
+	if [[ "$_FULL_LOOP_RESERVED_RECOVERY_COMPLETED" == "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]]; then
 		_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" "$expected_sources"
 		return $?
 	fi

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -18,6 +18,10 @@ _AIDEVOPS_RELEASE_LANE_JSON_STRING_TYPE="string"
 _AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX="lane-"
 _AIDEVOPS_RELEASE_LANE_OWNER_PREFIX="process-"
 _AIDEVOPS_RELEASE_LANE_STALE_PREPUBLICATION_SECONDS=300
+_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY="aggregation-recovery"
+_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH="aggregation-recovery-refresh"
+_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT="aggregate-publication-committing"
+_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH="reserved-authorization-refresh"
 
 _release_lane_cache_path() {
 	local repo="$1"
@@ -229,15 +233,18 @@ release_lane_begin_aggregate_recovery() {
 	local repo="$1"
 	local source_pr="$2"
 	local tag_name="$3"
-	local previous_sources="$4"
-	local expected_sources="$5"
-	local provisional_tag_object="${6:-}"
+	local lane_sources="$4"
+	local previous_sources="$5"
+	local expected_sources="$6"
+	local provisional_tag_object="${7:-}"
 	local operation_token=""
 	local state_json=""
 	local snapshot_json=""
+	local write_rc=0
+	[[ -n "$lane_sources" && -n "$previous_sources" && -n "$expected_sources" ]] || return 1
 	[[ "$provisional_tag_object" =~ ^[0-9a-f]{40}$ ]] || return 1
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg previous "$previous_sources" '
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg previous "$lane_sources" '
 		.active == true and .source_pr == $source_pr and .tag == $tag
 		and .expected_sources == $previous
 		and (.phase == "remote-publication" or .phase == "reconcile-required")
@@ -247,15 +254,186 @@ release_lane_begin_aggregate_recovery() {
 	snapshot_json="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
 	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
 	state_json=$(jq -c --arg expected "$expected_sources" --arg token "$operation_token" \
-		--arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-		--arg provisional "$provisional_tag_object" --argjson previous "$snapshot_json" '
+		--arg prior "$previous_sources" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --arg provisional "$provisional_tag_object" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" \
+		--argjson previous "$snapshot_json" '
 		.expected_sources=$expected | .operation_token=$token | .owner=$owner
-		| .phase="aggregation-recovery" | .updated_at=$now
-		| .aggregate_recovery={previous_state:$previous,provisional_tag_object:$provisional}
+		| .phase=$refresh | .updated_at=$now
+		| .aggregate_recovery={previous_state:$previous,provisional_tag_object:$provisional,
+			refresh:{previous_expected_sources:$prior,pending_expected_sources:$expected}}
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg token "$operation_token" \
+			--arg expected "$expected_sources" --arg previous "$previous_sources" \
+			--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" \
+			--arg provisional "$provisional_tag_object" '
+			.active == true and .source_pr == $source_pr and .tag == $tag
+			and .operation_token == $token and .phase == $refresh
+			and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+			and .aggregate_recovery.provisional_tag_object == $provisional
+			and .aggregate_recovery.refresh.previous_expected_sources == $previous
+			and .aggregate_recovery.refresh.pending_expected_sources == $expected
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
 	return 0
+}
+
+release_lane_begin_aggregate_refresh() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local previous_sources="$4"
+	local expected_sources="$5"
+	local provisional_tag_object="$6"
+	local operation_token=""
+	local state_json=""
+	local write_rc=0
+	[[ -n "$previous_sources" && -n "$expected_sources" && "$previous_sources" != "$expected_sources" ]] || return 1
+	[[ "$provisional_tag_object" =~ ^[0-9a-f]{40}$ ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg previous "$previous_sources" \
+		--arg provisional "$provisional_tag_object" --arg recovery "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" \
+		--arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .expected_sources == $previous and (.phase == $recovery or .phase == $committing)
+		and ((.terminal_receipt // null) == null)
+		and .aggregate_recovery.provisional_tag_object == $provisional
+		and (.aggregate_recovery.previous_state.schema_version == 1)
+		and ((.aggregate_recovery.previous_state.aggregate_recovery // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --arg expected "$expected_sources" --arg token "$operation_token" \
+		--arg previous "$previous_sources" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.expected_sources=$expected | .operation_token=$token | .owner=$owner
+		| .phase=$refresh | .updated_at=$now
+		| .aggregate_recovery.refresh={previous_expected_sources:$previous,pending_expected_sources:$expected}
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg token "$operation_token" \
+			--arg expected "$expected_sources" --arg previous "$previous_sources" \
+			--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" \
+			--arg provisional "$provisional_tag_object" '
+			.active == true and .source_pr == $source_pr and .tag == $tag
+			and .operation_token == $token and .phase == $refresh
+			and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+			and .aggregate_recovery.provisional_tag_object == $provisional
+			and .aggregate_recovery.refresh.previous_expected_sources == $previous
+			and .aggregate_recovery.refresh.pending_expected_sources == $expected
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	return 0
+}
+
+release_lane_finish_aggregate_refresh() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local previous_sources="$4"
+	local expected_sources="$5"
+	local provisional_tag_object="$6"
+	local state_json=""
+	local write_rc=0
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg previous "$previous_sources" \
+		--arg expected "$expected_sources" --arg provisional "$provisional_tag_object" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .operation_token == $token and .phase == $refresh
+		and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+		and .aggregate_recovery.provisional_tag_object == $provisional
+		and .aggregate_recovery.refresh.previous_expected_sources == $previous
+		and .aggregate_recovery.refresh.pending_expected_sources == $expected
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	state_json=$(jq -c --arg recovery "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.phase=$recovery | .updated_at=$now | del(.aggregate_recovery.refresh)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+			--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$expected_sources" \
+			--arg provisional "$provisional_tag_object" \
+			--arg recovery "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" '
+			.active == true and .source_pr == $source_pr and .tag == $tag
+			and .operation_token == $token and .phase == $recovery
+			and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+			and .aggregate_recovery.provisional_tag_object == $provisional
+			and ((.aggregate_recovery.refresh // null) == null)
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	return 0
+}
+
+release_lane_claim_aggregate_publication() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local expected_sources="$4"
+	local state_json=""
+	local write_rc=0
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	if jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$expected_sources" \
+		--arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .operation_token == $token and .phase == $committing
+		and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		return 0
+	fi
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$expected_sources" \
+		--arg recovery "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .operation_token == $token and .phase == $recovery
+		and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+		and ((.aggregate_recovery.refresh // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	state_json=$(jq -c --arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '.phase=$committing | .updated_at=$now' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+			--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$expected_sources" \
+			--arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" '
+			.active == true and .source_pr == $source_pr and .tag == $tag
+			and .operation_token == $token and .phase == $committing
+			and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	return 0
+}
+
+release_lane_verify_aggregate_publication() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local expected_sources="$4"
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg expected "$expected_sources" \
+		--arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .operation_token == $token and .phase == $committing
+		and .expected_sources == $expected and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null
+	return $?
 }
 
 release_lane_expand_reserved_authorization() {
@@ -265,9 +443,27 @@ release_lane_expand_reserved_authorization() {
 	# and rollback must restore that representation rather than a resolved manifest.
 	local previous_sources="$3"
 	local expected_sources="$4"
+	local operation_token=""
 	local state_json=""
+	local snapshot_json=""
+	local write_rc=0
+	[[ -n "$previous_sources" && -n "$expected_sources" && "$previous_sources" != "$expected_sources" ]] || return 1
 	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
 	release_lane_read "$repo" || return 1
+	if jq -e --argjson source_pr "$source_pr" --arg previous "$previous_sources" \
+		--arg expected "$expected_sources" --arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" '
+		.active == true and .source_pr == $source_pr and .operation_token != ""
+		and .phase == $refresh and .tag == null and .expected_sources == $expected
+		and ((.terminal_receipt // null) == null)
+		and .reserved_authorization_refresh.previous_expected_sources == $previous
+		and .reserved_authorization_refresh.pending_expected_sources == $expected
+		and (.reserved_authorization_refresh.previous_state.schema_version == 1)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT=$(jq -ce '.reserved_authorization_refresh.previous_state' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		return 0
+	fi
 	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
 		--arg previous "$previous_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
 		.active == true and .source_pr == $source_pr and .operation_token == $token
@@ -275,10 +471,68 @@ release_lane_expand_reserved_authorization() {
 		and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_JSON"
-	state_json=$(jq -c --arg expected "$expected_sources" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-		'.expected_sources=$expected | .updated_at=$now' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD"
-	return $?
+	snapshot_json="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --arg expected "$expected_sources" --arg previous "$previous_sources" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" --arg token "$operation_token" \
+		--arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--argjson snapshot "$snapshot_json" '
+		.expected_sources=$expected | .phase=$refresh | .operation_token=$token
+		| .owner=$owner | .updated_at=$now
+		| .reserved_authorization_refresh={previous_state:$snapshot,
+			previous_expected_sources:$previous,pending_expected_sources:$expected}
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg token "$operation_token" \
+			--arg previous "$previous_sources" --arg expected "$expected_sources" \
+			--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" '
+			.active == true and .source_pr == $source_pr and .operation_token == $token
+			and .phase == $refresh and .tag == null and .expected_sources == $expected
+			and ((.terminal_receipt // null) == null)
+			and .reserved_authorization_refresh.previous_expected_sources == $previous
+			and .reserved_authorization_refresh.pending_expected_sources == $expected
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	return 0
+}
+
+release_lane_finish_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local previous_sources="$3"
+	local expected_sources="$4"
+	local state_json=""
+	local write_rc=0
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg previous "$previous_sources" --arg expected "$expected_sources" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" '
+		.active == true and .source_pr == $source_pr and .operation_token == $token
+		and .phase == $refresh and .tag == null and .expected_sources == $expected
+		and ((.terminal_receipt // null) == null)
+		and .reserved_authorization_refresh.previous_expected_sources == $previous
+		and .reserved_authorization_refresh.pending_expected_sources == $expected
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	state_json=$(jq -c --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.phase=$reserved | .updated_at=$now | del(.reserved_authorization_refresh)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+			--arg expected "$expected_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
+			.active == true and .source_pr == $source_pr and .operation_token == $token
+			and .phase == $reserved and .tag == null and .expected_sources == $expected
+			and ((.terminal_receipt // null) == null)
+			and ((.reserved_authorization_refresh // null) == null)
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	return 0
 }
 
 release_lane_restore_reserved_authorization() {
@@ -286,18 +540,23 @@ release_lane_restore_reserved_authorization() {
 	local source_pr="$2"
 	local expected_sources="$3"
 	local snapshot_json="$4"
+	local write_rc=0
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
-		--arg expected "$expected_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
+		--arg expected "$expected_sources" --arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" '
 		.active == true and .source_pr == $source_pr and .operation_token == $token
-		and .phase == $reserved and .tag == null and .expected_sources == $expected
+		and .phase == $refresh and .tag == null and .expected_sources == $expected
 		and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	jq -e --argjson source_pr "$source_pr" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
 		.schema_version == 1 and .active == true and .source_pr == $source_pr
 		and .phase == $reserved and .tag == null
 	' <<<"$snapshot_json" >/dev/null || return 1
-	_release_lane_write "$repo" "$snapshot_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_release_lane_write "$repo" "$snapshot_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		[[ "$(jq -cS . <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$(jq -cS . <<<"$snapshot_json")" ]] || return "$write_rc"
+	fi
 	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -r '.operation_token' <<<"$snapshot_json") || return 1
 	return 0
 }
@@ -307,8 +566,12 @@ release_lane_restore_aggregate_recovery() {
 	local source_pr="$2"
 	local snapshot_json="$3"
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" '
-		.active == true and .source_pr == $source_pr and .phase == "aggregation-recovery"
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg recovery "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" \
+		--arg committing "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" '
+		.active == true and .source_pr == $source_pr
+		and (.phase == $recovery or .phase == $refresh or .phase == $committing)
 		and .operation_token == $token
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	if [[ -z "$snapshot_json" ]]; then
@@ -449,15 +712,22 @@ release_lane_merge_guard() {
 		return 0
 	fi
 	case "$phase" in
-	remote-publication | exact-tag-deployment) ;;
+	remote-publication | exact-tag-deployment | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" | "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH") ;;
 	*) return 0 ;;
 	esac
 	source_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	tag_name=$(jq -r '.tag // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	if [[ "$pr_number" == "$source_pr" || (-n "$tag_name" && "$head_ref" == "chore/release-${tag_name}-provenance") ]]; then
-		return 0
+	[[ "$pr_number" == "$source_pr" ]] && return 0
+	#aidevops:trust-boundary
+	if [[ -n "$tag_name" && "$head_ref" == "chore/release-${tag_name}-provenance" ]]; then
+		case "$phase" in
+		"$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH") ;;
+		*) return 0 ;;
+		esac
 	fi
-	if _release_lane_pr_is_metadata_only_aggregate "$repo" "$pr_number"; then
+	if [[ "$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" &&
+		"$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" ]] &&
+		_release_lane_pr_is_metadata_only_aggregate "$repo" "$pr_number"; then
 		return 0
 	fi
 	printf 'ACTIVE_RELEASE_LANE_MERGE_BLOCKED source_pr=%s phase=%s tag=%s\n' \

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -161,14 +161,29 @@ _release_provenance_resolve_tag_authorization() {
 	local release_head=""
 	local tag_commit=""
 	local expected_sources_json=""
+	local source_json=""
+	local observed_sources_json=""
 	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$requested_pr" =~ ^[0-9]+$ ]] || return 1
 	[[ "$repo_slug" =~ ^[^/]+/[^/]+$ && "$branch_name" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
 	release_head=$(git rev-parse HEAD 2>/dev/null) || return 1
 	tag_commit=$(git rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
 	[[ "$release_head" == "$tag_commit" ]] || return 1
+	_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name" \
+		"$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" >/dev/null || return 1
 	expected_sources_json=$(_release_provenance_expected_sources "$requested_pr" "$raw_sources" \
 		"$repo_slug" "$branch_name" "$tag_commit") || return 1
-	jq -cn --argjson expected "$expected_sources_json" '{expected_sources:$expected}'
+	source_json=$(jq -cn --argjson requested_pr "$requested_pr" \
+		--argjson source_pr "$_RELEASE_PROVENANCE_SOURCE_PR" \
+		--arg source_merge "$_RELEASE_PROVENANCE_SOURCE_MERGE" \
+		--argjson aggregated "$_RELEASE_PROVENANCE_AGGREGATED_SOURCES" '
+		{mode:(if ($aggregated | length) == 0 then "direct" else "aggregate" end),
+		 requested_pr:$requested_pr,source_pr:$source_pr,source_merge:$source_merge,
+		 aggregated_sources:($aggregated | sort_by(.pr))}
+	') || return 1
+	observed_sources_json=$(release_authorization_observed_sources_json \
+		"$expected_sources_json" "$source_json") || return 1
+	_release_provenance_assert_expected_sources "$expected_sources_json" "$observed_sources_json" || return 1
+	jq -c --argjson expected "$expected_sources_json" '. + {expected_sources:$expected}' <<<"$source_json"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -75,6 +75,7 @@ printf 'PASS recovery rejects remote tag, GitHub, npm, and Homebrew publication\
 printf 'PASS rollback requires every publication channel to remain absent\n'
 
 _FULL_LOOP_PHASE_FAILED=failed
+_FULL_LOOP_RELEASE_NOT_REQUESTED=not-requested
 _full_loop_release_receipt_path() {
 	printf '%s/release.status\n' "$TEST_ROOT"
 	return 0
@@ -84,9 +85,26 @@ if _full_loop_recovery_validate_receipt test/repo 42 >/dev/null 2>&1; then
 	printf 'FAIL recovery accepted a terminal release receipt\n'
 	exit 1
 fi
+INTENT_MODE=match
+_full_loop_release_validate_published_reconciliation_intent() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local source_json="$4"
+	[[ "$INTENT_MODE" == "match" && "$repo" == "test/repo" && "$source_pr" == "42" &&
+		"$tag_name" == "v1.2.3" && "$source_json" == '{"source_pr":42}' ]]
+	return $?
+}
+printf 'not-requested\n' >"${TEST_ROOT}/release.status"
+_full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}'
+INTENT_MODE=mismatch
+if _full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}' >/dev/null 2>&1; then
+	printf 'FAIL recovery accepted release:not-requested without matching publication intent\n'
+	exit 1
+fi
 printf 'failed\n' >"${TEST_ROOT}/release.status"
 _full_loop_recovery_validate_receipt test/repo 42
-printf 'PASS recovery rejects terminal receipts and permits failed retries\n'
+printf 'PASS recovery accepts authorized release:not-requested and rejects other terminal receipts\n'
 
 STATE_LOG="${TEST_ROOT}/state.log"
 : >"$STATE_LOG"
@@ -185,7 +203,7 @@ _full_loop_recovery_run_version_manager() {
 success_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || success_rc=$?
 [[ "$success_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager evidence lane " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager evidence lane " ]]
 printf 'PASS queued recovery records evidence and retains the expanded transaction\n'
 
 : >"$CALL_LOG"
@@ -201,7 +219,7 @@ _full_loop_recovery_tag_is_bound_to_current_aggregate() { return 1; }
 same_sources_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || same_sources_rc=$?
 [[ "$same_sources_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate load channels begin version-manager evidence lane " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate load channels begin version-manager evidence lane " ]]
 printf 'PASS fresh same-source aggregation still replaces the historical tag\n'
 
 : >"$CALL_LOG"
@@ -216,7 +234,7 @@ _full_loop_recovery_resume_publication() {
 resume_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || resume_rc=$?
 [[ "$resume_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate load resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate load resume " ]]
 printf 'PASS interrupted aggregate recovery resumes without another tag replacement\n'
 
 : >"$CALL_LOG"
@@ -236,7 +254,7 @@ if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&
 	printf 'FAIL failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume restore " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume restore " ]]
 printf 'PASS failed recovery restores authorization and release-lane state\n'
 
 : >"$CALL_LOG"
@@ -245,7 +263,7 @@ if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&
 	printf 'FAIL unsafe failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume " ]]
 printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 
 : >"$CALL_LOG"
@@ -256,7 +274,7 @@ _full_loop_recovery_resume_publication() {
 durable_queue_rc=0
 durable_queue_output=$(_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 2>&1) || durable_queue_rc=$?
 [[ "$durable_queue_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume " ]]
 [[ "$durable_queue_output" == *"aidevops release status 42"* ]]
 [[ "$durable_queue_output" == *"aidevops release reconcile 42"* ]]
 [[ "$durable_queue_output" != *"Aggregate recovery failed after tag state changed"* ]]

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -86,6 +86,7 @@ if _full_loop_recovery_validate_receipt test/repo 42 >/dev/null 2>&1; then
 	exit 1
 fi
 INTENT_MODE=match
+INTERRUPTED_INTENT_MODE=mismatch
 _full_loop_release_validate_published_reconciliation_intent() {
 	local repo="$1"
 	local source_pr="$2"
@@ -95,9 +96,21 @@ _full_loop_release_validate_published_reconciliation_intent() {
 		"$tag_name" == "v1.2.3" && "$source_json" == '{"source_pr":42}' ]]
 	return $?
 }
+_full_loop_recovery_validate_interrupted_publication_intent() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local source_json="$4"
+	[[ "$INTERRUPTED_INTENT_MODE" == "match" && "$repo" == "test/repo" && "$source_pr" == "42" &&
+		"$tag_name" == "v1.2.3" && "$source_json" == '{"source_pr":42}' ]]
+	return $?
+}
 printf 'not-requested\n' >"${TEST_ROOT}/release.status"
 _full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}'
 INTENT_MODE=mismatch
+INTERRUPTED_INTENT_MODE=match
+_full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}'
+INTERRUPTED_INTENT_MODE=mismatch
 if _full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}' >/dev/null 2>&1; then
 	printf 'FAIL recovery accepted release:not-requested without matching publication intent\n'
 	exit 1
@@ -124,11 +137,83 @@ _full_loop_restore_release_authorization_after_aggregate() {
 	return 0
 }
 if _full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3; then
-	printf 'FAIL lane read failure retained expanded authorization\n'
+	printf 'FAIL lane read failure began aggregate recovery\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$STATE_LOG")" == "expand restore-auth " ]]
-printf 'PASS lane uncertainty restores the pre-transaction authorization\n'
+[[ ! -s "$STATE_LOG" ]]
+printf 'PASS lane uncertainty blocks authorization expansion before mutation\n'
+
+(
+	transaction_log="${TEST_ROOT}/initial-transaction.log"
+	old_authorization='42@2222222222222222222222222222222222222222'
+	expanded_authorization="${old_authorization},43@3333333333333333333333333333333333333333"
+	authorization="$old_authorization"
+	lane_phase=remote-publication
+	auth_write_mode=success
+	: >"$transaction_log"
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expanded_authorization"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=1111111111111111111111111111111111111111
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$authorization"
+		return 0
+	}
+	_full_loop_read_release_authorization_recovery_snapshot() { return 1; }
+	release_authorization_subset() { return 0; }
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg phase "$lane_phase" \
+			'{schema_version:1,active:true,source_pr:42,tag:"v1.2.3",phase:$phase,expected_sources:"42",operation_token:"lane-old"}')
+		return 0
+	}
+	release_lane_begin_aggregate_recovery() {
+		local repo="$1"
+		local source_pr="$2"
+		local tag_name="$3"
+		local lane_sources="$4"
+		local previous_sources="$5"
+		local expected_sources="$6"
+		local provisional="$7"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && "$tag_name" == "v1.2.3" ]] || return 1
+		[[ "$lane_sources" == "42" && "$previous_sources" == "$old_authorization" ]] || return 1
+		[[ "$expected_sources" == "$expanded_authorization" && "$provisional" == "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]] || return 1
+		printf 'fence\n' >>"$transaction_log"
+		lane_phase=aggregation-recovery-refresh
+		_AIDEVOPS_RELEASE_LANE_TOKEN=lane-new
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"remote-publication","operation_token":"lane-old"}'
+		return 0
+	}
+	_full_loop_expand_release_authorization_for_aggregate() {
+		[[ "$lane_phase" == "aggregation-recovery-refresh" ]] || return 1
+		printf 'authorize\n' >>"$transaction_log"
+		[[ "$auth_write_mode" == "success" ]] || return 1
+		authorization="$expanded_authorization"
+		return 0
+	}
+	release_lane_finish_aggregate_refresh() {
+		[[ "$authorization" == "$expanded_authorization" ]] || return 1
+		printf 'finish\n' >>"$transaction_log"
+		lane_phase=aggregation-recovery
+		return 0
+	}
+	release_lane_restore_aggregate_recovery() {
+		printf 'restore-lane\n' >>"$transaction_log"
+		lane_phase=remote-publication
+		return 0
+	}
+	_full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3
+	[[ "$(tr '\n' ' ' <"$transaction_log")" == "fence authorize finish " ]]
+	[[ "$authorization" == "$expanded_authorization" && "$lane_phase" == "aggregation-recovery" ]]
+
+	authorization="$old_authorization"
+	lane_phase=remote-publication
+	auth_write_mode=failure
+	: >"$transaction_log"
+	if _full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ "$(tr '\n' ' ' <"$transaction_log")" == "fence authorize restore-lane " ]]
+	[[ "$authorization" == "$old_authorization" && "$lane_phase" == "remote-publication" ]]
+)
+printf 'PASS initial recovery fences the lane before authorization and restores pre-write failures\n'
 
 _FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333"
 _full_loop_read_release_authorization() {
@@ -143,11 +228,357 @@ release_lane_read() {
 	_AIDEVOPS_RELEASE_LANE_JSON='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":42,"expected_sources":"42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333","phase":"aggregation-recovery","tag":"v1.2.3","operation_token":"lane-new","aggregate_recovery":{"provisional_tag_object":"1111111111111111111111111111111111111111","previous_state":{"schema_version":1,"repository":"test/repo","active":true,"source_pr":42,"expected_sources":"42","phase":"remote-publication","tag":"v1.2.3","operation_token":"lane-old"}}}'
 	return 0
 }
+_full_loop_recovery_validate_interrupted_publication_intent() {
+	release_lane_read
+	return $?
+}
 _full_loop_recovery_load_existing_state_transaction test/repo 42 v1.2.3
 [[ "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" == "42@2222222222222222222222222222222222222222" ]]
 [[ "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" == 1111111111111111111111111111111111111111 ]]
 [[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "lane-new" ]]
 printf 'PASS interrupted recovery reloads exact authorization and lane snapshots\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	root_merge=2222222222222222222222222222222222222222
+	current_merge=3333333333333333333333333333333333333333
+	refreshed_merge=4444444444444444444444444444444444444444
+	provisional=1111111111111111111111111111111111111111
+	replacement=5555555555555555555555555555555555555555
+	root_authorization="42@${root_merge}"
+	test_current_authorization="${root_authorization},43@${current_merge}"
+	test_refreshed_authorization="${test_current_authorization},44@${refreshed_merge}"
+	root_record=$(jq -cn --arg merge "$root_merge" \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
+	previous_lane=$(jq -cn \
+		'{schema_version:1,repository:"test/repo",active:true,source_pr:42,expected_sources:"42",phase:"remote-publication",tag:"v1.2.3",operation_token:"lane-old",terminal_receipt:null}')
+	lane_json=$(jq -cn --arg expected "$test_current_authorization" --arg provisional "$provisional" \
+		--argjson previous "$previous_lane" \
+		'{schema_version:1,repository:"test/repo",active:true,source_pr:42,expected_sources:$expected,phase:"aggregation-recovery",tag:"v1.2.3",operation_token:"lane-current",terminal_receipt:null,aggregate_recovery:{previous_state:$previous,provisional_tag_object:$provisional}}')
+	current_source=$(jq -cn --arg merge "$root_merge" \
+		'{source_pr:42,source_merge:$merge,aggregated_sources:[]}')
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$test_current_authorization"
+		return 0
+	}
+	_full_loop_read_release_authorization_recovery_snapshot() {
+		printf '%s\n' "$root_record"
+		return 0
+	}
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$lane_json"
+		return 0
+	}
+	TAG_BOUND_MODE=match
+	_full_loop_recovery_tag_is_bound_to_current_aggregate() {
+		[[ "$TAG_BOUND_MODE" == "match" ]]
+		return $?
+	}
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$test_refreshed_authorization"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$provisional"
+	_full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"
+	lane_json=$(jq -cn --arg expected "$test_refreshed_authorization" \
+		--arg refresh_previous "$test_current_authorization" --arg provisional "$provisional" \
+		--argjson previous "$previous_lane" \
+		'{schema_version:1,repository:"test/repo",active:true,source_pr:42,expected_sources:$expected,phase:"aggregation-recovery-refresh",tag:"v1.2.3",operation_token:"lane-refresh",terminal_receipt:null,aggregate_recovery:{previous_state:$previous,provisional_tag_object:$provisional,refresh:{previous_expected_sources:$refresh_previous,pending_expected_sources:$expected}}}')
+	_full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"
+	test_current_authorization="$test_refreshed_authorization"
+	_full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"
+	test_current_authorization="${root_authorization},43@${current_merge}"
+	lane_json=$(jq -cn --arg expected "$test_current_authorization" --arg provisional "$provisional" \
+		--argjson previous "$previous_lane" \
+		'{schema_version:1,repository:"test/repo",active:true,source_pr:42,expected_sources:$expected,phase:"aggregation-recovery",tag:"v1.2.3",operation_token:"lane-current",terminal_receipt:null,aggregate_recovery:{previous_state:$previous,provisional_tag_object:$provisional}}')
+
+	nested_root=$(jq -c '.aggregate_recovery={previous_authorization:.}' <<<"$root_record")
+	root_record="$nested_root"
+	if _full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"; then
+		exit 1
+	fi
+	root_record=$(jq -cn --arg merge "$root_merge" \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
+
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$test_current_authorization"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$replacement"
+	current_source=$(jq -cn --arg root "$root_merge" --arg current "$current_merge" \
+		'{source_pr:99,source_merge:"6666666666666666666666666666666666666666",aggregated_sources:[{pr:42,merge:$root},{pr:43,merge:$current}]}')
+	_full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"
+	TAG_BOUND_MODE=mismatch
+	if _full_loop_recovery_validate_interrupted_publication_intent test/repo 42 v1.2.3 "$current_source"; then
+		exit 1
+	fi
+)
+printf 'PASS interrupted intent requires exact root snapshots and aggregate-bound replacement tags\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	test_authorization='42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333'
+	_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON='{"source_pr":99,"source_merge":"4444444444444444444444444444444444444444","aggregated_sources":[{"pr":42,"merge":"2222222222222222222222222222222222222222"},{"pr":43,"merge":"3333333333333333333333333333333333333333"}]}'
+	_full_loop_read_release_authorization_recovery_snapshot() {
+		printf '%s\n' '{"schema_version":1}'
+		return 0
+	}
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$test_authorization"
+		return 0
+	}
+	_full_loop_recovery_validate_receipt() { return 0; }
+	load_mode=transaction
+	_full_loop_recovery_load_existing_state_transaction() {
+		[[ "$load_mode" == "transaction" ]]
+		return $?
+	}
+	_full_loop_recovery_load_remote_publication_state() {
+		[[ "$load_mode" == "remote" ]]
+		return $?
+	}
+	_full_loop_recovery_prepare_existing_context test/repo 42 v1.2.3 43,42
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT" == "transaction" ]]
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" == "$test_authorization" ]]
+	[[ "$_FULL_LOOP_RESOLVED_SOURCE_PR" == "99" &&
+		"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" == "4444444444444444444444444444444444444444" ]]
+	load_mode=remote
+	_full_loop_recovery_prepare_existing_context test/repo 42 v1.2.3 42,43
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT" == "remote-publication" ]]
+	if _full_loop_recovery_prepare_existing_context test/repo 42 v1.2.3 42; then
+		exit 1
+	fi
+	if _full_loop_recovery_prepare_existing_context test/repo 42 v1.2.3 \
+		'42@9999999999999999999999999999999999999999,43@3333333333333333333333333333333333333333'; then
+		exit 1
+	fi
+)
+printf 'PASS persisted recovery context can resume after main advances while preserving exact PR intent\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	root_merge=2222222222222222222222222222222222222222
+	current_merge=3333333333333333333333333333333333333333
+	refreshed_merge=4444444444444444444444444444444444444444
+	provisional=1111111111111111111111111111111111111111
+	root_authorization="42@${root_merge}"
+	test_current_authorization="${root_authorization},43@${current_merge}"
+	test_refreshed_authorization="${test_current_authorization},44@${refreshed_merge}"
+	root_record=$(jq -cn --arg merge "$root_merge" \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
+	test_current_record=$(jq -cn --arg root "$root_merge" --arg current "$current_merge" --argjson previous "$root_record" \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,expected_sources:[{pr:42,merge:$root},{pr:43,merge:$current}],recorded_at:"2026-08-09T00:01:00Z",aggregate_recovery:{previous_authorization:$previous}}')
+	test_refreshed_record=$(jq -cn --arg root "$root_merge" --arg current "$current_merge" \
+		--arg refreshed "$refreshed_merge" --argjson previous "$root_record" \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,expected_sources:[{pr:42,merge:$root},{pr:43,merge:$current},{pr:44,merge:$refreshed}],recorded_at:"2026-08-09T00:02:00Z",aggregate_recovery:{previous_authorization:$previous}}')
+	test_lane_snapshot='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":42,"expected_sources":"42","phase":"remote-publication","tag":"v1.2.3","operation_token":"lane-old"}'
+	test_authorization="$test_current_authorization"
+	test_phase="aggregation-recovery"
+	set_test_lane_json() {
+		if [[ "$test_phase" == "aggregation-recovery-refresh" ]]; then
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$test_refreshed_authorization" \
+				--arg current "$test_current_authorization" --argjson previous "$test_lane_snapshot" \
+				'{phase:"aggregation-recovery-refresh",operation_token:"lane-refreshed",aggregate_recovery:{previous_state:$previous,refresh:{previous_expected_sources:$current,pending_expected_sources:$expected}}}')
+		else
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg current "$test_current_authorization" \
+				--argjson previous "$test_lane_snapshot" \
+				'{phase:"aggregation-recovery",operation_token:"lane-current",expected_sources:$current,aggregate_recovery:{previous_state:$previous}}')
+		fi
+		return 0
+	}
+	set_test_lane_json
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$test_authorization"
+		return 0
+	}
+	_full_loop_read_release_authorization_record() {
+		if [[ "$test_authorization" == "$test_refreshed_authorization" ]]; then
+			printf '%s\n' "$test_refreshed_record"
+		else
+			printf '%s\n' "$test_current_record"
+		fi
+		return 0
+	}
+	_full_loop_read_release_authorization_recovery_snapshot() {
+		printf '%s\n' "$root_record"
+		return 0
+	}
+	_full_loop_recovery_validate_interrupted_publication_intent() {
+		set_test_lane_json
+		return $?
+	}
+	REFRESH_LOG="${TEST_ROOT}/refresh.log"
+	: >"$REFRESH_LOG"
+	written_expected=""
+	written_previous=""
+	AUTH_WRITE_MODE=success
+	_full_loop_write_release_authorization_record() {
+		local repo="$1"
+		local source_pr="$2"
+		local expected="$3"
+		local previous="$4"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" ]] || return 1
+		written_expected="$expected"
+		written_previous="$previous"
+		printf 'write\n' >>"$REFRESH_LOG"
+		[[ "$AUTH_WRITE_MODE" == "success" ]] || return 1
+		test_authorization="$expected"
+		return 0
+	}
+	BEGIN_MODE=success
+	release_lane_begin_aggregate_refresh() {
+		local repo="$1"
+		local source_pr="$2"
+		local tag_name="$3"
+		local previous="$4"
+		local expected="$5"
+		local old_tag="$6"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && "$tag_name" == "v1.2.3" ]] || return 1
+		[[ "$previous" == "$test_current_authorization" && "$expected" == "$test_refreshed_authorization" &&
+			"$old_tag" == "$provisional" ]] || return 1
+		printf 'begin\n' >>"$REFRESH_LOG"
+		[[ "$BEGIN_MODE" == "success" ]] || return 1
+		test_phase="aggregation-recovery-refresh"
+		_AIDEVOPS_RELEASE_LANE_TOKEN=lane-refreshed
+		return 0
+	}
+	FINISH_MODE=success
+	release_lane_finish_aggregate_refresh() {
+		local repo="$1"
+		local source_pr="$2"
+		local tag_name="$3"
+		local previous="$4"
+		local expected="$5"
+		local old_tag="$6"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && "$tag_name" == "v1.2.3" ]] || return 1
+		[[ "$previous" == "$test_current_authorization" && "$expected" == "$test_refreshed_authorization" &&
+			"$old_tag" == "$provisional" ]] || return 1
+		printf 'finish\n' >>"$REFRESH_LOG"
+		[[ "$FINISH_MODE" == "success" ]] || return 1
+		test_phase="aggregation-recovery"
+		return 0
+	}
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$test_refreshed_authorization"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$provisional"
+	_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON='{"source_pr":42}'
+	_full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3
+	[[ "$written_expected" == "$test_refreshed_authorization" && "$written_previous" == "$root_record" ]]
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" == "$root_authorization" ]]
+	[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT" == "$test_lane_snapshot" ]]
+	[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "lane-refreshed" ]]
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "begin write finish " ]]
+
+	test_authorization="$test_current_authorization"
+	test_phase="aggregation-recovery"
+	BEGIN_MODE=failure
+	: >"$REFRESH_LOG"
+	if _full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ "$test_authorization" == "$test_current_authorization" ]]
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "begin " ]]
+
+	BEGIN_MODE=success
+	AUTH_WRITE_MODE=failure
+	: >"$REFRESH_LOG"
+	if _full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ "$test_phase" == "aggregation-recovery-refresh" && "$test_authorization" == "$test_current_authorization" ]]
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "begin write " ]]
+	AUTH_WRITE_MODE=success
+	: >"$REFRESH_LOG"
+	_full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3
+	[[ "$test_authorization" == "$test_refreshed_authorization" && "$test_phase" == "aggregation-recovery" ]]
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "write finish " ]]
+
+	test_phase="aggregation-recovery-refresh"
+	FINISH_MODE=failure
+	: >"$REFRESH_LOG"
+	if _full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "finish " ]]
+	FINISH_MODE=success
+	: >"$REFRESH_LOG"
+	_full_loop_recovery_refresh_state_transaction test/repo 42 v1.2.3
+	[[ "$test_phase" == "aggregation-recovery" ]]
+	[[ "$(tr '\n' ' ' <"$REFRESH_LOG")" == "finish " ]]
+)
+printf 'PASS refreshed recovery fences first and resumes every partial state without blind rollback\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	provisional=1111111111111111111111111111111111111111
+	replacement=2222222222222222222222222222222222222222
+	expected='42@3333333333333333333333333333333333333333'
+	current_tag="$provisional"
+	tag_bound=false
+	main_reachable=true
+	lane_phase="aggregate-publication-committing"
+	update_mode=success
+	transition_log="${TEST_ROOT}/transition.log"
+	: >"$transition_log"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$provisional"
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expected"
+	_AIDEVOPS_RELEASE_LANE_TOKEN=lane-owned
+	git() {
+		printf '%s\n' "$current_tag"
+		return 0
+	}
+	_full_loop_recovery_tag_is_bound_to_current_aggregate() {
+		[[ "$tag_bound" == "true" ]]
+		return $?
+	}
+	_full_loop_recovery_release_commit_main_reachability() {
+		[[ "$main_reachable" == "true" ]] && return 0
+		return 2
+	}
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$expected"
+		return 0
+	}
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$expected" --arg phase "$lane_phase" \
+			'{active:true,source_pr:42,tag:"v1.2.3",operation_token:"lane-owned",phase:$phase,expected_sources:$expected,terminal_receipt:null,aggregate_recovery:{}}')
+		return 0
+	}
+	release_lane_update() {
+		local repo="$1"
+		local source_pr="$2"
+		local phase="$3"
+		local tag_name="$4"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && "$phase" == "remote-publication" &&
+			"$tag_name" == "v1.2.3" ]] || return 1
+		printf 'update\n' >>"$transition_log"
+		lane_phase="remote-publication"
+		[[ "$update_mode" == "success" ]] || return 1
+		return 0
+	}
+	if _full_loop_recovery_transition_durable_publication test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ ! -s "$transition_log" ]]
+	current_tag="$replacement"
+	if _full_loop_recovery_transition_durable_publication test/repo 42 v1.2.3; then
+		exit 1
+	fi
+	[[ ! -s "$transition_log" ]]
+	tag_bound=true
+	main_reachable=false
+	pending_rc=0
+	_full_loop_recovery_transition_durable_publication test/repo 42 v1.2.3 || pending_rc=$?
+	[[ "$pending_rc" -eq 8 && ! -s "$transition_log" ]]
+	main_reachable=true
+	_full_loop_recovery_transition_durable_publication test/repo 42 v1.2.3
+	[[ "$(tr '\n' ' ' <"$transition_log")" == "update " ]]
+	lane_phase="aggregate-publication-committing"
+	update_mode=ambiguous
+	: >"$transition_log"
+	_full_loop_recovery_transition_durable_publication test/repo 42 v1.2.3
+	[[ "$lane_phase" == "remote-publication" && "$(tr '\n' ' ' <"$transition_log")" == "update " ]]
+)
+printf 'PASS durable transition waits for main reachability and classifies ambiguous lane writes\n'
 
 CALL_LOG="${TEST_ROOT}/calls.log"
 : >"$CALL_LOG"
@@ -158,6 +589,10 @@ _full_loop_recovery_validate_receipt() {
 _full_loop_recovery_validate_existing_tag() {
 	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="1111111111111111111111111111111111111111"
 	printf 'tag\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_prepare_existing_context() {
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT=none
 	return 0
 }
 _full_loop_recovery_verify_channels_absent() {
@@ -178,33 +613,45 @@ _full_loop_recovery_begin_state_transaction() {
 	printf 'begin\n' >>"$CALL_LOG"
 	return 0
 }
-_full_loop_recovery_restore_state_transaction() {
-	printf 'restore\n' >>"$CALL_LOG"
-	return 0
-}
 _full_loop_recovery_tag_rollback_safe() { return 0; }
 _full_loop_recovery_write_evidence() {
 	printf 'evidence\n' >>"$CALL_LOG"
-	return 0
-}
-release_lane_update() {
-	printf 'lane\n' >>"$CALL_LOG"
 	return 0
 }
 git() {
 	printf '4444444444444444444444444444444444444444\n'
 	return 0
 }
-
+TAG_BINDING_MODE=unbound
+_full_loop_recovery_tag_is_bound_to_current_aggregate() {
+	[[ "$TAG_BINDING_MODE" == "bound" ]]
+	return $?
+}
+DURABLE_MODE=pending
+_full_loop_recovery_transition_durable_publication() {
+	printf 'durable\n' >>"$CALL_LOG"
+	case "$DURABLE_MODE" in
+	success) return 0 ;;
+	pending) return 8 ;;
+	*) return 1 ;;
+	esac
+}
+REMOTE_MODE=success
+_full_loop_recovery_load_remote_publication_state() {
+	printf 'remote\n' >>"$CALL_LOG"
+	[[ "$REMOTE_MODE" == "success" ]]
+	return $?
+}
 _full_loop_recovery_run_version_manager() {
 	printf 'version-manager\n' >>"$CALL_LOG"
+	TAG_BINDING_MODE=bound
 	return 8
 }
 success_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || success_rc=$?
 [[ "$success_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager evidence lane " ]]
-printf 'PASS queued recovery records evidence and retains the expanded transaction\n'
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt channels begin version-manager evidence durable " ]]
+printf 'PASS queued recovery retains the committing fence until main reachability\n'
 
 : >"$CALL_LOG"
 _full_loop_recovery_tag_sources() {
@@ -215,14 +662,15 @@ _full_loop_recovery_load_existing_state_transaction() {
 	printf 'load\n' >>"$CALL_LOG"
 	return 1
 }
-_full_loop_recovery_tag_is_bound_to_current_aggregate() { return 1; }
+TAG_BINDING_MODE=unbound
 same_sources_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || same_sources_rc=$?
 [[ "$same_sources_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate load channels begin version-manager evidence lane " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt load channels begin version-manager evidence durable " ]]
 printf 'PASS fresh same-source aggregation still replaces the historical tag\n'
 
 : >"$CALL_LOG"
+DURABLE_MODE=success
 _full_loop_recovery_load_existing_state_transaction() {
 	printf 'load\n' >>"$CALL_LOG"
 	return 0
@@ -231,11 +679,49 @@ _full_loop_recovery_resume_publication() {
 	printf 'resume\n' >>"$CALL_LOG"
 	return 8
 }
+TAG_BINDING_MODE=bound
 resume_rc=0
 _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || resume_rc=$?
 [[ "$resume_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate load resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt load durable resume " ]]
 printf 'PASS interrupted aggregate recovery resumes without another tag replacement\n'
+
+: >"$CALL_LOG"
+DURABLE_MODE=pending
+_full_loop_release_prepare_tag_worktree() {
+	printf 'prepare-worktree\n' >>"$CALL_LOG"
+	return 0
+}
+pending_resume_rc=0
+pending_resume_output=$(_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 2>&1) || pending_resume_rc=$?
+[[ "$pending_resume_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt load durable prepare-worktree evidence version-manager durable " ]]
+[[ "$pending_resume_output" == *"same recover-aggregate command"* ]]
+printf 'PASS interrupted committing recovery idempotently repairs its protected queue\n'
+
+: >"$CALL_LOG"
+DURABLE_MODE=success
+_full_loop_recovery_load_existing_state_transaction() {
+	printf 'load\n' >>"$CALL_LOG"
+	return 1
+}
+remote_resume_rc=0
+_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || remote_resume_rc=$?
+[[ "$remote_resume_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt load remote resume " ]]
+printf 'PASS remote-publication recovery reruns enter normal reconciliation\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_load_existing_state_transaction() {
+	printf 'load\n' >>"$CALL_LOG"
+	return 0
+}
+TAG_BINDING_MODE=unbound
+pre_mutation_rc=0
+_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || pre_mutation_rc=$?
+[[ "$pre_mutation_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt load channels begin version-manager evidence durable " ]]
+printf 'PASS interrupted pre-mutation recovery completes the aggregate tag replacement\n'
 
 : >"$CALL_LOG"
 _full_loop_recovery_tag_sources() {
@@ -250,12 +736,14 @@ _full_loop_recovery_resume_publication() {
 	printf 'resume\n' >>"$CALL_LOG"
 	return 1
 }
+DURABLE_MODE=failure
+TAG_BINDING_MODE=unbound
 if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&1; then
 	printf 'FAIL failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume restore " ]]
-printf 'PASS failed recovery restores authorization and release-lane state\n'
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt channels begin version-manager durable " ]]
+printf 'PASS pre-tag failure retains its fenced transaction without non-atomic rollback\n'
 
 : >"$CALL_LOG"
 _full_loop_recovery_tag_rollback_safe() { return 1; }
@@ -263,7 +751,7 @@ if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&
 	printf 'FAIL unsafe failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt channels begin version-manager durable " ]]
 printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 
 : >"$CALL_LOG"
@@ -271,24 +759,95 @@ _full_loop_recovery_resume_publication() {
 	printf 'resume\n' >>"$CALL_LOG"
 	return 8
 }
+DURABLE_MODE=pending
+TAG_BINDING_MODE=bound
 durable_queue_rc=0
 durable_queue_output=$(_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 2>&1) || durable_queue_rc=$?
 [[ "$durable_queue_rc" -eq 8 ]]
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag receipt aggregate channels begin version-manager resume " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "tag aggregate receipt channels begin version-manager durable " ]]
 [[ "$durable_queue_output" == *"aidevops release status 42"* ]]
-[[ "$durable_queue_output" == *"aidevops release reconcile 42"* ]]
+[[ "$durable_queue_output" == *"same recover-aggregate command"* ]]
 [[ "$durable_queue_output" != *"Aggregate recovery failed after tag state changed"* ]]
-printf 'PASS durable protected-main queue remains pending after version-manager uncertainty\n'
+printf 'PASS protected-main queue remains exclusively fenced while its merge is pending\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	queue_log="${TEST_ROOT}/advanced-main-queue.log"
+	release_checkout="${TEST_ROOT}/advanced-main-release"
+	provisional=1111111111111111111111111111111111111111
+	replacement=2222222222222222222222222222222222222222
+	expected='42@3333333333333333333333333333333333333333'
+	mkdir -p "$release_checkout/.agents/scripts"
+	cat >"$release_checkout/.agents/scripts/version-manager.sh" <<'STUB'
+#!/usr/bin/env bash
+[[ "$PWD" == "$RECOVERY_RELEASE_PATH" ]] || exit 1
+[[ "$AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN" == "lane-owned" ]] || exit 1
+[[ "$AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES" == "42@3333333333333333333333333333333333333333" ]] || exit 1
+[[ "$*" == "recover-aggregate --tag v1.2.3 --source-pr 42 --expected-sources 42@3333333333333333333333333333333333333333 --old-tag-object 1111111111111111111111111111111111111111" ]] || exit 1
+printf 'version-manager\n' >>"$RECOVERY_QUEUE_LOG"
+exit 8
+STUB
+	export RECOVERY_QUEUE_LOG="$queue_log" RECOVERY_RELEASE_PATH="$release_checkout"
+	: >"$queue_log"
+	_full_loop_recovery_validate_existing_tag() {
+		_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="$provisional"
+		printf 'tag\n' >>"$queue_log"
+		return 0
+	}
+	_full_loop_recovery_prepare_existing_context() {
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expected"
+		_FULL_LOOP_RESOLVED_SOURCE_MERGE=3333333333333333333333333333333333333333
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT=transaction
+		_AIDEVOPS_RELEASE_LANE_TOKEN=lane-owned
+		return 0
+	}
+	_full_loop_recovery_tag_is_bound_to_current_aggregate() { return 0; }
+	_full_loop_recovery_transition_durable_publication() {
+		printf 'durable\n' >>"$queue_log"
+		return 8
+	}
+	_full_loop_recovery_write_evidence() {
+		printf 'evidence\n' >>"$queue_log"
+		return 0
+	}
+	_full_loop_release_prepare_tag_worktree() {
+		printf 'prepare-worktree\n' >>"$queue_log"
+		_FULL_LOOP_RELEASE_PATH="$release_checkout"
+		return 0
+	}
+	_full_loop_recovery_prepare_aggregate() {
+		printf 'fresh-aggregate\n' >>"$queue_log"
+		return 1
+	}
+	git() {
+		printf '%s\n' "$replacement"
+		return 0
+	}
+	queue_rc=0
+	_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42 || queue_rc=$?
+	[[ "$queue_rc" -eq 8 ]]
+	[[ "$(tr '\n' ' ' <"$queue_log")" == "tag durable prepare-worktree evidence version-manager durable " ]]
+)
+printf 'PASS persisted replacement-tag recovery recreates its detached tag worktree before queue repair\n'
 
 (
 	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
 	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH=reserved-authorization-refresh
 	RESERVED_LOG="${TEST_ROOT}/reserved.log"
 	: >"$RESERVED_LOG"
 	old_manifest='42@2222222222222222222222222222222222222222'
 	legacy_lane_intent='42'
 	expanded_manifest="${old_manifest},43@3333333333333333333333333333333333333333"
+	authorization="$old_manifest"
+	lane_phase=reserved
+	test_lane_sources="$legacy_lane_intent"
+	finish_mode=success
+	root_authorization_record=$(jq -cn --arg merge 2222222222222222222222222222222222222222 \
+		'{schema_version:1,repository:"test/repo",requested_pr:42,
+		  expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
 	_full_loop_recovery_validate_receipt() { return 0; }
 	_full_loop_release_find_tag_for_pr() { return 2; }
 	_full_loop_recovery_prepare_aggregate() {
@@ -302,89 +861,112 @@ printf 'PASS durable protected-main queue remains pending after version-manager 
 	}
 	_full_loop_release_reset_tag_worktree() { return 0; }
 	_full_loop_read_release_authorization() {
-		printf '%s\n' "$old_manifest"
+		printf '%s\n' "$authorization"
 		return 0
 	}
-	release_authorization_subset() { return 0; }
+	_full_loop_read_release_authorization_recovery_snapshot() {
+		printf '%s\n' "$root_authorization_record"
+		return 0
+	}
 	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
-			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
+		if [[ "$lane_phase" == "reserved-authorization-refresh" ]]; then
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
+				--arg expected "$expanded_manifest" \
+				'{schema_version:1,active:true,source_pr:42,phase:"reserved-authorization-refresh",
+				  tag:null,expected_sources:$expected,operation_token:"lane-refresh",terminal_receipt:null,
+				  reserved_authorization_refresh:{previous_expected_sources:$previous,
+				    pending_expected_sources:$expected,previous_state:{schema_version:1}}}')
+		else
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$test_lane_sources" \
+				'{schema_version:1,active:true,source_pr:42,phase:"reserved",tag:null,
+				  expected_sources:$expected,operation_token:"lane-old",terminal_receipt:null}')
+		fi
 		return 0
 	}
 	release_lane_acquire() {
-		_AIDEVOPS_RELEASE_LANE_RESULT=acquired
+		printf 'acquire\n' >>"$RESERVED_LOG"
+		_AIDEVOPS_RELEASE_LANE_RESULT=adopted
 		_AIDEVOPS_RELEASE_LANE_TOKEN=owned
 		return 0
 	}
 	_full_loop_expand_release_authorization_for_aggregate() {
+		[[ "$lane_phase" == "reserved-authorization-refresh" ]] || return 1
 		printf 'expand-auth\n' >>"$RESERVED_LOG"
+		authorization="$expanded_manifest"
 		return 0
 	}
 	release_lane_expand_reserved_authorization() {
 		[[ "$3" == "$legacy_lane_intent" ]] || return 1
-		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
-		printf 'expand-lane\n' >>"$RESERVED_LOG"
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"schema_version":1,"phase":"reserved"}'
+		printf 'fence\n' >>"$RESERVED_LOG"
+		lane_phase=reserved-authorization-refresh
+		test_lane_sources="$expanded_manifest"
 		return 0
 	}
-	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43
-	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate expand-auth expand-lane " ]]
-	printf 'PASS reserved recovery normalizes legacy lane intent before transactional expansion\n'
-
-	: >"$RESERVED_LOG"
-	_full_loop_read_release_authorization() {
-		printf '%s\n' "$expanded_manifest"
+	release_lane_finish_reserved_authorization() {
+		[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved-authorization-refresh" ]] || return 1
+		printf 'finish\n' >>"$RESERVED_LOG"
+		[[ "$finish_mode" == "success" ]] || return 1
+		lane_phase=reserved
+		test_lane_sources="$expanded_manifest"
 		return 0
-	}
-	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$expanded_manifest" \
-			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$expected,terminal_receipt:null}')
-		return 0
-	}
-	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
-	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate " ]]
-	printf 'PASS reserved recovery recognizes an already-converged authorization and lane\n'
-
-	: >"$RESERVED_LOG"
-	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn \
-			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:"44",terminal_receipt:null}')
-		return 0
-	}
-	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >"${TEST_ROOT}/legacy-mismatch.out" 2>&1; then
-		exit 1
-	fi
-	grep -q 'cannot be normalized against reviewed aggregate' "${TEST_ROOT}/legacy-mismatch.out"
-	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate " ]]
-	printf 'PASS reserved recovery rejects non-equivalent legacy PR identities without mutation\n'
-
-	: >"$RESERVED_LOG"
-	_full_loop_read_release_authorization() {
-		printf '%s\n' "$old_manifest"
-		return 0
-	}
-	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
-			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
-		return 0
-	}
-	release_lane_expand_reserved_authorization() {
-		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
-		printf 'expand-lane\n' >>"$RESERVED_LOG"
-		return 1
 	}
 	release_lane_restore_reserved_authorization() {
 		printf 'restore-lane\n' >>"$RESERVED_LOG"
+		lane_phase=reserved
+		test_lane_sources="$legacy_lane_intent"
 		return 0
 	}
-	_full_loop_restore_release_authorization_after_aggregate() {
-		printf 'restore-auth\n' >>"$RESERVED_LOG"
-		return 0
-	}
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence expand-auth finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" ]]
+	printf 'PASS reserved recovery fences the lane before authorization expansion\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$expanded_manifest"
+	lane_phase=reserved
+	test_lane_sources="$legacy_lane_intent"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence finish " ]]
+	[[ "$lane_phase" == "reserved" && "$test_lane_sources" == "$expanded_manifest" ]]
+	printf 'PASS reserved recovery repairs an authorization-first interruption without skipping the stale lane\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reserved-authorization-refresh
+	test_lane_sources="$expanded_manifest"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence expand-auth finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" ]]
+	printf 'PASS reserved recovery resumes an interruption between lane fencing and authorization\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reserved
+	test_lane_sources="$legacy_lane_intent"
+	finish_mode=failure
 	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
 		exit 1
 	fi
-	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate expand-auth expand-lane restore-lane restore-auth " ]]
-	printf 'PASS reserved recovery restores lane and authorization after a partial write\n'
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence expand-auth finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved-authorization-refresh" ]]
+	finish_mode=success
+	: >"$RESERVED_LOG"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence finish " ]]
+	[[ "$lane_phase" == "reserved" ]]
+	printf 'PASS reserved recovery retains and resumes a fenced post-authorization interruption\n'
+
+	lane_phase=reserved
+	test_lane_sources="$legacy_lane_intent"
+	_full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"
+	test_lane_sources="$expanded_manifest"
+	if _full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"; then
+		exit 1
+	fi
+	lane_phase=reserved-authorization-refresh
+	_full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"
+	printf 'PASS equal persisted PR sets still resume stale or fenced reserved-lane migration\n'
 )
 
 exit 0

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -120,6 +120,35 @@ run_merge_guard_test() (
 		release_lane_merge_guard test/repo 303 main chore/release-v1.2.3-provenance || return 1
 	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 404 main release/aggregate-recovery || return 1
+	for recovery_phase in aggregation-recovery aggregation-recovery-refresh aggregate-publication-committing reserved-authorization-refresh; do
+		state=$(jq -cn --arg phase "$recovery_phase" \
+			'{schema_version:1,repository:"test/repo",active:true,source_pr:101,phase:$phase,
+			  tag:(if $phase == "reserved-authorization-refresh" then null else "v1.2.3" end),
+			  operation_token:"token-old"}')
+		rc=0
+		output=$(AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+			release_lane_merge_guard test/repo 202 main feature/ordinary 2>&1) || rc=$?
+		[[ "$rc" -eq 75 && "$output" == *"phase=${recovery_phase}"* ]] || return 1
+		rc=0
+		AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+			release_lane_merge_guard test/repo 303 main chore/release-v1.2.3-provenance \
+			>/dev/null 2>&1 || rc=$?
+		if [[ "$recovery_phase" == "aggregate-publication-committing" ]]; then
+			[[ "$rc" -eq 0 ]] || return 1
+		else
+			[[ "$rc" -eq 75 ]] || return 1
+		fi
+		rc=0
+		AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+			release_lane_merge_guard test/repo 404 main release/aggregate-recovery \
+			>/dev/null 2>&1 || rc=$?
+		if [[ "$recovery_phase" == "aggregate-publication-committing" ||
+			"$recovery_phase" == "reserved-authorization-refresh" ]]; then
+			[[ "$rc" -eq 75 ]] || return 1
+		else
+			[[ "$rc" -eq 0 ]] || return 1
+		fi
+	done
 	state='{"schema_version":1,"repository":"test/repo","active":false,"source_pr":101,"phase":"terminal","tag":"v1.2.3","operation_token":"token-old","terminal_receipt":"superseded"}'
 	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 202 main feature/ordinary || return 1
@@ -242,6 +271,13 @@ run_stale_reclamation_guard_test() (
 run_aggregate_recovery_rotation_test() (
 	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101","phase":"remote-publication","tag":"v1.2.3","updated_at":"2026-08-09T00:00:00Z","operation_token":"token-old"}'
 	local old_state="$state"
+	local first_recovery_token=""
+	local refresh_token=""
+	local initial_authorization='101@1111111111111111111111111111111111111111'
+	local initial_expanded='101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222'
+	local refreshed_expanded=""
+	local claimed_state=""
+	local write_mode="success"
 	release_lane_read() {
 		_AIDEVOPS_RELEASE_LANE_JSON="$state"
 		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
@@ -253,16 +289,57 @@ run_aggregate_recovery_rotation_test() (
 		local expected_head="$3"
 		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
 		state="$state_json"
+		[[ "$write_mode" == "success" ]] || return 1
 		return 0
 	}
+	write_mode="ambiguous"
 	release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
-		'101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222' \
+		"$initial_authorization" "$initial_expanded" \
 		3333333333333333333333333333333333333333 || return 1
-	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery" &&
-	"$(jq -r '.expected_sources' <<<"$state")" == 101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222 &&
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery-refresh" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == "$initial_expanded" &&
 	"$(jq -r '.operation_token' <<<"$state")" != "token-old" &&
 	"$(jq -r '.aggregate_recovery.provisional_tag_object' <<<"$state")" == 3333333333333333333333333333333333333333 &&
+	"$(jq -r '.aggregate_recovery.refresh.previous_expected_sources' <<<"$state")" == "$initial_authorization" &&
+	"$(jq -r '.aggregate_recovery.refresh.pending_expected_sources' <<<"$state")" == "$initial_expanded" &&
 	"$(jq -c '.aggregate_recovery.previous_state' <<<"$state")" == "$old_state" ]] || return 1
+	release_lane_finish_aggregate_refresh test/repo 101 v1.2.3 "$initial_authorization" \
+		"$initial_expanded" 3333333333333333333333333333333333333333 || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery" &&
+	"$(jq -r '.aggregate_recovery.refresh // empty' <<<"$state")" == "" ]] || return 1
+	first_recovery_token=$(jq -r '.operation_token' <<<"$state") || return 1
+	refreshed_expanded="${initial_expanded},103@4444444444444444444444444444444444444444"
+	write_mode="ambiguous"
+	release_lane_begin_aggregate_refresh test/repo 101 v1.2.3 "$initial_expanded" \
+		"$refreshed_expanded" 3333333333333333333333333333333333333333 || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery-refresh" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == "$refreshed_expanded" &&
+	"$(jq -r '.operation_token' <<<"$state")" != "$first_recovery_token" &&
+	"$(jq -c '.aggregate_recovery.previous_state' <<<"$state")" == "$old_state" &&
+	"$(jq -r '.aggregate_recovery.refresh.previous_expected_sources' <<<"$state")" == "$initial_expanded" &&
+	"$(jq -r '.aggregate_recovery.refresh.pending_expected_sources' <<<"$state")" == "$refreshed_expanded" &&
+	"$(jq -r '.aggregate_recovery.provisional_tag_object' <<<"$state")" == 3333333333333333333333333333333333333333 ]] || return 1
+	refresh_token=$(jq -r '.operation_token' <<<"$state") || return 1
+	write_mode="ambiguous"
+	release_lane_finish_aggregate_refresh test/repo 101 v1.2.3 "$initial_expanded" \
+		"$refreshed_expanded" 3333333333333333333333333333333333333333 || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery" &&
+	"$(jq -r '.operation_token' <<<"$state")" == "$refresh_token" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == "$refreshed_expanded" &&
+	"$(jq -r '.aggregate_recovery.refresh // empty' <<<"$state")" == "" &&
+	"$(jq -c '.aggregate_recovery.previous_state' <<<"$state")" == "$old_state" ]] || return 1
+	write_mode="ambiguous"
+	release_lane_claim_aggregate_publication test/repo 101 v1.2.3 "$refreshed_expanded" || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregate-publication-committing" &&
+	"$(jq -r '.operation_token' <<<"$state")" == "$refresh_token" ]] || return 1
+	release_lane_verify_aggregate_publication test/repo 101 v1.2.3 "$refreshed_expanded" || return 1
+	claimed_state="$state"
+	state=$(jq -c '.operation_token="lane-rotated"' <<<"$state") || return 1
+	if release_lane_verify_aggregate_publication test/repo 101 v1.2.3 "$refreshed_expanded"; then
+		return 1
+	fi
+	state="$claimed_state"
+	write_mode="success"
 	release_lane_restore_aggregate_recovery test/repo 101 "$old_state" || return 1
 	[[ "$state" == "$old_state" ]]
 	return $?
@@ -281,11 +358,13 @@ run_aggregate_recovery_rejection_test() (
 	}
 	if release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
 		'101@1111111111111111111111111111111111111111' \
+		'101@1111111111111111111111111111111111111111' \
 		3333333333333333333333333333333333333333; then
 		return 1
 	fi
 	state_mode="terminal"
 	if release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
+		'101@1111111111111111111111111111111111111111' \
 		'101@1111111111111111111111111111111111111111' \
 		3333333333333333333333333333333333333333; then
 		return 1
@@ -298,6 +377,7 @@ run_reserved_aggregate_authorization_test() (
 	local state="$old_state"
 	local expanded='101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222'
 	local write_conflict=false
+	local first_token=""
 	release_lane_read() {
 		_AIDEVOPS_RELEASE_LANE_JSON="$state"
 		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
@@ -315,7 +395,23 @@ run_reserved_aggregate_authorization_test() (
 	_AIDEVOPS_RELEASE_LANE_TOKEN="token-owned"
 	release_lane_expand_reserved_authorization test/repo 101 \
 		'101' "$expanded" || return 1
-	[[ "$(jq -r '.expected_sources' <<<"$state")" == "$expanded" ]] || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "reserved-authorization-refresh" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == "$expanded" &&
+	"$(jq -r '.operation_token' <<<"$state")" != "token-owned" &&
+	"$(jq -r '.reserved_authorization_refresh.previous_expected_sources' <<<"$state")" == "101" &&
+	"$(jq -r '.reserved_authorization_refresh.pending_expected_sources' <<<"$state")" == "$expanded" &&
+	"$(jq -c '.reserved_authorization_refresh.previous_state' <<<"$state")" == "$old_state" ]] || return 1
+	first_token=$(jq -r '.operation_token' <<<"$state") || return 1
+	_AIDEVOPS_RELEASE_LANE_TOKEN="token-owned"
+	release_lane_expand_reserved_authorization test/repo 101 '101' "$expanded" || return 1
+	[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$first_token" ]] || return 1
+	release_lane_finish_reserved_authorization test/repo 101 '101' "$expanded" || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "reserved" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == "$expanded" &&
+	"$(jq -r '.reserved_authorization_refresh // empty' <<<"$state")" == "" ]] || return 1
+	state="$old_state"
+	_AIDEVOPS_RELEASE_LANE_TOKEN="token-owned"
+	release_lane_expand_reserved_authorization test/repo 101 '101' "$expanded" || return 1
 	release_lane_restore_reserved_authorization test/repo 101 "$expanded" "$old_state" || return 1
 	[[ "$state" == "$old_state" ]] || return 1
 	write_conflict=true
@@ -349,7 +445,7 @@ if run_default_stale_boundary_and_fencing_test; then assert_result 'default stal
 if run_stale_reclamation_guard_test; then assert_result 'preparing, tagged, and receipted lanes remain reconcile-only' true; else assert_result 'preparing, tagged, and receipted lanes remain reconcile-only' false; fi
 if run_aggregate_recovery_rotation_test; then assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' true; else assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' false; fi
 if run_aggregate_recovery_rejection_test; then assert_result 'aggregate recovery rejects competing owners and terminal lanes' true; else assert_result 'aggregate recovery rejects competing owners and terminal lanes' false; fi
-if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggregate authorization uses owned CAS expansion and exact rollback' true; else assert_result 'reserved aggregate authorization uses owned CAS expansion and exact rollback' false; fi
+if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' true; else assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -315,8 +315,22 @@ tag_authorization_json=$(
 		bash "$HELPER" resolve-tag-authorization --tag v2.0.0 --source-pr 42 --repo test/aggregate \
 		--expected-sources 42,43,44,45
 )
-jq -e '(.expected_sources | map(.pr)) == [42,43,44,45]' <<<"$tag_authorization_json" >/dev/null
-printf 'PASS immutable-tag authorization resolves every trusted PR to its verified merge SHA\n'
+jq -e --arg source_merge "$COMPLETE_AGGREGATE_MERGE" '
+	.mode == "aggregate" and .source_pr == 100 and .source_merge == $source_merge
+	and (.expected_sources | map(.pr)) == [42,43,44,45]
+	and (.aggregated_sources | map(.pr)) == [42,43,44,45]
+' <<<"$tag_authorization_json" >/dev/null
+printf 'PASS immutable-tag authorization resolves exact source provenance and every trusted merge SHA\n'
+if (
+	cd "$AGG_REPO" || exit 1
+	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" resolve-tag-authorization --tag v2.0.0 --source-pr 42 --repo test/aggregate \
+		--expected-sources 42,43,44
+) >/dev/null 2>&1; then
+	printf 'FAIL immutable-tag authorization accepted a strict subset of the signed aggregate\n'
+	exit 1
+fi
+printf 'PASS immutable-tag authorization rejects incomplete persisted source sets\n'
 (
 	cd "$AGG_REPO" || exit 1
 	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \

--- a/.agents/scripts/tests/test-version-manager-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-version-manager-aggregate-recovery.sh
@@ -62,8 +62,21 @@ verify_release_source_pr() {
 	VERSION_MANAGER_AGGREGATED_SOURCES="42@${SOURCE_MERGE}"
 	return 0
 }
+verify_release_tag_source() {
+	VERSION_MANAGER_SOURCE_PR=99
+	VERSION_MANAGER_SOURCE_MERGE_SHA="$AGGREGATE_MERGE"
+	VERSION_MANAGER_AGGREGATED_SOURCES="42@${SOURCE_MERGE}"
+	VERSION_MANAGER_EXPECTED_SOURCES="42@${SOURCE_MERGE}"
+	return 0
+}
 validate_version_consistency() { return 0; }
-_verify_recovered_aggregate_tag() { return 0; }
+ROTATE_AFTER_TAG=false
+_verify_recovered_aggregate_tag() {
+	if [[ "$ROTATE_AFTER_TAG" == "true" ]]; then
+		LANE_TOKEN="lane-rotated"
+	fi
+	return 0
+}
 release_source_pr_required() { return 0; }
 _release_contains_efficiency_change() { return 1; }
 push_changes() { return "${PUSH_RC:-8}"; }
@@ -86,6 +99,29 @@ expected_sources=""
 old_tag_object=""
 _parse_aggregate_recovery_args --tag v1.2.3 --source-pr 42 \
 	--expected-sources "42@${SOURCE_MERGE}" --old-tag-object "$OLD_TAG_OBJECT"
+AIDEVOPS_RELEASE_LANE_REPOSITORY=test/repo
+AIDEVOPS_RELEASE_LANE_SOURCE_PR=42
+AIDEVOPS_RELEASE_LANE_TAG=v1.2.3
+AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES="42@${SOURCE_MERGE}"
+AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN=lane-owned
+export AIDEVOPS_RELEASE_LANE_REPOSITORY AIDEVOPS_RELEASE_LANE_SOURCE_PR
+export AIDEVOPS_RELEASE_LANE_TAG AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES
+export AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
+LANE_TOKEN=lane-owned
+LANE_PHASE=aggregation-recovery
+release_lane_claim_aggregate_publication() {
+	[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$LANE_TOKEN" ]] || return 1
+	case "$LANE_PHASE" in
+	aggregation-recovery) LANE_PHASE=aggregate-publication-committing ;;
+	aggregate-publication-committing) ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+release_lane_verify_aggregate_publication() {
+	[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$LANE_TOKEN" && "$LANE_PHASE" == "aggregate-publication-committing" ]]
+	return $?
+}
 _validate_aggregate_recovery_context "$tag_name" "$source_pr" "$expected_sources" "$old_tag_object"
 recovery_rc=0
 _execute_aggregate_recovery "$tag_name" "$old_tag_object" || recovery_rc=$?
@@ -97,8 +133,48 @@ NEW_TAG_OBJECT=$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)
 git -C "$RECOVERY" for-each-ref --format='%(contents)' refs/tags/v1.2.3 | grep -q "Aidevops-Source-PR: 99"
 printf 'PASS aggregate recovery replaces a local-only tag without incrementing the version\n'
 
+printf 'advanced main\n' >"${REPO}/advanced.txt"
+git -C "$REPO" add advanced.txt
+git -C "$REPO" commit -q -m 'concurrent main advance'
+git -C "$REPO" push -q origin main
+ADVANCED_MAIN=$(git -C "$REPO" rev-parse HEAD)
+git -C "$RECOVERY" fetch -q origin main
+git -C "$RECOVERY" reset -q --hard origin/main
+_validate_aggregate_recovery_context "$tag_name" "$source_pr" "$expected_sources" "$old_tag_object"
+[[ "$_VERSION_MANAGER_AGGREGATE_TAG_MODE" == "recovered" ]]
+[[ "$(git -C "$RECOVERY" rev-parse origin/main)" == "$ADVANCED_MAIN" ]]
+resumed_rc=0
+_execute_aggregate_recovery "$tag_name" "$old_tag_object" || resumed_rc=$?
+[[ "$resumed_rc" -eq 8 ]]
+[[ "$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)" == "$NEW_TAG_OBJECT" ]]
+[[ "$(git -C "$RECOVERY" rev-parse HEAD)" == "$(git -C "$RECOVERY" rev-parse 'v1.2.3^{commit}')" ]]
+printf 'PASS interrupted aggregate recovery resumes the exact replacement tag after main advances\n'
+
 restore_unpublished_aggregate_tag 1.2.3 "$OLD_TAG_OBJECT"
 git -C "$RECOVERY" reset -q --hard "$AGGREGATE_MERGE"
+_VERSION_MANAGER_AGGREGATE_TAG_MODE="$_VERSION_MANAGER_AGGREGATE_TAG_MODE_PROVISIONAL"
+LANE_TOKEN=lane-rotated
+LANE_PHASE=aggregation-recovery
+stale_rc=0
+_execute_aggregate_recovery v1.2.3 "$OLD_TAG_OBJECT" || stale_rc=$?
+[[ "$stale_rc" -eq 1 ]]
+[[ "$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)" == "$OLD_TAG_OBJECT" ]]
+[[ "$(git -C "$RECOVERY" rev-parse HEAD)" == "$AGGREGATE_MERGE" ]]
+printf 'PASS rotated aggregate lane token fences a stale process before local mutation\n'
+
+LANE_TOKEN=lane-owned
+LANE_PHASE=aggregation-recovery
+ROTATE_AFTER_TAG=true
+post_tag_rc=0
+_execute_aggregate_recovery v1.2.3 "$OLD_TAG_OBJECT" || post_tag_rc=$?
+[[ "$post_tag_rc" -eq 1 ]]
+[[ "$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)" == "$OLD_TAG_OBJECT" ]]
+printf 'PASS post-tag lane rotation restores the unpublished provisional tag\n'
+
+git -C "$RECOVERY" reset -q --hard "$AGGREGATE_MERGE"
+LANE_TOKEN=lane-owned
+LANE_PHASE=aggregation-recovery
+ROTATE_AFTER_TAG=false
 PUSH_RC=1
 failed_rc=0
 _main_recover_aggregate --tag v1.2.3 --source-pr 42 \

--- a/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
@@ -177,6 +177,16 @@ export REPO_ROOT="$REPO"
 # shellcheck source=../version-manager-git.sh
 source "${SCRIPT_DIR}/version-manager-git.sh"
 
+AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN=stale-token
+export AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
+_version_manager_verify_aggregate_lane_fence() { return 1; }
+fenced_push_rc=0
+push_changes 1.2.3 >/dev/null 2>&1 || fenced_push_rc=$?
+[[ "$fenced_push_rc" -eq 1 && ! -e "$DIRECT_PUSH_COUNT" ]]
+unset AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
+unset -f _version_manager_verify_aggregate_lane_fence
+printf 'PASS stale aggregate lane is checked immediately before direct publication push\n'
+
 push_rc=0
 push_output=$(push_changes 1.2.3 2>&1) || push_rc=$?
 if [[ "$push_rc" -ne 8 ]]; then
@@ -205,6 +215,21 @@ printf 'PASS recovery branch preserves the original release commit and tag objec
 grep -q '^pr create .*--head chore/release-v1.2.3-provenance .*--base main ' "$FAKE_GH_LOG"
 grep -q "^pr merge 77 --repo test/repo --auto --merge --match-head-commit ${RECOVERY_HEAD}$" "$FAKE_GH_LOG"
 printf 'PASS recovery queues merge topology against the exact PR head\n'
+
+merge_calls_before=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
+AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN=stale-token
+export AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
+_version_manager_verify_aggregate_lane_fence() { return 1; }
+if _version_manager_queue_exact_merge test/repo "$RECOVERY_BRANCH" "$RECOVERY_HEAD" \
+	77 1.2.3 "$TAG_OBJECT" "$RELEASE_COMMIT" >/dev/null 2>&1; then
+	printf 'FAIL stale aggregate lane queued a protected-main merge\n'
+	exit 1
+fi
+merge_calls_after=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
+[[ "$merge_calls_after" -eq "$merge_calls_before" ]]
+unset AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
+unset -f _version_manager_verify_aggregate_lane_fence
+printf 'PASS stale aggregate lane is checked immediately before protected-main merge queueing\n'
 
 STALE_PR_HEAD="$CURRENT_MAIN"
 export STALE_PR_HEAD

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -47,6 +47,7 @@ source "${SCRIPT_DIR}/version-manager-protected-main.sh"
 # from "commit succeeded" (0). Callers that expect a new bump commit on HEAD
 # must treat exit 2 as fatal — see _release_execute (t2437/GH#20073).
 readonly VERSION_MANAGER_NO_CHANGES_EXIT=2
+readonly _VERSION_MANAGER_SOURCE_ENTRY_JQ='"\(.pr)@\(.merge)"'
 
 # --- Functions ---
 
@@ -155,13 +156,41 @@ verify_release_source_pr() {
 	source_json=$(cd "$REPO_ROOT" && bash "$resolver" "${resolver_args[@]}") || return 1
 	VERSION_MANAGER_SOURCE_PR=$(jq -er '.source_pr' <<<"$source_json") || return 1
 	VERSION_MANAGER_SOURCE_MERGE_SHA=$(jq -er '.source_merge' <<<"$source_json") || return 1
-	VERSION_MANAGER_AGGREGATED_SOURCES=$(jq -cr '.aggregated_sources // [] | .[] | "\(.pr)@\(.merge)"' <<<"$source_json") || return 1
-	VERSION_MANAGER_EXPECTED_SOURCES=$(jq -er '
-		(.expected_sources // (if .mode == "direct" then [{pr:.source_pr,merge:.source_merge}] else .aggregated_sources end))
-		| sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")
-	' <<<"$source_json") || return 1
+	VERSION_MANAGER_AGGREGATED_SOURCES=$(jq -cr ".aggregated_sources // [] | .[] | ${_VERSION_MANAGER_SOURCE_ENTRY_JQ}" \
+		<<<"$source_json") || return 1
+	VERSION_MANAGER_EXPECTED_SOURCES=$(jq -er "
+		(.expected_sources // (if .mode == \"direct\" then [{pr:.source_pr,merge:.source_merge}] else .aggregated_sources end))
+		| sort_by(.pr) | map(${_VERSION_MANAGER_SOURCE_ENTRY_JQ}) | join(\",\")
+	" <<<"$source_json") || return 1
 	export VERSION_MANAGER_SOURCE_PR VERSION_MANAGER_SOURCE_MERGE_SHA VERSION_MANAGER_AGGREGATED_SOURCES VERSION_MANAGER_EXPECTED_SOURCES
 	print_success "Release provenance verified: PR #${VERSION_MANAGER_SOURCE_PR}, merge ${VERSION_MANAGER_SOURCE_MERGE_SHA}"
+	return 0
+}
+
+verify_release_tag_source() {
+	local tag_name="$1"
+	local source_pr="$2"
+	local branch="${3:-main}"
+	local repo_slug="${4:-}"
+	local expected_sources="${5:-}"
+	local resolver="${AIDEVOPS_RELEASE_SOURCE_RESOLVER:-${SCRIPT_DIR}/release-provenance-helper.sh}"
+	local source_json=""
+	local -a resolver_args=(resolve-tag-authorization --tag "$tag_name" --source-pr "$source_pr" --branch "$branch")
+	if [[ -z "$repo_slug" ]]; then
+		repo_slug=$(_release_repo_slug 2>/dev/null || true)
+	fi
+	[[ -n "$repo_slug" && -x "$resolver" ]] || return 1
+	resolver_args+=(--repo "$repo_slug")
+	[[ -n "$expected_sources" ]] && resolver_args+=(--expected-sources "$expected_sources")
+	source_json=$(cd "$REPO_ROOT" && bash "$resolver" "${resolver_args[@]}") || return 1
+	VERSION_MANAGER_SOURCE_PR=$(jq -er '.source_pr' <<<"$source_json") || return 1
+	VERSION_MANAGER_SOURCE_MERGE_SHA=$(jq -er '.source_merge' <<<"$source_json") || return 1
+	VERSION_MANAGER_AGGREGATED_SOURCES=$(jq -cr ".aggregated_sources // [] | .[] | ${_VERSION_MANAGER_SOURCE_ENTRY_JQ}" \
+		<<<"$source_json") || return 1
+	VERSION_MANAGER_EXPECTED_SOURCES=$(jq -er ".expected_sources | sort_by(.pr) | map(${_VERSION_MANAGER_SOURCE_ENTRY_JQ}) | join(\",\")" \
+		<<<"$source_json") || return 1
+	export VERSION_MANAGER_SOURCE_PR VERSION_MANAGER_SOURCE_MERGE_SHA
+	export VERSION_MANAGER_AGGREGATED_SOURCES VERSION_MANAGER_EXPECTED_SOURCES
 	return 0
 }
 
@@ -620,6 +649,7 @@ push_changes() {
 		# Use --atomic to ensure commit and tag are pushed together (all-or-nothing).
 		# Capture stderr so permanent branch-policy rejection is classified after
 		# one attempt rather than retried as transient contention.
+		_version_manager_require_aggregate_fence || return 1
 		if push_output=$(git push --atomic origin HEAD:refs/heads/main --tags 2>&1); then
 			print_success "Pushed changes and tags to remote"
 			return 0
@@ -649,6 +679,16 @@ push_changes() {
 			return 1
 		fi
 		if [[ "$(git rev-parse origin/main 2>/dev/null)" != "$release_parent" ]]; then
+			if [[ -n "${AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN:-}" ]]; then
+				_version_manager_require_aggregate_fence || return 1
+				if _version_manager_queue_protected_main_release "$version"; then
+					case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+					remote-tag-present | tag-pushed) return 0 ;;
+					esac
+					return 8
+				fi
+				return 1
+			fi
 			print_error "origin/main advanced after release provenance was recorded"
 			print_info "Discard this release worktree and rerun from the latest merged source PR"
 			git tag -d "$tag_name" 2>/dev/null || true

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -38,6 +38,16 @@ _VERSION_MANAGER_PR_STATE_OPEN="open"
 _VERSION_MANAGER_PR_STATE_CLOSED="closed"
 _VERSION_MANAGER_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
 
+#aidevops:trust-boundary
+_version_manager_require_aggregate_fence() {
+	if declare -F _version_manager_verify_aggregate_lane_fence >/dev/null 2>&1; then
+		_version_manager_verify_aggregate_lane_fence
+		return $?
+	fi
+	[[ -z "${AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN:-}" ]]
+	return $?
+}
+
 _version_manager_push_requires_pr() {
 	local push_output="$1"
 
@@ -337,6 +347,7 @@ _version_manager_prepare_protected_release_head() {
 		return 1
 	fi
 
+	_version_manager_require_aggregate_fence || return 1
 	if push_output=$(git -C "$REPO_ROOT" push origin \
 		"${_VERSION_MANAGER_PROTECTED_RELEASE_HEAD}:refs/heads/${branch_name}" 2>&1); then
 		return 0
@@ -409,9 +420,11 @@ _version_manager_queue_exact_merge() {
 		"$tag_object" "$release_commit" || return 1
 	is_draft=$(jq -r '.draft // false' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	if [[ "$is_draft" == "true" ]]; then
+		_version_manager_require_aggregate_fence || return 1
 		gh pr ready "$pr_number" --repo "$repo" >/dev/null 2>&1 || return 1 # aidevops-allow: raw-gh-wrapper
 	fi
 
+	_version_manager_require_aggregate_fence || return 1
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo" --auto --merge \
 		--match-head-commit "$expected_head" 2>&1) || merge_rc=$? # aidevops-allow: raw-gh-wrapper
 	if [[ "$merge_rc" -eq 0 ]]; then
@@ -436,6 +449,7 @@ _version_manager_queue_exact_merge() {
 
 	# Prevent generic squash automation from destroying ancestry when native
 	# merge queueing is unavailable. Reconciliation retries the exact merge.
+	_version_manager_require_aggregate_fence || return 1
 	if gh pr ready "$pr_number" --repo "$repo" --undo >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
 		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="queued-draft"
 		print_warning "Protected release PR #${pr_number} is preserved as a draft because exact merge queueing was unavailable"
@@ -478,6 +492,7 @@ _version_manager_create_or_reuse_protected_pr() {
 			fi
 			create_args+=(--label "$origin_label" --label "status:in-review" --label "release")
 		fi
+		_version_manager_require_aggregate_fence || return 1
 		create_output=$(gh pr create "${create_args[@]}" 2>&1) || create_rc=$? # aidevops-allow: raw-gh-wrapper
 		rm -f "$body_file"
 		_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
@@ -529,6 +544,7 @@ _version_manager_publish_reachable_tag() {
 		print_info "Create a newly reviewed exact-tip aggregation release; no tag or package channel was mutated"
 		return 1
 	fi
+	_version_manager_require_aggregate_fence || return 1
 	if ! push_output=$(git -C "$REPO_ROOT" push origin \
 		"refs/tags/${tag_name}:refs/tags/${tag_name}" 2>&1); then
 		print_error "Failed to publish preserved ${tag_name} after main became reachable"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -23,6 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=./task-identity-lib.sh
 source "${SCRIPT_DIR}/task-identity-lib.sh"
+# shellcheck source=./release-lane-helper.sh
+source "${SCRIPT_DIR}/release-lane-helper.sh"
 
 # Repository root directory
 # First try git (works when called from any location within a repo)
@@ -35,6 +37,52 @@ fi
 VERSION_FILE="$REPO_ROOT/VERSION"
 _VERSION_MANAGER_ACTION_RELEASE="release"
 _VERSION_MANAGER_ACTION_RECOVER_AGGREGATE="recover-aggregate"
+_VERSION_MANAGER_AGGREGATE_TAG_MODE=""
+_VERSION_MANAGER_AGGREGATE_TAG_MODE_PROVISIONAL="provisional"
+_VERSION_MANAGER_AGGREGATE_TAG_MODE_RECOVERED="recovered"
+
+_version_manager_load_aggregate_lane_context() {
+	local repository="${AIDEVOPS_RELEASE_LANE_REPOSITORY:-}"
+	local source_pr="${AIDEVOPS_RELEASE_LANE_SOURCE_PR:-}"
+	local tag_name="${AIDEVOPS_RELEASE_LANE_TAG:-}"
+	local expected_sources="${AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES:-}"
+	local operation_token="${AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN:-}"
+	[[ -n "$repository" && "$source_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && -n "$expected_sources" ]] || return 1
+	[[ -n "$operation_token" ]] || return 1
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	return 0
+}
+
+_version_manager_require_aggregate_lane_context() {
+	local tag_name="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	_version_manager_load_aggregate_lane_context || return 1
+	[[ "${AIDEVOPS_RELEASE_LANE_TAG:-}" == "$tag_name" ]] || return 1
+	[[ "${AIDEVOPS_RELEASE_LANE_SOURCE_PR:-}" == "$source_pr" ]] || return 1
+	[[ "${AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES:-}" == "$expected_sources" ]] || return 1
+	return 0
+}
+
+#aidevops:trust-boundary
+_version_manager_claim_aggregate_lane() {
+	_version_manager_load_aggregate_lane_context || return 1
+	release_lane_claim_aggregate_publication \
+		"${AIDEVOPS_RELEASE_LANE_REPOSITORY:-}" "${AIDEVOPS_RELEASE_LANE_SOURCE_PR:-}" \
+		"${AIDEVOPS_RELEASE_LANE_TAG:-}" "${AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES:-}"
+	return $?
+}
+
+#aidevops:trust-boundary
+_version_manager_verify_aggregate_lane_fence() {
+	[[ -n "${AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN:-}" ]] || return 0
+	_version_manager_load_aggregate_lane_context || return 1
+	release_lane_verify_aggregate_publication \
+		"${AIDEVOPS_RELEASE_LANE_REPOSITORY:-}" "${AIDEVOPS_RELEASE_LANE_SOURCE_PR:-}" \
+		"${AIDEVOPS_RELEASE_LANE_TAG:-}" "${AIDEVOPS_RELEASE_LANE_EXPECTED_SOURCES:-}"
+	return $?
+}
 
 _version_manager_marker_is_truthy() {
 	local marker=""
@@ -657,17 +705,40 @@ _validate_aggregate_recovery_context() {
 	local old_tag_object="$4"
 	local version=""
 	local current_object=""
+	local source_merge=""
+	local tag_parent=""
+	local tag_tree=""
+	local parent_tree=""
+	_VERSION_MANAGER_AGGREGATE_TAG_MODE=""
 	assert_release_linked_worktree || return 1
 	verify_remote_sync main || return 1
 	check_working_tree_clean || return 1
 	version=$(get_current_version) || return 1
 	[[ "$tag_name" == "v${version}" ]] || return 1
 	current_object=$(git rev-parse "refs/tags/${tag_name}" 2>/dev/null) || return 1
-	[[ "$current_object" == "$old_tag_object" ]] || return 1
-	verify_release_source_pr "$source_pr" main "" "$expected_sources" || return 1
-	[[ -n "${VERSION_MANAGER_AGGREGATED_SOURCES:-}" ]] || return 1
-	[[ "${VERSION_MANAGER_SOURCE_MERGE_SHA:-}" == "$(git rev-parse HEAD 2>/dev/null)" ]] || return 1
+	if [[ "$current_object" == "$old_tag_object" ]]; then
+		verify_release_source_pr "$source_pr" main "" "$expected_sources" || return 1
+		[[ -n "${VERSION_MANAGER_AGGREGATED_SOURCES:-}" ]] || return 1
+		source_merge="${VERSION_MANAGER_SOURCE_MERGE_SHA:-}"
+		[[ "$source_merge" == "$(git rev-parse HEAD 2>/dev/null)" ]] || return 1
+		validate_version_consistency "$version" || return 1
+		_VERSION_MANAGER_AGGREGATE_TAG_MODE="$_VERSION_MANAGER_AGGREGATE_TAG_MODE_PROVISIONAL"
+		return 0
+	fi
+	_verify_bump_commit_at_ref "$tag_name" "$version" || return 1
+	tag_parent=$(git rev-parse "${tag_name}^{commit}^" 2>/dev/null) || return 1
+	git checkout --detach --quiet "${tag_name}^{commit}" || return 1
 	validate_version_consistency "$version" || return 1
+	_verify_recovered_aggregate_tag "$tag_name" || return 1
+	verify_release_tag_source "$tag_name" "$source_pr" main "" "$expected_sources" || return 1
+	[[ -n "${VERSION_MANAGER_AGGREGATED_SOURCES:-}" ]] || return 1
+	source_merge="${VERSION_MANAGER_SOURCE_MERGE_SHA:-}"
+	_version_manager_tag_absent_from_all_remotes "refs/tags/${tag_name}" || return 1
+	[[ "$tag_parent" == "$source_merge" ]] || return 1
+	tag_tree=$(git rev-parse "${tag_name}^{tree}" 2>/dev/null) || return 1
+	parent_tree=$(git rev-parse "${tag_parent}^{tree}" 2>/dev/null) || return 1
+	[[ "$tag_tree" == "$parent_tree" ]] || return 1
+	_VERSION_MANAGER_AGGREGATE_TAG_MODE="$_VERSION_MANAGER_AGGREGATE_TAG_MODE_RECOVERED"
 	return 0
 }
 
@@ -677,6 +748,7 @@ _verify_recovered_aggregate_tag() {
 	local resolver="${AIDEVOPS_RELEASE_SOURCE_RESOLVER:-${SCRIPT_DIR}/release-provenance-helper.sh}"
 	[[ -n "$repo_slug" ]] || repo_slug=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || return 1
 	[[ -x "$resolver" ]] || return 1
+	git -C "$REPO_ROOT" verify-tag "$tag_name" >/dev/null 2>&1 || return 1
 	(cd "$REPO_ROOT" && bash "$resolver" verify-local-source --tag "$tag_name" --repo "$repo_slug" >/dev/null)
 	return $?
 }
@@ -687,17 +759,40 @@ _execute_aggregate_recovery() {
 	local version="${tag_name#v}"
 	local source_merge="${VERSION_MANAGER_SOURCE_MERGE_SHA:-}"
 	local push_rc=0
-	_create_aggregate_recovery_bump_commit "$version" "$source_merge" || return 1
-	replace_unpublished_aggregate_tag "$version" "$old_tag_object" || return 1
-	if ! _verify_recovered_aggregate_tag "$tag_name"; then
-		restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
-		return 1
-	fi
+	local replacement_created=false
+	_version_manager_claim_aggregate_lane || return 1
+	case "$_VERSION_MANAGER_AGGREGATE_TAG_MODE" in
+	"$_VERSION_MANAGER_AGGREGATE_TAG_MODE_PROVISIONAL")
+		_create_aggregate_recovery_bump_commit "$version" "$source_merge" || return 1
+		_version_manager_verify_aggregate_lane_fence || return 1
+		replace_unpublished_aggregate_tag "$version" "$old_tag_object" || return 1
+		replacement_created=true
+		if ! _verify_recovered_aggregate_tag "$tag_name"; then
+			restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+			return 1
+		fi
+		if ! _version_manager_verify_aggregate_lane_fence; then
+			restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+			return 1
+		fi
+		;;
+	"$_VERSION_MANAGER_AGGREGATE_TAG_MODE_RECOVERED")
+		_version_manager_verify_aggregate_lane_fence || return 1
+		git checkout --detach --quiet "${tag_name}^{commit}" || return 1
+		_verify_bump_commit_at_ref HEAD "$version" || return 1
+		[[ "$(git rev-parse HEAD^ 2>/dev/null)" == "$source_merge" ]] || return 1
+		check_working_tree_clean || return 1
+		_version_manager_verify_aggregate_lane_fence || return 1
+		;;
+	*) return 1 ;;
+	esac
 	push_changes "$version" || push_rc=$?
 	case "$push_rc" in
 	0 | 8) return "$push_rc" ;;
 	esac
-	restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+	if [[ "$replacement_created" == "true" ]]; then
+		restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+	fi
 	return 1
 }
 
@@ -707,6 +802,7 @@ _main_recover_aggregate() {
 	local expected_sources=""
 	local old_tag_object=""
 	_parse_aggregate_recovery_args "$@" || return 1
+	_version_manager_require_aggregate_lane_context "$tag_name" "$source_pr" "$expected_sources" || return 1
 	_validate_aggregate_recovery_context "$tag_name" "$source_pr" "$expected_sources" "$old_tag_object" || return 1
 	_execute_aggregate_recovery "$tag_name" "$old_tag_object"
 	return $?

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -101,11 +101,24 @@ aidevops release recover-aggregate <original-source-pr> --tag <vX.Y.Z> \
 The command requires the reviewed aggregate at the exact `origin/main` tip,
 confirms the tag is absent from the remote, GitHub Releases, npm, and Homebrew,
 and verifies the existing authorization is an exact subset of the aggregate.
-It then rotates the lane token, expands authorization, creates a same-version
-empty bump commit over the aggregate, and replaces only the local unpublished
-tag. A failure before durable publication restores the exact previous tag
-object, authorization manifest, and lane state. Remote tags are never rewritten.
-See `reference/release-aggregation-recovery.md` for the state and rollback
+It first rotates the lane token into a fenced refresh phase, expands
+authorization, and completes that state transition. Version-manager then claims
+an `aggregate-publication-committing` phase before creating a same-version empty
+bump commit over the aggregate and replacing only the local unpublished tag.
+The exact lane token is rechecked immediately before every publication push and
+protected-main PR mutation. The committing phase remains exclusive while its
+protected PR is open; rerun the same recovery command to resume that queue from
+the persisted aggregate even if `main` advanced. It enters `remote-publication`
+only after the exact release commit reaches `main`. Once authorization expands,
+failures retain the fenced transaction for retry instead of attempting separate
+lane and authorization rollback writes. If `main` advances before the local tag
+changes, a refreshed exact-tip aggregate may extend the fenced source set through
+an idempotent `aggregation-recovery-refresh` phase that preserves the original
+snapshots and rotates the lane token before authorization changes. Interrupted
+refreshes resume from that fenced phase. Reserved-lane authorization migration
+likewise rotates through `reserved-authorization-refresh` before widening the
+persisted manifest. Remote tags are never rewritten. See
+`reference/release-aggregation-recovery.md` for the state and interruption
 contract.
 
 Protected-main reconciliation rechecks the exact tree immediately before pushing the preserved tag. A descendant with a different tree is `aggregation-required` and stops before tag or package mutation, even when it contains the signed release commit. During exact-tag deployment, generic `setup.sh --non-interactive` is blocked by the release lane; only setup carrying the matching source PR and tag may enter the existing setup mutex. The acquisition order is release lane, then setup lock.


### PR DESCRIPTION
## Summary

- Make no-release aggregate recovery resumable across authorization, lane, tag, and protected-main interruptions.
- Fence authorization expansion with a token-rotating lane transaction and retain ambiguous post-mutation state for exact retry instead of attempting non-atomic rollback.
- Resume an immutable replacement tag after `main` advances, verify its exact provenance, and recreate its detached tag worktree before repairing the protected-main queue.

## Files Changed

- Recovery and lane state machines: `.agents/scripts/full-loop-release-aggregate-recovery.sh`, `.agents/scripts/full-loop-release-helper.sh`, `.agents/scripts/release-lane-helper.sh`
- Immutable source and protected-main publication: `.agents/scripts/release-provenance-helper.sh`, `.agents/scripts/version-manager.sh`, `.agents/scripts/version-manager-git.sh`, `.agents/scripts/version-manager-protected-main.sh`
- Focused regression suites and release recovery documentation

## Runtime Testing

- **Risk level:** Critical
- `./.agents/scripts/linters-local.sh --changed`
- Aggregate recovery, release lane, provenance, protected-main fallback, linked-release, release reconciliation, cleanup receipt, and full-loop helper suites
- Final read-only P0/P1 review: no remaining findings

Resolves #30213

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.259 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 4h and 1,727,070 tokens on this with the user in an interactive session. Overall, 3h 22m since this issue was created.
