### PR TITLE
GH#30218: fix canonical auth and signed tag recovery

### DIFF
--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -87,14 +87,20 @@ def _config_is_allowed_global_auth_write(args: list[str]) -> bool:
     credential_key = key == "credential.helper" or (
         key.startswith("credential.") and key.endswith(".helper")
     )
-    return (
-        bool(args)
-        and any(arg in {"--global", "--user"} for arg in args)
-        and not any(arg in {"--local", "--worktree", "--file", "-f"} for arg in args)
-        and not any(arg.startswith(("--file=", "--blob=")) for arg in args)
-        and not any(arg in destructive_writes for arg in args)
-        and bool(key)
-        and credential_key
+    user_scoped = any(arg in {"--global", "--user"} for arg in args)
+    repo_scoped = any(arg in {"--local", "--worktree", "--file", "-f"} for arg in args)
+    alternate_source = any(arg.startswith(("--file=", "--blob=")) for arg in args)
+    destructive = any(arg in destructive_writes for arg in args)
+    return all(
+        (
+            args,
+            user_scoped,
+            not repo_scoped,
+            not alternate_source,
+            not destructive,
+            key,
+            credential_key,
+        )
     )
 
 

--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -65,10 +65,52 @@ def _config_is_read_only(args: list[str]) -> bool:
         "--remove-section",
         "--replace-all",
     }
-    return (
+    return _config_is_allowed_global_auth_write(args) or (
         bool(args)
         and any(arg in read_flags for arg in args)
         and not any(arg in write_flags for arg in args)
+    )
+
+
+def _config_is_allowed_global_auth_write(args: list[str]) -> bool:
+    """Allow GitHub CLI auth setup to update user-scoped credential config.
+
+    The canonical guard protects repository worktrees. A `gh auth refresh` or
+    `gh auth setup-git` may run while the shell happens to be inside a canonical
+    checkout, but its intended mutation is `~/.gitconfig`, not the repository.
+    Keep this narrow: only explicit user-scope writes to credential helper keys
+    are allowed; repo-local config writes remain blocked.
+    """
+    if not args or not any(arg in {"--global", "--user"} for arg in args):
+        return False
+    if any(arg in {"--local", "--worktree", "--file", "-f"} for arg in args):
+        return False
+    if any(arg.startswith(('--file=', '--blob=')) for arg in args):
+        return False
+    destructive_writes = {"--unset", "--unset-all", "--remove-section", "--rename-section"}
+    if any(arg in destructive_writes for arg in args):
+        return False
+
+    value_options = {"--type", "--fixed-value"}
+    skip_next = False
+    keys: list[str] = []
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in value_options:
+            skip_next = True
+            continue
+        if arg.startswith("--") or arg in {"--global", "--user", "--add", "--replace-all"}:
+            continue
+        if arg.startswith("-"):
+            return False
+        keys.append(arg)
+    if not keys:
+        return False
+    key = keys[0]
+    return key == "credential.helper" or (
+        key.startswith("credential.") and key.endswith(".helper")
     )
 
 

--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -81,37 +81,42 @@ def _config_is_allowed_global_auth_write(args: list[str]) -> bool:
     Keep this narrow: only explicit user-scope writes to credential helper keys
     are allowed; repo-local config writes remain blocked.
     """
-    if not args or not any(arg in {"--global", "--user"} for arg in args):
-        return False
-    if any(arg in {"--local", "--worktree", "--file", "-f"} for arg in args):
-        return False
-    if any(arg.startswith(('--file=', '--blob=')) for arg in args):
-        return False
     destructive_writes = {"--unset", "--unset-all", "--remove-section", "--rename-section"}
-    if any(arg in destructive_writes for arg in args):
-        return False
+    keys = _config_write_keys(args)
+    key = keys[0]
+    credential_key = key == "credential.helper" or (
+        key.startswith("credential.") and key.endswith(".helper")
+    )
+    return (
+        bool(args)
+        and any(arg in {"--global", "--user"} for arg in args)
+        and not any(arg in {"--local", "--worktree", "--file", "-f"} for arg in args)
+        and not any(arg.startswith(("--file=", "--blob=")) for arg in args)
+        and not any(arg in destructive_writes for arg in args)
+        and bool(key)
+        and credential_key
+    )
 
+
+def _config_write_keys(args: list[str]) -> list[str]:
     value_options = {"--type", "--fixed-value"}
-    skip_next = False
+    ignored_flags = {"--global", "--user", "--add", "--replace-all"}
     keys: list[str] = []
+    skip_next = False
+    invalid = False
     for arg in args:
         if skip_next:
             skip_next = False
-            continue
-        if arg in value_options:
+        elif arg in value_options:
             skip_next = True
+        elif arg.startswith("--") or arg in ignored_flags:
             continue
-        if arg.startswith("--") or arg in {"--global", "--user", "--add", "--replace-all"}:
-            continue
-        if arg.startswith("-"):
-            return False
-        keys.append(arg)
-    if not keys:
-        return False
-    key = keys[0]
-    return key == "credential.helper" or (
-        key.startswith("credential.") and key.endswith(".helper")
-    )
+        elif arg.startswith("-"):
+            invalid = True
+            break
+        else:
+            keys.append(arg)
+    return keys if not invalid and keys else [""]
 
 
 def _clean_is_read_only(args: list[str]) -> bool:

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -105,6 +105,7 @@ _full_loop_release_candidate_tags_for_pr() {
 	local direct_marker=",${requested_pr},"
 	local aggregate_marker=",${requested_pr}@"
 	local legacy_source_marker=""
+	local emitted=0
 
 	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
 	ref_format+='%(trailers:key=Aidevops-Source-PR,valueonly,separator=%x2C)%1f'
@@ -121,13 +122,23 @@ _full_loop_release_candidate_tags_for_pr() {
 		if [[ ",${source_prs}," == *"$direct_marker"* ]] ||
 			[[ ",${aggregated_sources}," == *"$aggregate_marker"* ]]; then
 			printf '%s\n' "$candidate_tag"
+			emitted=1
 			continue
 		fi
 		legacy_source_marker=",${source_merge},"
 		if [[ -n "$source_merge" && "$legacy_source_lookup" == *"$legacy_source_marker"* ]]; then
 			printf '%s\n' "$candidate_tag"
+			emitted=1
 		fi
 	done <<<"$trailer_index"
+	if [[ "$emitted" -eq 0 ]]; then
+		# Some signed annotated tags do not expose parsed custom trailers through
+		# `for-each-ref %(trailers:...)` even though their raw tag body is valid and
+		# `_full_loop_release_source_json_from_tag` can verify it. Fall back to a full
+		# newest-first semver tag scan so recovery remains correct; the caller still
+		# performs strict body/provenance checks before accepting any tag.
+		git -C "$REPO_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname || return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -149,6 +149,14 @@ assert_blocked "blocks canonical symbolic-ref unknown options" "git symbolic-ref
 assert_blocked "blocks canonical symbolic-ref without a ref" "git symbolic-ref --short"
 assert_blocked "blocks canonical symbolic-ref option terminator" "git symbolic-ref -- refs/remotes/origin/HEAD"
 assert_blocked "blocks canonical symbolic-ref second ref after option terminator" "git symbolic-ref -- HEAD refs/heads/safety/example"
+assert_allowed "allows gh auth global credential helper config from canonical cwd" "$REPO" \
+	"git config --global credential.https://github.com.helper '!gh auth git-credential'"
+assert_allowed "allows gh auth global replace-all credential helper config" "$REPO" \
+	"git config --global --replace-all credential.helper '!gh auth git-credential'"
+assert_blocked "blocks canonical local credential helper config" \
+	"git config credential.helper '!gh auth git-credential'"
+assert_blocked "blocks canonical global non-credential config write" \
+	"git config --global include.path '$TEST_ROOT/unsafe.gitconfig'"
 assert_blocked "blocks mutation in a repository with an aidevops project marker" \
 	"git -C '$MARKED_REPO' add managed.txt"
 assert_blocked "blocks git-dir-only mutation targeting a managed canonical repository" \

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -471,6 +471,71 @@ if [[ "$candidate_tags" != $'v1.9.0\nv1.7.0' ]]; then
 fi
 printf 'PASS one-pass trailer index preserves exact newest-first candidates\n'
 
+fallback_candidate_tags_file="${TEST_ROOT}/candidate-tags-fallback.txt"
+(
+	git() {
+		local args="$*"
+		case "$args" in
+		*" for-each-ref "*)
+			printf '%b\n' \
+				'v2.0.0\x1f\x1f\x1f' \
+				'v1.9.0\x1f\x1f\x1f'
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*" tag --list "*)
+			printf '%s\n' v2.0.0 v1.9.0
+			;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_candidate_tags_for_pr 89
+) >"$fallback_candidate_tags_file"
+fallback_candidate_tags=$(<"$fallback_candidate_tags_file")
+if [[ "$fallback_candidate_tags" != $'v2.0.0\nv1.9.0' ]]; then
+	printf 'FAIL empty trailer index did not fall back to full tag scan\n'
+	exit 1
+fi
+printf 'PASS empty trailer index falls back to full tag scan\n'
+
+fallback_find_tag_file="${TEST_ROOT}/find-tag-fallback.txt"
+(
+	git() {
+		local args="$*"
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*" for-each-ref "*)
+			printf '%b\n' 'v2.0.0\x1f\x1f\x1f'
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*" tag --list "*) printf '%s\n' v2.0.0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v2.0.0" ]] || return 1
+		printf '%s\n' 'Aidevops-Source-PR: 89'
+		return 0
+	}
+	_full_loop_release_source_json_from_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v2.0.0" ]] || return 1
+		printf '%s\n' '{"source_pr":89,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}'
+		return 0
+	}
+	_full_loop_release_verify_candidate_tag_provenance() { return 0; }
+	_full_loop_release_find_tag_for_pr test/repo 89 || exit 1
+	printf '%s\n' "$_FULL_LOOP_RELEASE_FOUND_TAG"
+) >"$fallback_find_tag_file"
+fallback_find_tag=$(<"$fallback_find_tag_file")
+if [[ "$fallback_find_tag" != "v2.0.0" ]]; then
+	printf 'FAIL full tag fallback did not recover a body-parseable signed tag\n'
+	exit 1
+fi
+printf 'PASS full tag fallback recovers a body-parseable signed tag\n'
+
 if (
 	git() {
 		local args="$*"


### PR DESCRIPTION
## Summary

- Resolves #30218
- allow narrowly scoped `git config --global/--user credential*.helper ...` writes from canonical checkouts so `gh auth refresh` / `gh auth setup-git` can update user Git credential config without mutating the repo
- keep repo-local/worktree/file config writes blocked by the canonical Git guard
- make release reconciliation fall back from the fast trailer index to a full newest-first semver tag scan when signed annotated tags have raw body trailers that `for-each-ref %(trailers:...)` does not expose

## Root cause

`canonical_git_readonly.py` treated every `git config` write from a canonical checkout as repository mutation. That broke safe GitHub CLI auth refreshes because `gh` writes user-scoped credential helper config while the shell may be inside the canonical checkout.

`full-loop-release-reconcile.sh` relied on the optimized `for-each-ref` trailer index for candidate release tags. Signed annotated tags can still have parseable raw tag bodies while exposing no custom trailers through that index, so valid signed provenance was skipped.

## Verification

- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-canonical-git-command-guard.sh`
- `shellcheck .agents/scripts/tests/test-canonical-git-command-guard.sh .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `python3 -m py_compile .agents/scripts/canonical_git_readonly.py`
- `.agents/scripts/linters-local.sh --changed`
- `bun install && bun run typecheck`

## Files

- `.agents/scripts/canonical_git_readonly.py`: narrow safe credential-helper config allowance
- `.agents/scripts/full-loop-release-reconcile.sh`: fallback candidate tag scan when fast trailer parsing emits no candidates
- `.agents/scripts/tests/test-canonical-git-command-guard.sh`: guard regressions for allowed GitHub auth config and blocked unsafe config writes
- `.agents/scripts/tests/test-full-loop-release-reconcile.sh`: fallback release tag discovery regressions

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.260 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.5 spent 11h 34m and 81,963 tokens on this with the user in an interactive session.