### PR TITLE
t18238: feat: add social provider health

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -26,6 +26,59 @@ archive for the remaining category. Until a provider child records fresh
 evidence, every mark other than **Live** is a disposition for investigation, not
 a claim that the route is enabled.
 
+## Runtime provider readiness
+
+The planning matrix above documents implemented and candidate routes; it is not
+runtime evidence. Use the content-free provider health surface before selecting
+or executing a channel:
+
+```bash
+knowledge-social-helper.sh provider-health-status [--provider PROVIDER]
+knowledge-social-helper.sh provider-health-report [--provider PROVIDER]
+knowledge-social-helper.sh provider-health-collect
+knowledge-social-helper.sh provider-health-reconcile \
+  [--decisions-file PRIVATE_JSON] [--limit 1-100] [--per-provider-limit 1-20]
+```
+
+The JSON contract is
+`.agents/schemas/social-provider-health.schema.json`. It reports every provider
+in the read registry or outbound action catalogue plus each provider present in
+the selected corpus. Each exact local account alias and each enabled read stream
+or supported write action has separate canonical readiness dimensions. Alias
+visibility follows the selected corpus grant; aliases are local selectors, not
+remote account IDs. A read action is `usable` only after fresh authenticated,
+authorized, reachable stream evidence. A write action additionally requires an
+unexpired exact-intent approval for a due operation and no unresolved ambiguous
+receipt for that action. Both require no active selected-account cooldown.
+Documentation, environment-variable presence, or a previous success cannot by
+itself make an action usable.
+
+Quota values remain `null` when no provider evidence establishes them. A
+persisted future retry/reset boundary activates cooldown and transactionally
+fences both new outbound claims and the provider-start boundary for that exact
+connection. Structured outbound rate-limit evidence without a valid reset uses
+one bounded local safety cooldown without inferring quota. A cooldown discovered
+after claim records a retry-safe pre-provider receipt and returns the operation
+to `approved` without contacting the provider. Repeated reset responses pause
+work and never justify bypass, rapid polling, or notification storms. One
+blocked, stale, or unknown enabled action makes the aggregate `partial` while
+preserving healthy sibling evidence.
+
+Health collection reads no campaign body, subject, media path, credential,
+remote account ID, or provider response body. Snapshots are atomically replaced
+as owner-only files. Provider results arriving after claim expiry remain
+`unknown` with their content-free evidence retained for reconciliation.
+Reconciliation first fences expired claims as `unknown`; those transitions
+consume the global pass budget. It then selects exact explicit owner decisions,
+and only actual resolutions consume the remaining global and
+per-provider budgets. Cooldown or undecided receipts cannot starve eligible
+sibling accounts; a no-decision inspection is bounded by the same remaining
+global and per-provider limits. Original unknown attempt evidence and appended
+reconciliation receipts are immutable. The routine never creates a publish
+intent, places an ambiguous operation back in the queue, or contacts a provider.
+A successful decision requires the stable opaque provider receipt ID;
+`not-sent` forbids one.
+
 ## Requested providers
 
 | Provider | Authored content | Interactions and curation | Mentions or messages | Relationships and subscriptions | Lists or custom feeds | Current disposition |

--- a/.agents/configs/capability-registry.json
+++ b/.agents/configs/capability-registry.json
@@ -73,37 +73,48 @@
       "probes": {"deployed": {"path": "scripts/campaign-research-helper.py"}, "tool_visible": {"tool": "python3"}}
     },
     {
+      "name": "social-provider-readiness",
+      "aliases": ["social-health", "provider-health", "social-readiness"],
+      "owner": "Content",
+      "description": "Content-free provider, account, action, queue, cooldown, freshness, and receipt readiness",
+      "runtimes": ["opencode", "claude-code"],
+      "entry_points": ["aidevops/knowledge-plane/06-social-provider-capabilities.md", "scripts/social-provider-health.py"],
+      "fallback": "gated-no-mutation",
+      "required": ["deployed", "runtime_compatible", "tool_visible"],
+      "probes": {"deployed": {"path": "scripts/social-provider-health.py"}, "configured": {"live": "requires a selected social corpus connection"}, "authenticated": {"live": "requires fresh identity-bound provider evidence"}, "authorized": {"live": "requires an unexpired exact-intent approval"}, "reachable": {"live": "requires fresh provider evidence without an active cooldown"}, "tool_visible": {"tool": "python3"}, "usable": {"live": "requires provider-health action status usable"}}
+    },
+    {
       "name": "linkedin-approved-posting",
       "aliases": ["linkedin-publish", "linkedin-outbound"],
-      "owner": "Social",
+      "owner": "Content",
       "description": "Approval-bound official LinkedIn member text posts",
       "runtimes": ["opencode", "claude-code"],
       "entry_points": ["content/social-linkedin.md", "scripts/_knowledge_social_linkedin_outbound_provider.py"],
       "fallback": "gated-no-mutation",
-      "required": ["deployed", "configured", "authenticated", "authorized", "reachable"],
-      "probes": {"deployed": {"path": "scripts/_knowledge_social_linkedin_outbound_provider.py"}, "configured": {"env_pattern": "LINKEDIN_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires Posts product eligibility and exact member binding"}, "reachable": {"live": "requires official LinkedIn API request"}}
+      "required": ["deployed", "configured", "authenticated", "authorized", "reachable", "usable"],
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_linkedin_outbound_provider.py"}, "configured": {"env_pattern": "LINKEDIN_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires Posts product eligibility and exact member binding"}, "reachable": {"live": "requires official LinkedIn API request"}, "usable": {"live": "requires provider-health LinkedIn post status usable"}}
     },
     {
       "name": "youtube-approved-upload",
       "aliases": ["youtube-publish", "youtube-outbound"],
-      "owner": "Social",
+      "owner": "Content",
       "description": "Approval-bound official YouTube private video uploads",
       "runtimes": ["opencode", "claude-code"],
       "entry_points": ["content/social-youtube.md", "scripts/_knowledge_social_youtube_outbound_provider.py"],
       "fallback": "gated-no-mutation",
-      "required": ["deployed", "configured", "authenticated", "authorized", "reachable"],
-      "probes": {"deployed": {"path": "scripts/_knowledge_social_youtube_outbound_provider.py"}, "configured": {"env_pattern": "YOUTUBE_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires youtube.upload scope and exact channel binding"}, "reachable": {"live": "requires official YouTube Data API request"}}
+      "required": ["deployed", "configured", "authenticated", "authorized", "reachable", "usable"],
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_youtube_outbound_provider.py"}, "configured": {"env_pattern": "YOUTUBE_<PROFILE>_ACCESS_TOKEN"}, "authenticated": {"live": "requires selected token"}, "authorized": {"live": "requires youtube.upload scope and exact channel binding"}, "reachable": {"live": "requires official YouTube Data API request"}, "usable": {"live": "requires provider-health YouTube post status usable"}}
     },
     {
       "name": "approval-bound-social-publishing",
       "aliases": ["meta-publishing", "tiktok-publishing", "social-outbound"],
-      "owner": "Social",
+      "owner": "Content",
       "description": "Approved Meta and TikTok publishing through identity-bound official transports",
       "runtimes": ["opencode", "claude-code"],
-      "entry_points": ["content/social-meta.md", "content/social-tiktok.md", "scripts/knowledge_social_operations.py"],
+      "entry_points": ["content/social-meta.md", "content/social-tiktok.md", "scripts/knowledge_social_operations.py", "scripts/social-provider-health.py"],
       "fallback": "approval-required-manual-handoff",
       "required": ["deployed", "configured", "authenticated", "authorized", "reachable", "usable"],
-      "probes": {"deployed": {"path": "scripts/_knowledge_social_meta_outbound_provider.py"}, "configured": {"live": "requires selected official provider transport"}, "authenticated": {"live": "requires selected product token"}, "authorized": {"live": "requires exact identity and publish permission check"}, "reachable": {"live": "requires official provider health request"}, "usable": {"live": "requires approved intent and preflight"}}
+      "probes": {"deployed": {"path": "scripts/_knowledge_social_meta_outbound_provider.py"}, "configured": {"live": "requires selected official provider transport"}, "authenticated": {"live": "requires selected product token"}, "authorized": {"live": "requires exact identity and publish permission check"}, "reachable": {"live": "requires official provider health request"}, "usable": {"live": "requires provider-health action status usable"}}
     },
     {
       "name": "vault-operations",

--- a/.agents/configs/rate-limits.json.txt
+++ b/.agents/configs/rate-limits.json.txt
@@ -2,6 +2,7 @@
   "_comment": "Rate limit configuration per provider (t1330). Copy to ~/.config/aidevops/rate-limits.json and adjust for your plan.",
   "_note": "Values are per-minute limits. Set to 0 to disable tracking for that metric.",
   "_threshold": "warn_pct controls when a provider is flagged as throttle-risk (default 80%).",
+  "_cooldown_semantics": "Persisted provider rate-limit and retry/reset evidence is authoritative. A structured rate limit without a valid reset uses one bounded local safety cooldown while quotas remain unknown; repeated responses pause work instead of triggering retries or notification storms.",
   "warn_pct": 80,
   "window_minutes": 1,
   "providers": {
@@ -75,6 +76,54 @@
       "input_tokens_per_min": 0,
       "output_tokens_per_min": 0,
       "billing_type": "token"
+    },
+    "xapi": {
+      "_comment": "X API limits vary by endpoint, app, account, and product tier; retain provider reset evidence and do not infer a universal request budget.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-window"
+    },
+    "reddit": {
+      "_comment": "Reddit API limits are runtime and identity specific; retain provider retry/reset evidence and do not infer a universal request budget.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-window"
+    },
+    "meta_facebook": {
+      "_comment": "Facebook Graph limits depend on the selected app, product, Page, and account; only persisted provider reset evidence activates cooldown.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-gated"
+    },
+    "meta_instagram": {
+      "_comment": "Instagram Graph limits depend on the selected app, product, and Professional account; only persisted provider reset evidence activates cooldown.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-gated"
+    },
+    "meta_threads": {
+      "_comment": "Threads limits depend on the selected app, product, and account; only persisted provider reset evidence activates cooldown.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-gated"
+    },
+    "tiktok": {
+      "_comment": "TikTok publishing limits and review gates depend on the selected app and account; only persisted provider reset evidence activates cooldown.",
+      "requests_per_min": 0,
+      "tokens_per_min": 0,
+      "input_tokens_per_min": 0,
+      "output_tokens_per_min": 0,
+      "billing_type": "provider-gated"
     },
     "linkedin": {
       "_comment": "LinkedIn API capacity is product and application gated; do not infer a quota from read access.",

--- a/.agents/reference/capability-registry.md
+++ b/.agents/reference/capability-registry.md
@@ -2,7 +2,7 @@
 
 # Capability Registry
 
-Catalogued capabilities: **6**
+Catalogued capabilities: **11**
 
 | Capability | Owner | Runtimes | Mandatory readiness | Fallback |
 |---|---|---|---|---|
@@ -11,4 +11,9 @@ Catalogued capabilities: **6**
 | `browser-automation` | Build+ | opencode, claude-code | deployed, enabled, runtime_compatible, tool_visible, reachable | `static-web-fetch` |
 | `cloudflare-management` | Aidevops | opencode | enabled, authenticated, authorized, reachable, runtime_compatible, tool_visible | `cloudflare-cli-guidance` |
 | `seo-data` | SEO | opencode, claude-code | configured, authenticated, authorized, reachable, tool_visible | `public-search-research` |
+| `campaign-research-dossiers` | Research | opencode, claude-code | deployed, runtime_compatible, tool_visible | `research-unavailable` |
+| `social-provider-readiness` | Content | opencode, claude-code | deployed, runtime_compatible, tool_visible | `gated-no-mutation` |
+| `linkedin-approved-posting` | Content | opencode, claude-code | deployed, configured, authenticated, authorized, reachable, usable | `gated-no-mutation` |
+| `youtube-approved-upload` | Content | opencode, claude-code | deployed, configured, authenticated, authorized, reachable, usable | `gated-no-mutation` |
+| `approval-bound-social-publishing` | Content | opencode, claude-code | deployed, configured, authenticated, authorized, reachable, usable | `approval-required-manual-handoff` |
 | `vault-operations` | Vault | opencode, claude-code | deployed, configured, enabled, authenticated, authorized, usable | `redacted-manual-handoff` |

--- a/.agents/schemas/social-provider-health.schema.json
+++ b/.agents/schemas/social-provider-health.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Social Provider Health v1",
+  "description": "Content-free readiness, queue, cooldown, freshness, and receipt evidence. This document never authorizes or executes a provider write.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generated_at", "status", "partial", "summary", "providers"],
+  "properties": {
+    "schema": {"const": "aidevops.social-provider-health/v1"},
+    "generated_at": {"type": "integer", "minimum": 0},
+    "status": {"enum": ["healthy", "partial", "blocked", "unconfigured"]},
+    "partial": {"type": "boolean"},
+    "summary": {"$ref": "#/$defs/summary"},
+    "providers": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/provider"}
+    }
+  },
+  "$defs": {
+    "nullableEpoch": {"type": ["integer", "null"], "minimum": 0},
+    "nullableCount": {"type": ["integer", "null"], "minimum": 0},
+    "status": {
+      "enum": [
+        "unconfigured",
+        "unauthenticated",
+        "ambiguous",
+        "rate_limited",
+        "unreachable",
+        "stale",
+        "usable",
+        "awaiting_approval",
+        "ready",
+        "partial",
+        "unknown"
+      ]
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "catalogued",
+        "deployed",
+        "installed",
+        "configured",
+        "enabled",
+        "authenticated",
+        "authorized",
+        "reachable",
+        "runtime_compatible",
+        "tool_visible",
+        "usable"
+      ],
+      "properties": {
+        "catalogued": {"type": ["boolean", "null"]},
+        "deployed": {"type": ["boolean", "null"]},
+        "installed": {"type": ["boolean", "null"]},
+        "configured": {"type": ["boolean", "null"]},
+        "enabled": {"type": ["boolean", "null"]},
+        "authenticated": {"type": ["boolean", "null"]},
+        "authorized": {"type": ["boolean", "null"]},
+        "reachable": {"type": ["boolean", "null"]},
+        "runtime_compatible": {"type": ["boolean", "null"]},
+        "tool_visible": {"type": ["boolean", "null"]},
+        "usable": {"type": ["boolean", "null"]}
+      }
+    },
+    "supportedActions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["read", "write"],
+      "properties": {
+        "read": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "write": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      }
+    },
+    "queue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "draft",
+        "approved",
+        "claimed",
+        "succeeded",
+        "failed",
+        "unknown",
+        "cancelled",
+        "due",
+        "leased",
+        "total"
+      ],
+      "properties": {
+        "draft": {"type": "integer", "minimum": 0},
+        "approved": {"type": "integer", "minimum": 0},
+        "claimed": {"type": "integer", "minimum": 0},
+        "succeeded": {"type": "integer", "minimum": 0},
+        "failed": {"type": "integer", "minimum": 0},
+        "unknown": {"type": "integer", "minimum": 0},
+        "cancelled": {"type": "integer", "minimum": 0},
+        "due": {"type": "integer", "minimum": 0},
+        "leased": {"type": "integer", "minimum": 0},
+        "total": {"type": "integer", "minimum": 0}
+      }
+    },
+    "quota": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["remaining", "limit", "reset_at", "cooldown"],
+      "properties": {
+        "remaining": {"$ref": "#/$defs/nullableCount"},
+        "limit": {"$ref": "#/$defs/nullableCount"},
+        "reset_at": {"$ref": "#/$defs/nullableEpoch"},
+        "cooldown": {"type": "boolean"}
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_at", "lag_seconds", "stale_after_seconds", "stale"],
+      "properties": {
+        "evidence_at": {"$ref": "#/$defs/nullableEpoch"},
+        "lag_seconds": {"$ref": "#/$defs/nullableCount"},
+        "stale_after_seconds": {"$ref": "#/$defs/nullableCount"},
+        "stale": {"type": "boolean"}
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "mode", "dimensions", "queue", "quota", "freshness", "status", "fallback", "next_action"],
+      "properties": {
+        "action": {"type": "string", "minLength": 1},
+        "mode": {"enum": ["read", "write"]},
+        "dimensions": {"$ref": "#/$defs/dimensions"},
+        "queue": {"$ref": "#/$defs/queue"},
+        "quota": {"$ref": "#/$defs/quota"},
+        "freshness": {"$ref": "#/$defs/freshness"},
+        "status": {"$ref": "#/$defs/status"},
+        "fallback": {"type": "string", "minLength": 1},
+        "next_action": {"type": "string", "minLength": 1}
+      }
+    },
+    "account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "account_alias",
+        "status",
+        "dimensions",
+        "supported_actions",
+        "actions",
+        "queue",
+        "quota",
+        "freshness",
+        "last_success_at",
+        "last_failure_class",
+        "fallback",
+        "next_action"
+      ],
+      "properties": {
+        "account_alias": {"type": "string", "minLength": 1},
+        "status": {"$ref": "#/$defs/status"},
+        "dimensions": {"$ref": "#/$defs/dimensions"},
+        "supported_actions": {"$ref": "#/$defs/supportedActions"},
+        "actions": {"type": "array", "items": {"$ref": "#/$defs/action"}},
+        "queue": {"$ref": "#/$defs/queue"},
+        "quota": {"$ref": "#/$defs/quota"},
+        "freshness": {"$ref": "#/$defs/freshness"},
+        "last_success_at": {"$ref": "#/$defs/nullableEpoch"},
+        "last_failure_class": {"type": ["string", "null"]},
+        "fallback": {"type": "string", "minLength": 1},
+        "next_action": {"type": "string", "minLength": 1}
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "status",
+        "dimensions",
+        "supported_actions",
+        "accounts",
+        "queue",
+        "quota",
+        "freshness",
+        "last_success_at",
+        "last_failure_class",
+        "fallback",
+        "next_action"
+      ],
+      "properties": {
+        "provider_id": {"type": "string", "minLength": 1},
+        "status": {"$ref": "#/$defs/status"},
+        "dimensions": {"$ref": "#/$defs/dimensions"},
+        "supported_actions": {"$ref": "#/$defs/supportedActions"},
+        "accounts": {"type": "array", "items": {"$ref": "#/$defs/account"}},
+        "queue": {"$ref": "#/$defs/queue"},
+        "quota": {"$ref": "#/$defs/quota"},
+        "freshness": {"$ref": "#/$defs/freshness"},
+        "last_success_at": {"$ref": "#/$defs/nullableEpoch"},
+        "last_failure_class": {"type": ["string", "null"]},
+        "fallback": {"type": "string", "minLength": 1},
+        "next_action": {"type": "string", "minLength": 1}
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["catalogued_providers", "configured_providers", "usable_providers", "queued_operations", "unresolved_unknown_receipts"],
+      "properties": {
+        "catalogued_providers": {"type": "integer", "minimum": 0},
+        "configured_providers": {"type": "integer", "minimum": 0},
+        "usable_providers": {"type": "integer", "minimum": 0},
+        "queued_operations": {"type": "integer", "minimum": 0},
+        "unresolved_unknown_receipts": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/.agents/scripts/_knowledge_collector_health.py
+++ b/.agents/scripts/_knowledge_collector_health.py
@@ -35,23 +35,28 @@ def _health(connection: Connection, record: dict[str, Any], now: int) -> str:
     return health
 
 
+def health_record(
+    connection: Connection, record: dict[str, Any], now: int
+) -> dict[str, Any]:
+    """Project one content-free collector record for shared health consumers."""
+    boundary = due_at(connection, record, now)
+    health = _health(connection, record, now)
+    last_success = record.get("last_success", 0)
+    return {
+        "connection_id": connection.connection_id,
+        "connector_id": connection.connector_id,
+        "due": boundary is not None and boundary <= now,
+        "freshness_lag_seconds": now - last_success if last_success else None,
+        "health": health,
+        "missed_sla": health in ("stale", "terminal-failure"),
+        "mode": connection.mode,
+        "next_due": boundary,
+    }
+
+
 def plan(connections: list[Connection], state: dict[str, Any], now: int) -> list[dict[str, Any]]:
     result = []
     for connection in connections:
         record = _record(state, connection.connection_id)
-        boundary = due_at(connection, record, now)
-        health = _health(connection, record, now)
-        last_success = record.get("last_success", 0)
-        result.append(
-            {
-                "connection_id": connection.connection_id,
-                "connector_id": connection.connector_id,
-                "due": boundary is not None and boundary <= now,
-                "freshness_lag_seconds": now - last_success if last_success else None,
-                "health": health,
-                "missed_sla": health in ("stale", "terminal-failure"),
-                "mode": connection.mode,
-                "next_due": boundary,
-            }
-        )
+        result.append(health_record(connection, record, now))
     return result

--- a/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_linkedin_outbound_provider.py
@@ -9,12 +9,18 @@ import json
 from dataclasses import dataclass
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
 from _knowledge_social_linkedin import API_VERSION
 from _knowledge_social_linkedin_provider import PROFILE_NAME, _access_token
 from _knowledge_social_outbound import ClaimedOperation
-from _knowledge_social_outbound_provider import ProviderAdapterError, ProviderIdentityError
+from _knowledge_social_outbound_provider import (
+    ProviderAdapterError,
+    ProviderIdentityError,
+    ProviderRateLimitError,
+    redirect_free_provider_open,
+    raise_for_provider_rate_limit,
+)
 from knowledge_social_import import reject_credentials
 from knowledge_social_store import SocialStoreError, validate_opaque
 
@@ -79,7 +85,7 @@ class LinkedInPreparedProvider:
     """Prepared official LinkedIn post route with exact member binding."""
 
     claimed: ClaimedOperation
-    opener: UrlOpen = urlopen
+    opener: UrlOpen = redirect_free_provider_open
 
     def verify_identity(self) -> None:
         try:
@@ -88,7 +94,9 @@ class LinkedInPreparedProvider:
                 token, f"{IDENTITY_ENDPOINT}?q=memberAndApplication", method="GET"
             )
             with self.opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-                if getattr(response, "status", 200) != 200:
+                status = getattr(response, "status", 200)
+                raise_for_provider_rate_limit(status, response.headers)
+                if status != 200:
                     raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable")
                 member_id = _member_id(
                     _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
@@ -99,7 +107,14 @@ class LinkedInPreparedProvider:
                 )
         except ProviderIdentityError:
             raise
-        except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
+        except ProviderRateLimitError:
+            raise
+        except HTTPError as error:
+            raise_for_provider_rate_limit(error.code, error.headers)
+            raise ProviderIdentityError(
+                "LinkedIn outbound capability or identity is unavailable"
+            ) from None
+        except (URLError, OSError, SocialStoreError, ProviderAdapterError):
             raise ProviderIdentityError("LinkedIn outbound capability or identity is unavailable") from None
 
     def _post(self) -> tuple[str | None, str | None]:
@@ -126,7 +141,9 @@ class LinkedInPreparedProvider:
             _request(token, POST_ENDPOINT, method="POST", data=body),
             timeout=HTTP_TIMEOUT_SECONDS,
         ) as response:
-            if getattr(response, "status", 201) not in (200, 201):
+            status = getattr(response, "status", 201)
+            raise_for_provider_rate_limit(status, response.headers)
+            if status not in (200, 201):
                 return None, "provider_unavailable"
             remote_id = response.headers.get("x-restli-id")
             if not isinstance(remote_id, str) or not remote_id:
@@ -139,7 +156,12 @@ class LinkedInPreparedProvider:
     def invoke(self) -> tuple[str | None, str | None]:
         try:
             return self._post()
-        except (HTTPError, URLError, OSError):
+        except ProviderRateLimitError:
+            raise
+        except HTTPError as error:
+            raise_for_provider_rate_limit(error.code, error.headers)
+            return None, "provider_unavailable"
+        except (URLError, OSError):
             return None, "provider_unavailable"
         except (SocialStoreError, ProviderAdapterError, UnicodeError):
             return None, "validation"

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -41,6 +41,7 @@ FAILURE_CLASSES = (
     "executor_lost",
     "identity",
     "provider_unavailable",
+    "rate_limit",
     "reconciled_not_sent",
     "runtime",
     "validation",

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -6,12 +6,16 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Callable, Protocol
+from typing import Any, Callable, Protocol
+from urllib.request import HTTPRedirectHandler, build_opener
 
 from _knowledge_social_outbound import ClaimedOperation
 from _knowledge_social_x import XAdapterError, response_status
@@ -21,6 +25,8 @@ from knowledge_social_store import SocialStoreError, validate_opaque
 
 WRITE_TIMEOUT_SECONDS = 120
 MAX_PROVIDER_OUTPUT_BYTES = 1024 * 1024
+MAX_PROVIDER_RETRY_SECONDS = 31 * 24 * 60 * 60
+DEFAULT_PROVIDER_RETRY_SECONDS = 60
 
 
 class ProviderAdapterError(RuntimeError):
@@ -29,6 +35,60 @@ class ProviderAdapterError(RuntimeError):
 
 class ProviderIdentityError(RuntimeError):
     """Raised when the selected provider account cannot be verified safely."""
+
+
+class ProviderRateLimitError(RuntimeError):
+    """Raised with bounded provider reset evidence after an HTTP rate limit."""
+
+    def __init__(self, retry_after_seconds: int | None):
+        super().__init__("provider rate limit")
+        self.retry_after_seconds = retry_after_seconds
+
+
+def provider_retry_seconds(
+    value: str | None, current_time: float | None = None
+) -> int | None:
+    """Parse one provider Retry-After duration or HTTP date into a bounded delay."""
+    if value is None or not isinstance(value, str) or len(value) > 128:
+        return None
+    parsed_date = False
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        parsed_date = True
+        try:
+            parsed = parsedate_to_datetime(value)
+            if parsed.utcoffset() is None:
+                return None
+            seconds = parsed.timestamp() - (
+                time.time() if current_time is None else current_time
+            )
+        except (OverflowError, TypeError, ValueError):
+            return None
+    if not math.isfinite(seconds):
+        return None
+    if seconds < 0:
+        return 0 if parsed_date else None
+    return min(math.ceil(seconds), MAX_PROVIDER_RETRY_SECONDS)
+
+
+def raise_for_provider_rate_limit(status: int, headers: Any) -> None:
+    """Raise only when a provider response supplies an HTTP 429 classification."""
+    if status == 429:
+        retry_after = headers.get("Retry-After") if headers is not None else None
+        raise ProviderRateLimitError(provider_retry_seconds(retry_after))
+
+
+class RejectProviderRedirect(HTTPRedirectHandler):
+    """Reject redirects before urllib can forward provider authorization headers."""
+
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def redirect_free_provider_open(request: Any, **kwargs: Any) -> Any:
+    """Open one provider request without following any redirect."""
+    return build_opener(RejectProviderRedirect()).open(request, **kwargs)
 
 
 class PreparedProvider(Protocol):

--- a/.agents/scripts/_knowledge_social_outbound_reconciliation.py
+++ b/.agents/scripts/_knowledge_social_outbound_reconciliation.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterable, Mapping
 
-from _knowledge_social_outbound import _verified_operation, now_epoch
-from knowledge_social_import import canonical_json
+from _knowledge_social_outbound import (
+    OUTBOUND_PROVIDER_ACTIONS,
+    _new_id,
+    _verified_operation,
+    now_epoch,
+)
+from _knowledge_social_outbound_runtime import expire_claims
 from knowledge_social_store import SocialStoreError, validate_opaque
 
 LIST_OPERATIONS_SQL = """SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
@@ -20,14 +25,20 @@ LIST_OPERATIONS_SQL = """SELECT o.operation_id,o.action,o.state,o.scheduled_at,o
                FROM outbound_operations o
                LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
               WHERE o.created_by=?
-              ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
+               ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
 LIST_OPERATION_SQL = """SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
                     a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
                     a.failure_class,a.started_at,a.finished_at
                FROM outbound_operations o
                LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
               WHERE o.created_by=? AND o.operation_id=?
-              ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
+               ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
+UNKNOWN_RECEIPTS_SQL = """SELECT o.operation_id,o.provider,o.connection_id,o.action,
+                    o.updated_at,a.failure_class,a.provider_remote_id,a.finished_at
+               FROM outbound_operations o
+               JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE o.created_by=? AND o.state='unknown'
+              ORDER BY o.updated_at,o.operation_id LIMIT ?"""
 
 
 @dataclass(frozen=True)
@@ -80,40 +91,80 @@ def _validated_reconciliation(
     )
 
 
+def _unknown_attempt(
+    database: sqlite3.Connection,
+    row: sqlite3.Row,
+    decision: ValidatedReconciliation,
+) -> sqlite3.Row:
+    attempt = database.execute(
+        """SELECT status,failure_class,provider_remote_id,finished_at,diagnostics
+             FROM outbound_attempts
+            WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
+        (row["last_attempt_id"], decision.operation_id, row["claim_token"]),
+    ).fetchone()
+    if attempt is None:
+        raise SocialStoreError("unknown outbound receipt is inconsistent")
+    return attempt
+
+
+def _append_reconciliation(
+    database: sqlite3.Connection,
+    row: sqlite3.Row,
+    attempt: sqlite3.Row,
+    decision: ValidatedReconciliation,
+) -> str:
+    reconciliation_id = _new_id("rec")
+    database.execute(
+        """INSERT INTO outbound_reconciliations(
+               reconciliation_id,operation_id,attempt_id,principal_id,outcome,
+               resolved_state,provider_remote_id,reconciled_at,original_status,
+               original_failure_class,original_provider_remote_id,
+               original_finished_at,original_diagnostics)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            reconciliation_id,
+            decision.operation_id,
+            row["last_attempt_id"],
+            decision.principal_id,
+            decision.outcome,
+            decision.state,
+            decision.provider_remote_id,
+            decision.reconciled_at,
+            attempt["status"],
+            attempt["failure_class"],
+            attempt["provider_remote_id"],
+            attempt["finished_at"],
+            attempt["diagnostics"],
+        ),
+    )
+    return reconciliation_id
+
+
 def _persist_reconciliation(
     database: sqlite3.Connection, decision: ValidatedReconciliation
-) -> None:
+) -> str:
     database.execute("BEGIN IMMEDIATE")
     try:
         row = _verified_operation(database, decision.operation_id)
         if row["state"] != "unknown" or row["created_by"] != decision.principal_id:
             raise SocialStoreError("only an owner unknown operation can be reconciled")
+        attempt = _unknown_attempt(database, row, decision)
+        reconciliation_id = _append_reconciliation(
+            database, row, attempt, decision
+        )
         changed = database.execute(
-            """UPDATE outbound_attempts
-                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
-                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
-            (
-                decision.state,
-                decision.reconciled_at,
-                decision.provider_remote_id,
-                None if decision.state == "succeeded" else "reconciled_not_sent",
-                canonical_json({"reconciled": decision.outcome}),
-                row["last_attempt_id"],
-                decision.operation_id,
-                row["claim_token"],
-            ),
+            """UPDATE outbound_operations SET state=?,updated_at=?
+                 WHERE operation_id=? AND state='unknown'""",
+            (decision.state, decision.reconciled_at, decision.operation_id),
         ).rowcount
         if changed != 1:
-            raise SocialStoreError("unknown outbound receipt is inconsistent")
-        database.execute(
-            "UPDATE outbound_operations SET state=?,updated_at=? WHERE operation_id=?",
-            (decision.state, decision.reconciled_at, decision.operation_id),
-        )
+            raise SocialStoreError("unknown outbound operation is inconsistent")
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
             database.execute("ROLLBACK")
         raise
+    return reconciliation_id
 
 
 def reconcile_unknown(
@@ -121,8 +172,12 @@ def reconcile_unknown(
 ) -> dict[str, Any]:
     """Resolve an ambiguous attempt without ever placing it back in the queue."""
     decision = _validated_reconciliation(request)
-    _persist_reconciliation(database, decision)
-    result = {"operation_id": decision.operation_id, "state": decision.state}
+    reconciliation_id = _persist_reconciliation(database, decision)
+    result = {
+        "operation_id": decision.operation_id,
+        "reconciliation_id": reconciliation_id,
+        "state": decision.state,
+    }
     if decision.provider_remote_id is not None:
         result["provider_remote_id"] = decision.provider_remote_id
     return result
@@ -148,3 +203,178 @@ def list_operations(
             (principal_id, validate_opaque(operation_id, "operation_id"), limit),
         ).fetchall()
     return [dict(row) for row in rows]
+
+
+def unknown_receipts(
+    database: sqlite3.Connection,
+    principal_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return bounded ambiguous receipts without private intent content."""
+    if limit < 1 or limit > 1000:
+        raise SocialStoreError("unknown receipt limit must be between 1 and 1000")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    rows = database.execute(UNKNOWN_RECEIPTS_SQL, (principal_id, limit)).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _validated_limits(limit: int, per_provider_limit: int) -> None:
+    if limit < 1 or limit > 100:
+        raise SocialStoreError("reconciliation limit must be between 1 and 100")
+    if per_provider_limit < 1 or per_provider_limit > 20:
+        raise SocialStoreError(
+            "per-provider reconciliation limit must be between 1 and 20"
+        )
+
+
+def _decision_map(
+    decisions: Iterable[ReconciliationRequest], principal_id: str
+) -> dict[str, ReconciliationRequest]:
+    result: dict[str, ReconciliationRequest] = {}
+    for decision in decisions:
+        operation_id = validate_opaque(decision.operation_id, "operation_id")
+        if validate_opaque(decision.principal_id, "principal_id") != principal_id:
+            raise SocialStoreError("reconciliation decision owner does not match")
+        if operation_id in result:
+            raise SocialStoreError("reconciliation decisions contain a duplicate operation")
+        result[operation_id] = decision
+    return result
+
+
+def _decision_receipts(
+    database: sqlite3.Connection,
+    principal_id: str,
+    operation_ids: Iterable[str],
+) -> list[dict[str, Any]]:
+    ids = tuple(operation_ids)
+    if not ids:
+        return []
+    placeholders = ",".join("?" for _operation_id in ids)
+    rows = database.execute(
+        f"""SELECT o.operation_id,o.provider,o.connection_id,o.action,
+                    o.updated_at,a.failure_class,a.provider_remote_id,a.finished_at
+               FROM outbound_operations o
+               JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE o.created_by=? AND o.state='unknown'
+                AND o.operation_id IN ({placeholders})
+              ORDER BY o.updated_at,o.operation_id""",  # nosec B608 -- placeholders only
+        (principal_id, *ids),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _bounded_receipts(
+    receipts: Iterable[dict[str, Any]], limit: int, per_provider_limit: int
+) -> list[dict[str, Any]]:
+    if limit == 0:
+        return []
+    selected: list[dict[str, Any]] = []
+    provider_counts: dict[str, int] = {}
+    for receipt in receipts:
+        provider = str(receipt["provider"])
+        if provider_counts.get(provider, 0) >= per_provider_limit:
+            continue
+        provider_counts[provider] = provider_counts.get(provider, 0) + 1
+        selected.append(receipt)
+        if len(selected) == limit:
+            break
+    return selected
+
+
+def bounded_reconcile(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+    *,
+    decisions: Iterable[ReconciliationRequest] = (),
+    cooldowns: Mapping[str, int] | None = None,
+    limit: int = 10,
+    per_provider_limit: int = 3,
+) -> dict[str, Any]:
+    """Apply bounded, account-cooldown-aware owner decisions without replay."""
+    _validated_limits(limit, per_provider_limit)
+    if current_time < 0:
+        raise SocialStoreError("reconciliation time must be a non-negative epoch")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    decision_by_id = _decision_map(decisions, principal_id)
+    if len(decision_by_id) > limit:
+        raise SocialStoreError("reconciliation decisions exceed the global limit")
+    expired = expire_claims(database, principal_id, current_time, limit)
+    remaining = limit - len(expired)
+    candidates = (
+        _decision_receipts(database, principal_id, decision_by_id)
+        if decision_by_id
+        else _bounded_receipts(
+            unknown_receipts(
+                database,
+                principal_id,
+                min(1000, limit * len(OUTBOUND_PROVIDER_ACTIONS)),
+            ),
+            remaining,
+            per_provider_limit,
+        )
+    )
+    cooldowns = cooldowns or {}
+    resolved: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    pending: list[dict[str, Any]] = []
+    selected_ids: set[str] = set()
+    provider_counts: dict[str, int] = {}
+    for receipt in candidates:
+        operation_id = str(receipt["operation_id"])
+        provider = str(receipt["provider"])
+        connection_id = str(receipt["connection_id"])
+        selected_ids.add(operation_id)
+        decision = decision_by_id.get(operation_id)
+        if decision is None:
+            pending.append(receipt)
+            continue
+        if cooldowns.get(connection_id, 0) > current_time:
+            skipped.append(
+                {
+                    "operation_id": operation_id,
+                    "provider_id": provider,
+                    "reason": "cooldown",
+                }
+            )
+            pending.append(receipt)
+            continue
+        if remaining == 0:
+            skipped.append(
+                {
+                    "operation_id": operation_id,
+                    "provider_id": provider,
+                    "reason": "global_budget",
+                }
+            )
+            pending.append(receipt)
+            continue
+        if provider_counts.get(provider, 0) >= per_provider_limit:
+            skipped.append(
+                {
+                    "operation_id": operation_id,
+                    "provider_id": provider,
+                    "reason": "provider_budget",
+                }
+            )
+            pending.append(receipt)
+            continue
+        resolved.append(reconcile_unknown(database, decision))
+        provider_counts[provider] = provider_counts.get(provider, 0) + 1
+        remaining -= 1
+    for operation_id in sorted(set(decision_by_id) - selected_ids):
+        skipped.append(
+            {
+                "operation_id": operation_id,
+                "provider_id": "unknown",
+                "reason": "not_due_or_budgeted",
+            }
+        )
+    return {
+        "expired_claims": expired,
+        "resolved": resolved,
+        "resolved_count": len(resolved),
+        "skipped": skipped,
+        "unresolved": pending,
+        "unresolved_count": len(pending),
+    }

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -47,6 +47,25 @@ class AttemptOutcome:
     provider_remote_id: str | None = None
     failure_class: str | None = None
     finished_at: int | None = None
+    retry_after: int | None = None
+
+
+def active_connection_cooldown(
+    database: sqlite3.Connection, connection_id: str, current_time: int
+) -> int | None:
+    """Return the latest active reset boundary for one exact connection."""
+    connection_id = validate_opaque(connection_id, "connection_id")
+    if current_time < 0:
+        raise SocialStoreError("cooldown time must be a non-negative epoch")
+    row = database.execute(
+        """SELECT MAX(CAST(retry_after AS INTEGER)) AS reset_at
+             FROM sync_runs
+            WHERE connection_id=? AND status='paused' AND failure_class='rate_limit'
+              AND retry_after!='' AND retry_after NOT GLOB '*[^0-9]*'
+              AND CAST(retry_after AS INTEGER)>?""",
+        (connection_id, current_time),
+    ).fetchone()
+    return int(row["reset_at"]) if row and row["reset_at"] is not None else None
 
 
 def record_provider_checkpoint(
@@ -91,10 +110,84 @@ def due_operation_ids(
                AND o.created_by=? AND a.principal_id=?
                AND a.intent_sha256=o.intent_sha256
                AND a.revoked_at IS NULL AND a.expires_at>?
-             ORDER BY o.scheduled_at,o.operation_id LIMIT ?""",
-        (current_time, principal_id, principal_id, current_time, limit),
+               AND NOT EXISTS(
+                   SELECT 1 FROM sync_runs s
+                    WHERE s.connection_id=o.connection_id
+                      AND s.status='paused' AND s.failure_class='rate_limit'
+                      AND s.retry_after!=''
+                      AND s.retry_after NOT GLOB '*[^0-9]*'
+                      AND CAST(s.retry_after AS INTEGER)>?
+               )
+              ORDER BY o.scheduled_at,o.operation_id LIMIT ?""",
+        (
+            current_time,
+            principal_id,
+            principal_id,
+            current_time,
+            current_time,
+            limit,
+        ),
     ).fetchall()
-    return [str(_verified_operation(database, row["operation_id"])["operation_id"]) for row in rows]
+    return [
+        str(_verified_operation(database, row["operation_id"])["operation_id"])
+        for row in rows
+    ]
+
+
+def outbound_health_rows(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+) -> list[dict[str, Any]]:
+    """Return content-free operation evidence for health aggregation."""
+    principal_id = validate_opaque(principal_id, "principal_id")
+    if current_time < 0:
+        raise SocialStoreError("health time must be a non-negative epoch")
+    has_reconciliations = database.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' "
+        "AND name='outbound_reconciliations'"
+    ).fetchone()
+    attempt_status = (
+        "COALESCE(r.resolved_state,a.status)" if has_reconciliations else "a.status"
+    )
+    finished_at = (
+        "COALESCE(r.reconciled_at,a.finished_at)"
+        if has_reconciliations
+        else "a.finished_at"
+    )
+    failure_class = (
+        "CASE WHEN r.outcome='succeeded' THEN NULL "
+        "WHEN r.outcome='not-sent' THEN 'reconciled_not_sent' "
+        "ELSE a.failure_class END"
+        if has_reconciliations
+        else "a.failure_class"
+    )
+    reconciliation_join = (
+        "LEFT JOIN outbound_reconciliations r ON r.attempt_id=a.attempt_id"
+        if has_reconciliations
+        else ""
+    )
+    rows = database.execute(
+        f"""SELECT o.operation_id,o.provider,o.connection_id,o.action,o.state,
+                  o.scheduled_at,o.updated_at,o.claim_expires_at,
+                  a.attempt_id,{attempt_status} AS attempt_status,
+                  a.provider_started_at,{finished_at} AS finished_at,
+                  {failure_class} AS failure_class,
+                  CASE WHEN EXISTS(
+                      SELECT 1 FROM outbound_approvals p
+                       WHERE p.operation_id=o.operation_id
+                         AND p.principal_id=o.created_by
+                         AND p.intent_sha256=o.intent_sha256
+                         AND p.revoked_at IS NULL AND p.expires_at>?
+                   ) THEN 1 ELSE 0 END AS has_current_approval
+             FROM outbound_operations o
+              LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              {reconciliation_join}
+             WHERE o.created_by=?
+             ORDER BY o.connection_id,o.action,o.created_at,o.operation_id""",  # nosec B608 -- fixed internal projections
+        (current_time, principal_id),
+    ).fetchall()
+    return [dict(row) for row in rows]
 
 
 def _claimable_operation(
@@ -107,6 +200,10 @@ def _claimable_operation(
         or row["created_by"] != principal_id
     ):
         raise SocialStoreError("operation is not due and approved")
+    if active_connection_cooldown(
+        database, str(row["connection_id"]), request.current_time
+    ) is not None:
+        raise SocialStoreError("operation account is in provider cooldown")
     approval = database.execute(
         """SELECT approval_id FROM outbound_approvals
             WHERE operation_id=? AND principal_id=? AND intent_sha256=?
@@ -215,11 +312,20 @@ def mark_provider_started(
                    JOIN outbound_approvals a ON a.operation_id=o.operation_id
                     WHERE o.operation_id=outbound_attempts.operation_id
                       AND o.state='claimed' AND o.claim_token=outbound_attempts.claim_token
-                      AND o.claimed_by=? AND o.last_attempt_id=outbound_attempts.attempt_id
-                      AND o.claim_expires_at>? AND a.principal_id=o.created_by
-                      AND a.intent_sha256=o.intent_sha256 AND a.revoked_at IS NULL
-                      AND a.expires_at>?
-               )""",
+                       AND o.claimed_by=? AND o.last_attempt_id=outbound_attempts.attempt_id
+                       AND o.claim_expires_at>? AND a.principal_id=o.created_by
+                       AND a.intent_sha256=o.intent_sha256 AND a.revoked_at IS NULL
+                       AND a.expires_at>?
+                       AND NOT EXISTS(
+                           SELECT 1 FROM sync_runs s
+                            WHERE s.connection_id=o.connection_id
+                              AND s.status='paused'
+                              AND s.failure_class='rate_limit'
+                              AND s.retry_after!=''
+                              AND s.retry_after NOT GLOB '*[^0-9]*'
+                              AND CAST(s.retry_after AS INTEGER)>?
+                       )
+                )""",
         (
             started_at,
             claimed.attempt_id,
@@ -229,10 +335,91 @@ def mark_provider_started(
             executor_id,
             started_at,
             started_at,
+            started_at,
         ),
     ).rowcount
     if changed != 1:
         raise SocialStoreError("outbound provider boundary is stale or already marked")
+
+
+def defer_claim_for_cooldown(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    current_time: int,
+) -> dict[str, Any] | None:
+    """Return a pre-provider claim to approved while preserving its attempt."""
+    executor_id = validate_opaque(executor_id, "executor_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = database.execute(
+            """SELECT o.connection_id,o.state,o.claim_token,o.claimed_by,
+                      o.last_attempt_id,a.status,a.provider_started_at
+                 FROM outbound_operations o
+                 JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+                WHERE o.operation_id=?""",
+            (claimed.operation_id,),
+        ).fetchone()
+        expected = (
+            "claimed",
+            claimed.claim_token,
+            executor_id,
+            claimed.attempt_id,
+            "running",
+            None,
+        )
+        actual = tuple(row)[1:] if row is not None else ()
+        if actual != expected:
+            raise SocialStoreError("cooldown deferral claim is stale")
+        reset_at = active_connection_cooldown(
+            database, str(row["connection_id"]), current_time
+        )
+        if reset_at is None:
+            database.execute("ROLLBACK")
+            return None
+        attempt_changed = database.execute(
+            """UPDATE outbound_attempts
+                  SET status='failed',finished_at=?,failure_class='rate_limit',
+                      diagnostics=?
+                WHERE attempt_id=? AND operation_id=? AND claim_token=?
+                  AND executor_id=? AND status='running'
+                  AND provider_started_at IS NULL""",
+            (
+                current_time,
+                canonical_json({"phase": "pre-provider", "reason": "cooldown"}),
+                claimed.attempt_id,
+                claimed.operation_id,
+                claimed.claim_token,
+                executor_id,
+            ),
+        ).rowcount
+        operation_changed = database.execute(
+            """UPDATE outbound_operations
+                  SET state='approved',claimed_by=NULL,claim_expires_at=NULL,updated_at=?
+                WHERE operation_id=? AND state='claimed' AND claim_token=?
+                  AND claimed_by=? AND last_attempt_id=?""",
+            (
+                current_time,
+                claimed.operation_id,
+                claimed.claim_token,
+                executor_id,
+                claimed.attempt_id,
+            ),
+        ).rowcount
+        if attempt_changed != 1 or operation_changed != 1:
+            raise SocialStoreError("cooldown deferral claim is inconsistent")
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {
+        "operation_id": claimed.operation_id,
+        "attempt_id": claimed.attempt_id,
+        "state": "approved",
+        "failure_class": "rate_limit",
+        "retry_after": reset_at,
+    }
 
 
 def _assert_outcome_fields(
@@ -257,6 +444,14 @@ def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
         provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
     if outcome.failure_class is not None and outcome.failure_class not in FAILURE_CLASSES:
         raise SocialStoreError("invalid outbound failure class")
+    retry_after = outcome.retry_after
+    if retry_after is not None and (
+        isinstance(retry_after, bool)
+        or not isinstance(retry_after, int)
+        or retry_after <= finished_at
+        or outcome.failure_class != "rate_limit"
+    ):
+        raise SocialStoreError("invalid outbound rate-limit reset")
     _assert_outcome_fields(
         outcome.status, provider_remote_id, outcome.failure_class
     )
@@ -265,6 +460,7 @@ def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
         provider_remote_id,
         outcome.failure_class,
         finished_at,
+        retry_after,
     )
 
 
@@ -272,14 +468,14 @@ def _provider_started(
     database: sqlite3.Connection,
     claimed: ClaimedOperation,
     executor_id: str,
-) -> bool:
+) -> tuple[bool, int]:
     row = database.execute(
-        "SELECT state,claim_token,claimed_by,last_attempt_id FROM outbound_operations "
-        "WHERE operation_id=?",
+        "SELECT state,claim_token,claimed_by,last_attempt_id,claim_expires_at "
+        "FROM outbound_operations WHERE operation_id=?",
         (claimed.operation_id,),
     ).fetchone()
     expected = ("claimed", claimed.claim_token, executor_id, claimed.attempt_id)
-    actual = tuple(row) if row is not None else ()
+    actual = tuple(row)[:4] if row is not None else ()
     if actual != expected:
         raise SocialStoreError("stale outbound executor cannot finalize")
     attempt = database.execute(
@@ -295,7 +491,7 @@ def _provider_started(
     ).fetchone()
     if attempt is None:
         raise SocialStoreError("outbound attempt is no longer running")
-    return attempt["provider_started_at"] is not None
+    return attempt["provider_started_at"] is not None, int(row["claim_expires_at"])
 
 
 def _assert_outcome_boundary(provider_started: bool, outcome: AttemptOutcome) -> None:
@@ -303,6 +499,19 @@ def _assert_outcome_boundary(provider_started: bool, outcome: AttemptOutcome) ->
         raise SocialStoreError("started provider attempts cannot be retry-safe failures")
     if not provider_started and outcome.status in ("succeeded", "unknown"):
         raise SocialStoreError("provider outcome requires a started provider attempt")
+
+
+def _expired_claim_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
+    failure_class = outcome.failure_class or "executor_lost"
+    return AttemptOutcome(
+        "unknown",
+        provider_remote_id=outcome.provider_remote_id,
+        failure_class=failure_class,
+        finished_at=outcome.finished_at,
+        retry_after=(
+            outcome.retry_after if failure_class == "rate_limit" else None
+        ),
+    )
 
 
 def _persist_outcome(
@@ -339,6 +548,44 @@ def _persist_outcome(
     )
 
 
+def _persist_rate_limit_cooldown(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    outcome: AttemptOutcome,
+) -> None:
+    if outcome.retry_after is None:
+        return
+    row = database.execute(
+        """SELECT o.connection_id,o.action,a.provider_started_at
+             FROM outbound_operations o
+             JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+            WHERE o.operation_id=? AND a.attempt_id=?""",
+        (claimed.operation_id, claimed.attempt_id),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("outbound rate-limit receipt is unavailable")
+    database.execute(
+        """INSERT INTO sync_runs(
+               run_id,connection_id,status,failure_class,retry_after,stream,run_kind,
+               collector_id,started_at,completed_at,diagnostics)
+             VALUES(?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            _new_id("run"),
+            row["connection_id"],
+            "paused",
+            "rate_limit",
+            str(outcome.retry_after),
+            row["action"],
+            "outbound",
+            executor_id,
+            row["provider_started_at"] or outcome.finished_at,
+            outcome.finished_at,
+            canonical_json({"phase": "provider", "reason": "rate_limit"}),
+        ),
+    )
+
+
 def _outcome_receipt(
     claimed: ClaimedOperation, outcome: AttemptOutcome
 ) -> dict[str, Any]:
@@ -351,6 +598,8 @@ def _outcome_receipt(
         result["provider_remote_id"] = outcome.provider_remote_id
     if outcome.failure_class is not None:
         result["failure_class"] = outcome.failure_class
+    if outcome.retry_after is not None:
+        result["retry_after"] = outcome.retry_after
     return result
 
 
@@ -365,9 +614,15 @@ def finalize_operation(
     executor_id = validate_opaque(executor_id, "executor_id")
     database.execute("BEGIN IMMEDIATE")
     try:
-        provider_started = _provider_started(database, claimed, executor_id)
-        _assert_outcome_boundary(provider_started, outcome)
+        provider_started, claim_expires_at = _provider_started(
+            database, claimed, executor_id
+        )
+        if claim_expires_at <= int(outcome.finished_at):
+            outcome = _expired_claim_outcome(outcome)
+        else:
+            _assert_outcome_boundary(provider_started, outcome)
         _persist_outcome(database, claimed, executor_id, outcome, provider_started)
+        _persist_rate_limit_cooldown(database, claimed, executor_id, outcome)
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:

--- a/.agents/scripts/_knowledge_social_share_data.py
+++ b/.agents/scripts/_knowledge_social_share_data.py
@@ -39,6 +39,7 @@ LOCAL_ONLY_TABLES = frozenset(
         "outbound_operations",
         "outbound_approvals",
         "outbound_attempts",
+        "outbound_reconciliations",
         "notification_state",
     }
 )

--- a/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_youtube_outbound_provider.py
@@ -13,11 +13,21 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
-from _knowledge_social_youtube_provider import PROFILE_NAME, _access_token
+from _knowledge_social_youtube_provider import (
+    PROFILE_NAME,
+    RATE_LIMIT_REASONS,
+    _access_token,
+)
 from _knowledge_social_outbound import ClaimedOperation
-from _knowledge_social_outbound_provider import ProviderAdapterError, ProviderIdentityError
+from _knowledge_social_outbound_provider import (
+    ProviderAdapterError,
+    ProviderIdentityError,
+    ProviderRateLimitError,
+    redirect_free_provider_open,
+    raise_for_provider_rate_limit,
+)
 from knowledge_social_import import reject_credentials
 from knowledge_social_store import SocialStoreError, validate_opaque
 
@@ -46,6 +56,28 @@ def _decode_response(payload: bytes) -> dict[str, Any]:
         raise ProviderAdapterError("YouTube write response root must be an object")
     reject_credentials(decoded)
     return decoded
+
+
+def _http_error_status(error: HTTPError) -> int:
+    """Normalize only allowlisted YouTube quota reasons to HTTP 429."""
+    if error.code != 403:
+        return error.code
+    try:
+        payload = _decode_response(error.read(MAX_RESPONSE_BYTES + 1))
+    except (OSError, SocialStoreError, ProviderAdapterError):
+        return error.code
+    envelope = payload.get("error")
+    entries = envelope.get("errors") if isinstance(envelope, dict) else None
+    if not isinstance(entries, list):
+        return error.code
+    reasons = {
+        reason
+        for entry in entries
+        if isinstance(entry, dict)
+        for reason in (entry.get("reason"),)
+        if isinstance(reason, str)
+    }
+    return 429 if reasons.intersection(RATE_LIMIT_REASONS) else error.code
 
 
 def _api_request(token: str, endpoint: str, params: dict[str, str]) -> Request:
@@ -88,7 +120,7 @@ class YouTubePreparedProvider:
     """Prepared YouTube video upload with exact owned-channel verification."""
 
     claimed: ClaimedOperation
-    opener: UrlOpen = urlopen
+    opener: UrlOpen = redirect_free_provider_open
 
     def verify_identity(self) -> None:
         try:
@@ -101,7 +133,9 @@ class YouTubePreparedProvider:
                 ),
                 timeout=HTTP_TIMEOUT_SECONDS,
             ) as response:
-                if getattr(response, "status", 200) != 200:
+                status = getattr(response, "status", 200)
+                raise_for_provider_rate_limit(status, response.headers)
+                if status != 200:
                     raise ProviderIdentityError("YouTube upload capability or identity is unavailable")
                 payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
             items = payload.get("items")
@@ -117,7 +151,14 @@ class YouTubePreparedProvider:
             _verified_media(self.claimed)
         except ProviderIdentityError:
             raise
-        except (HTTPError, URLError, OSError, SocialStoreError, ProviderAdapterError):
+        except ProviderRateLimitError:
+            raise
+        except HTTPError as error:
+            raise_for_provider_rate_limit(_http_error_status(error), error.headers)
+            raise ProviderIdentityError(
+                "YouTube upload capability or identity is unavailable"
+            ) from None
+        except (URLError, OSError, SocialStoreError, ProviderAdapterError):
             raise ProviderIdentityError("YouTube upload capability or identity is unavailable") from None
 
     def _upload(
@@ -153,6 +194,10 @@ class YouTubePreparedProvider:
             method="POST",
         )
         with self.opener(initiate, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            raise_for_provider_rate_limit(status, response.headers)
+            if status not in (200, 201):
+                return None, "provider_unavailable"
             location = response.headers.get("Location")
         if not isinstance(location, str) or not location.startswith("https://www.googleapis.com/"):
             return None, "validation"
@@ -170,6 +215,10 @@ class YouTubePreparedProvider:
                 method="PUT",
             )
             with self.opener(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                status = getattr(response, "status", 200)
+                raise_for_provider_rate_limit(status, response.headers)
+                if status not in (200, 201):
+                    return None, "provider_unavailable"
                 payload = _decode_response(response.read(MAX_RESPONSE_BYTES + 1))
         remote_id = payload.get("id")
         if not isinstance(remote_id, str):
@@ -181,7 +230,12 @@ class YouTubePreparedProvider:
     ) -> tuple[str | None, str | None]:
         try:
             return self._upload(checkpoint)
-        except (HTTPError, URLError, OSError):
+        except ProviderRateLimitError:
+            raise
+        except HTTPError as error:
+            raise_for_provider_rate_limit(_http_error_status(error), error.headers)
+            return None, "provider_unavailable"
+        except (URLError, OSError):
             return None, "provider_unavailable"
         except (SocialStoreError, ProviderAdapterError, UnicodeError):
             return None, "validation"

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -32,6 +32,7 @@ SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
 BROWSER_HELPER="${SCRIPT_DIR}/knowledge_social_browser.py"
 OPERATIONS_HELPER="${SCRIPT_DIR}/knowledge_social_operations.py"
+PROVIDER_HEALTH_HELPER="${SCRIPT_DIR}/social-provider-health.py"
 REGISTRY_HELPER="${SCRIPT_DIR}/knowledge_social_registry.py"
 VAULT_RUNTIME_CHECK="${SCRIPT_DIR}/vault-runtime-check.py"
 VAULT_RUNTIME_PYTHON="${HOME:+$HOME/.aidevops/.agent-workspace/python-env/vault/bin/python3}"
@@ -54,6 +55,10 @@ usage_operations() {
     [--base PATH] [--alias ALIAS] [--operation-id ID] [--limit N]
   knowledge-social-helper.sh operation-reconcile [--base PATH] [--alias ALIAS] \
     --operation-id ID --outcome succeeded|not-sent [--provider-id ID]
+  knowledge-social-helper.sh provider-health-status|provider-health-collect|provider-health-report \
+    [--base PATH] [--alias ALIAS] [--provider PROVIDER] [--stale-seconds SECONDS]
+  knowledge-social-helper.sh provider-health-reconcile [--base PATH] [--alias ALIAS] \
+    [--decisions-file PRIVATE_JSON] [--limit 1-100] [--per-provider-limit 1-20]
   knowledge-social-helper.sh notifications-refresh [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh notifications-list [--base PATH] [--alias ALIAS] \
     [--status unread|seen|action-required|responded|dismissed] [--limit 1-1000]
@@ -66,6 +71,11 @@ to an expiring approval. Due runners verify the stable X identity immediately
 before one mapped write attempt. Ambiguous outcomes are never retried; reconcile
 them explicitly. Notification commands maintain a local workflow overlay without
 mutating mention/reply evidence.
+
+Provider health commands aggregate only content-free readiness, queue, cooldown,
+freshness, and receipt evidence. Reconciliation expires stale claims and applies
+only explicit owner decisions within global and per-provider bounds; it never
+creates or retries a publish intent.
 
 EOF
 	return 0
@@ -559,6 +569,23 @@ run_registry_command() {
 	return 0
 }
 
+run_provider_health_command() {
+	local subcommand="$1"
+	shift || return 1
+	require_runtime || return 1
+	if [[ ! -r "$PROVIDER_HEALTH_HELPER" ]]; then
+		printf 'ERROR: social provider health implementation missing: %s\n' "$PROVIDER_HEALTH_HELPER" >&2
+		return 1
+	fi
+	case "$subcommand" in
+	provider-health-status | provider-health-collect | provider-health-report | provider-health-reconcile)
+		python3 "$PROVIDER_HEALTH_HELPER" "${subcommand#provider-health-}" "$@" || return 1
+		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
 run_query_command() {
 	local subcommand="$1"
 	shift || return 1
@@ -632,6 +659,9 @@ main() {
 		;;
 	providers | provider-resolve | provider-run)
 		run_registry_command "$subcommand" "$@" || return 1
+		;;
+	provider-health-status | provider-health-collect | provider-health-report | provider-health-reconcile)
+		run_provider_health_command "$subcommand" "$@" || return 1
 		;;
 	sync-due | reconcile-due | reconcile | receipts)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -38,8 +38,10 @@ from _knowledge_social_outbound import (
     revoke_approval,
 )
 from _knowledge_social_outbound_provider import (
+    DEFAULT_PROVIDER_RETRY_SECONDS,
     ProviderAdapterError,
     ProviderIdentityError,
+    ProviderRateLimitError,
     prepare_provider,
 )
 from _knowledge_social_outbound_reconciliation import (
@@ -51,6 +53,7 @@ from _knowledge_social_outbound_runtime import (
     AttemptOutcome,
     ClaimRequest,
     claim_operation,
+    defer_claim_for_cooldown,
     due_operation_ids,
     expire_claims,
     finalize_operation,
@@ -135,6 +138,34 @@ def _unknown_provider_outcome(
     )
 
 
+def _rate_limited_provider_outcome(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    status: str,
+    error: ProviderRateLimitError,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    finished_at = _clock(args)
+    retry_seconds = (
+        error.retry_after_seconds
+        if error.retry_after_seconds is not None and error.retry_after_seconds > 0
+        else DEFAULT_PROVIDER_RETRY_SECONDS
+    )
+    retry_after = finished_at + retry_seconds
+    return finalize_operation(
+        database,
+        claimed,
+        executor_id,
+        AttemptOutcome(
+            status,
+            failure_class="rate_limit",
+            finished_at=finished_at,
+            retry_after=retry_after,
+        ),
+    )
+
+
 def _execute_claimed(
     database: sqlite3.Connection,
     claimed: ClaimedOperation,
@@ -149,27 +180,42 @@ def _execute_claimed(
         )
     try:
         provider.verify_identity()
+    except ProviderRateLimitError as error:
+        return _rate_limited_provider_outcome(
+            database, claimed, executor_id, "failed", error, args
+        )
     except ProviderIdentityError:
         return _pre_provider_failure(
             database, claimed, executor_id, "identity", args
         )
 
+    provider_started_at = _clock(args)
     try:
         mark_provider_started(
-            database, claimed, executor_id, started_at=_clock(args)
+            database, claimed, executor_id, started_at=provider_started_at
         )
     except SocialStoreError:
+        deferred = defer_claim_for_cooldown(
+            database, claimed, executor_id, provider_started_at
+        )
+        if deferred is not None:
+            return deferred
         return _pre_provider_failure(
             database, claimed, executor_id, "authorization", args
         )
 
-    if claimed.provider == "youtube":
-        checkpoint = lambda checkpoint_id: record_provider_checkpoint(
-            database, claimed, executor_id, checkpoint_id
+    try:
+        if claimed.provider == "youtube":
+            checkpoint = lambda checkpoint_id: record_provider_checkpoint(
+                database, claimed, executor_id, checkpoint_id
+            )
+            provider_remote_id, failure_class = provider.invoke(checkpoint)
+        else:
+            provider_remote_id, failure_class = provider.invoke()
+    except ProviderRateLimitError as error:
+        return _rate_limited_provider_outcome(
+            database, claimed, executor_id, "unknown", error, args
         )
-        provider_remote_id, failure_class = provider.invoke(checkpoint)
-    else:
-        provider_remote_id, failure_class = provider.invoke()
     if failure_class is not None:
         return _unknown_provider_outcome(
             database,

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -42,8 +42,8 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 7
-SCHEMA_VERSION_SQL = "PRAGMA user_version=7"
+SCHEMA_VERSION = 8
+SCHEMA_VERSION_SQL = "PRAGMA user_version=8"
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
 
@@ -232,8 +232,38 @@ def _tables() -> tuple[str, ...]:
             provider_remote_id TEXT, failure_class TEXT, diagnostics TEXT,
             CHECK(provider_started_at IS NULL OR provider_started_at>=started_at),
             CHECK((status='running' AND finished_at IS NULL) OR
-                  (status!='running' AND finished_at IS NOT NULL)),
+                   (status!='running' AND finished_at IS NOT NULL)),
             UNIQUE(operation_id, claim_token))""",
+        """CREATE TABLE IF NOT EXISTS outbound_reconciliations (
+            reconciliation_id TEXT PRIMARY KEY,
+            operation_id TEXT NOT NULL REFERENCES outbound_operations(operation_id),
+            attempt_id TEXT NOT NULL REFERENCES outbound_attempts(attempt_id),
+            principal_id TEXT NOT NULL,
+            outcome TEXT NOT NULL CHECK(outcome IN ('succeeded','not-sent')),
+            resolved_state TEXT NOT NULL CHECK(resolved_state IN ('succeeded','failed')),
+            provider_remote_id TEXT, reconciled_at INTEGER NOT NULL,
+            original_status TEXT NOT NULL CHECK(original_status='unknown'),
+            original_failure_class TEXT NOT NULL, original_provider_remote_id TEXT,
+            original_finished_at INTEGER NOT NULL, original_diagnostics TEXT,
+            UNIQUE(operation_id, attempt_id),
+            CHECK(
+                (outcome='succeeded' AND resolved_state='succeeded' AND
+                 provider_remote_id IS NOT NULL) OR
+                (outcome='not-sent' AND resolved_state='failed' AND
+                provider_remote_id IS NULL)
+            ))""",
+        """CREATE TRIGGER IF NOT EXISTS outbound_unknown_attempts_no_update
+            BEFORE UPDATE ON outbound_attempts WHEN OLD.status='unknown'
+            BEGIN SELECT RAISE(ABORT,'unknown outbound receipts are immutable'); END""",
+        """CREATE TRIGGER IF NOT EXISTS outbound_unknown_attempts_no_delete
+            BEFORE DELETE ON outbound_attempts WHEN OLD.status='unknown'
+            BEGIN SELECT RAISE(ABORT,'unknown outbound receipts are immutable'); END""",
+        """CREATE TRIGGER IF NOT EXISTS outbound_reconciliations_no_update
+            BEFORE UPDATE ON outbound_reconciliations
+            BEGIN SELECT RAISE(ABORT,'outbound reconciliation receipts are immutable'); END""",
+        """CREATE TRIGGER IF NOT EXISTS outbound_reconciliations_no_delete
+            BEFORE DELETE ON outbound_reconciliations
+            BEGIN SELECT RAISE(ABORT,'outbound reconciliation receipts are immutable'); END""",
         """CREATE TABLE IF NOT EXISTS notification_state (
             notification_id TEXT PRIMARY KEY, principal_id TEXT NOT NULL,
             provider TEXT NOT NULL, connection_id TEXT NOT NULL,
@@ -250,6 +280,7 @@ def _tables() -> tuple[str, ...]:
         "CREATE INDEX IF NOT EXISTS idx_reconciliation_status ON reconciliation_items(connection_id, stream, status)",
         "CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_operations(state,scheduled_at,operation_id)",
         "CREATE INDEX IF NOT EXISTS idx_outbound_approvals ON outbound_approvals(operation_id,expires_at,revoked_at)",
+        "CREATE INDEX IF NOT EXISTS idx_outbound_reconciliations ON outbound_reconciliations(operation_id,reconciled_at)",
         "CREATE INDEX IF NOT EXISTS idx_notification_status ON notification_state(principal_id,status,updated_at)",
     )
 

--- a/.agents/scripts/social-provider-health.py
+++ b/.agents/scripts/social-provider-health.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Report social provider readiness and reconcile content-free receipts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_outbound import OUTBOUND_PROVIDER_ACTIONS
+from _knowledge_social_outbound_reconciliation import ReconciliationRequest
+from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    connect_read_only,
+    migrate,
+    require_schema,
+    validate_root,
+)
+from social_provider_health import (
+    DEFAULT_STALE_SECONDS,
+    build_health_report,
+    reconcile_provider_receipts,
+    render_human,
+    require_health_schema,
+    write_snapshot,
+)
+
+DEFAULT_BASE = Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+MAX_DECISION_BYTES = 1024 * 1024
+
+
+class ProviderHealthError(RuntimeError):
+    """Raised for privacy-safe provider health command failures."""
+
+
+def _clock(args: argparse.Namespace) -> int:
+    override = args.now_epoch
+    if override is not None:
+        if os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+            raise ProviderHealthError("test clocks are disabled outside the test harness")
+        if override < 0:
+            raise ProviderHealthError("test clock must be a non-negative epoch")
+        return override
+    return int(time.time())
+
+
+def _context(args: argparse.Namespace, capability: str) -> tuple[str, Path]:
+    principal_id, corpora = authorized_scope(
+        args.base or DEFAULT_BASE, capability, args.alias
+    )
+    return principal_id, validate_root(corpora[0][1])
+
+
+def _decision_document(path: Path) -> list[dict[str, Any]]:
+    validate_private_file(path, "social reconciliation decision file", repair=False)
+    if path.stat().st_size > MAX_DECISION_BYTES:
+        raise ProviderHealthError("social reconciliation decisions exceed the size limit")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ProviderHealthError(
+            "social reconciliation decisions are not valid private JSON"
+        ) from error
+    if not isinstance(value, list):
+        raise ProviderHealthError("social reconciliation decisions must be an array")
+    if any(not isinstance(item, dict) for item in value):
+        raise ProviderHealthError("social reconciliation decision must be an object")
+    return value
+
+
+def _decisions(
+    path: Path | None, principal_id: str, reconciled_at: int
+) -> tuple[ReconciliationRequest, ...]:
+    if path is None:
+        return ()
+    decisions: list[ReconciliationRequest] = []
+    for item in _decision_document(path):
+        if set(item) - {"operation_id", "outcome", "provider_id"}:
+            raise ProviderHealthError("social reconciliation decision has unknown fields")
+        operation_id = item.get("operation_id")
+        outcome = item.get("outcome")
+        provider_id = item.get("provider_id")
+        if not isinstance(operation_id, str) or outcome not in ("succeeded", "not-sent"):
+            raise ProviderHealthError("social reconciliation decision is invalid")
+        if provider_id is not None and not isinstance(provider_id, str):
+            raise ProviderHealthError("social reconciliation provider ID must be text")
+        decisions.append(
+            ReconciliationRequest(
+                operation_id,
+                principal_id,
+                outcome,
+                provider_id,
+                reconciled_at,
+            )
+        )
+    return tuple(decisions)
+
+
+def _health(args: argparse.Namespace, now: int) -> tuple[dict[str, Any], bool]:
+    capability = "knowledge.manage" if args.command == "collect" else "knowledge.read"
+    principal_id, root = _context(args, capability)
+    writable = args.command == "collect"
+    database = connect(root) if writable else connect_read_only(root)
+    try:
+        if writable:
+            migrate(database)
+            require_schema(database)
+        else:
+            require_health_schema(database)
+        report = build_health_report(
+            database,
+            principal_id,
+            now,
+            stale_seconds=args.stale_seconds,
+            provider=args.provider,
+        )
+    finally:
+        database.close()
+    if args.command == "collect":
+        write_snapshot(root / "state" / "social-provider-health.json", report)
+    return report, args.command == "report"
+
+
+def _reconcile(args: argparse.Namespace, now: int) -> dict[str, Any]:
+    principal_id, root = _context(args, "knowledge.manage")
+    database = connect(root)
+    try:
+        migrate(database)
+        require_schema(database)
+        decisions = _decisions(args.decisions_file, principal_id, now)
+        if len(decisions) > args.limit:
+            raise ProviderHealthError(
+                "social reconciliation decisions exceed the invocation limit"
+            )
+        return reconcile_provider_receipts(
+            database,
+            principal_id,
+            now,
+            decisions=decisions,
+            limit=args.limit,
+            per_provider_limit=args.per_provider_limit,
+        )
+    finally:
+        database.close()
+
+
+def _add_scope(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--now-epoch", type=int, help=argparse.SUPPRESS)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    for command in ("status", "collect", "report"):
+        health = commands.add_parser(command)
+        _add_scope(health)
+        health.add_argument("--provider")
+        health.add_argument("--stale-seconds", type=int, default=DEFAULT_STALE_SECONDS)
+    reconcile = commands.add_parser("reconcile")
+    _add_scope(reconcile)
+    reconcile.add_argument("--decisions-file", type=Path)
+    reconcile.add_argument("--limit", type=int, default=10)
+    reconcile.add_argument("--per-provider-limit", type=int, default=3)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        now = _clock(args)
+        if args.command == "reconcile":
+            print(json.dumps(_reconcile(args, now), sort_keys=True))
+        else:
+            report, human = _health(args, now)
+            print(render_human(report) if human else json.dumps(report, sort_keys=True))
+        return 0
+    except (
+        CatalogError,
+        OSError,
+        ProviderHealthError,
+        SocialStoreError,
+        sqlite3.Error,
+        ValueError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/social_provider_health.py
+++ b/.agents/scripts/social_provider_health.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Content-free social provider readiness and receipt reconciliation."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from _knowledge_social_outbound import OUTBOUND_PROVIDER_ACTIONS
+from _knowledge_social_outbound_reconciliation import (
+    ReconciliationRequest,
+    bounded_reconcile,
+)
+from _knowledge_social_outbound_runtime import (
+    active_connection_cooldown,
+    outbound_health_rows,
+)
+from knowledge_social_registry import (
+    PROVIDERS,
+    ProviderRegistryError,
+    resolve_provider,
+)
+from knowledge_social_store import SCHEMA_VERSION, SocialStoreError
+
+SCHEMA = "aidevops.social-provider-health/v1"
+DEFAULT_STALE_SECONDS = 86_400
+UNWIRED_WRITE_PROVIDERS = frozenset(
+    ("meta_facebook", "meta_instagram", "meta_threads", "tiktok")
+)
+QUEUE_STATES = (
+    "draft",
+    "approved",
+    "claimed",
+    "succeeded",
+    "failed",
+    "unknown",
+    "cancelled",
+)
+DIMENSIONS = (
+    "catalogued",
+    "deployed",
+    "installed",
+    "configured",
+    "enabled",
+    "authenticated",
+    "authorized",
+    "reachable",
+    "runtime_compatible",
+    "tool_visible",
+    "usable",
+)
+CATALOGUED_PROVIDER_IDS = frozenset((*PROVIDERS, *OUTBOUND_PROVIDER_ACTIONS))
+MIN_HEALTH_SCHEMA_VERSION = 7
+
+
+def require_health_schema(database: sqlite3.Connection) -> None:
+    """Accept the read-compatible pre-reconciliation schema or current schema."""
+    version = int(database.execute("PRAGMA user_version").fetchone()[0])
+    if version < MIN_HEALTH_SCHEMA_VERSION or version > SCHEMA_VERSION:
+        raise SocialStoreError(
+            "social provider health requires schema version "
+            f"{MIN_HEALTH_SCHEMA_VERSION} through {SCHEMA_VERSION}"
+        )
+
+
+def _json_object(value: str, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SocialStoreError(f"stored social {label} is invalid") from error
+    if not isinstance(parsed, dict):
+        raise SocialStoreError(f"stored social {label} must be an object")
+    return parsed
+
+
+def _json_array(value: str, label: str) -> list[str]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SocialStoreError(f"stored social {label} is invalid") from error
+    if not isinstance(parsed, list) or any(not isinstance(item, str) for item in parsed):
+        raise SocialStoreError(f"stored social {label} must be an array of text")
+    return sorted(set(parsed))
+
+
+def _stale_seconds(row: sqlite3.Row, fallback: int) -> int:
+    policy = _json_object(str(row["policy_json"]), "health policy")
+    value = policy.get("health_stale_seconds", fallback)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 60:
+        raise SocialStoreError(
+            "stored social health_stale_seconds must be an integer of at least 60"
+        )
+    return value
+
+
+def _connections(database: sqlite3.Connection) -> list[sqlite3.Row]:
+    return database.execute(
+        "SELECT connection_id,provider,auth_profile_ref,enabled_streams,policy_json "
+        "FROM connections ORDER BY provider,connection_id"
+    ).fetchall()
+
+
+def _latest_sync(
+    database: sqlite3.Connection, connection_id: str
+) -> sqlite3.Row | None:
+    return database.execute(
+        """SELECT status,failure_class,retry_after,started_at,completed_at
+             FROM sync_runs WHERE connection_id=?
+             ORDER BY COALESCE(completed_at,started_at,0) DESC,rowid DESC LIMIT 1""",
+        (connection_id,),
+    ).fetchone()
+
+
+def _latest_stream_sync(
+    database: sqlite3.Connection, connection_id: str, stream: str
+) -> sqlite3.Row | None:
+    return database.execute(
+        """SELECT status,failure_class,retry_after,started_at,completed_at
+             FROM sync_runs WHERE connection_id=? AND stream=?
+             ORDER BY COALESCE(completed_at,started_at,0) DESC,rowid DESC LIMIT 1""",
+        (connection_id, stream),
+    ).fetchone()
+
+
+def _canonical_provider(provider: str) -> str:
+    try:
+        return resolve_provider(provider).provider
+    except ProviderRegistryError:
+        return provider
+
+
+def _queue(rows: list[dict[str, Any]], now: int) -> dict[str, int]:
+    result = {state: 0 for state in QUEUE_STATES}
+    for row in rows:
+        state = str(row["state"])
+        if state in result:
+            result[state] += 1
+    result["due"] = sum(
+        row["state"] == "approved"
+        and int(row["scheduled_at"]) <= now
+        and bool(row["has_current_approval"])
+        for row in rows
+    )
+    result["leased"] = sum(row["state"] == "claimed" for row in rows)
+    result["total"] = len(rows)
+    return result
+
+
+def _evidence(
+    sync: sqlite3.Row | None, rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    events: list[tuple[int, str, str | None, bool]] = []
+    successes: list[int] = []
+    failures: list[tuple[int, str]] = []
+    if sync is not None:
+        observed_at = int(sync["completed_at"] or sync["started_at"] or 0)
+        status = str(sync["status"])
+        failure = sync["failure_class"]
+        reached = status in ("complete", "partial") or failure == "rate_limit"
+        if observed_at:
+            events.append((observed_at, status, failure, reached))
+        if status in ("complete", "partial") and observed_at:
+            successes.append(observed_at)
+        if failure is not None and observed_at:
+            failures.append((observed_at, str(failure)))
+    for row in rows:
+        observed_at = int(row["finished_at"] or 0)
+        status = row["attempt_status"]
+        failure = row["failure_class"]
+        reached = status == "succeeded" or (
+            failure == "rate_limit" and row["provider_started_at"] is not None
+        )
+        if status is not None and observed_at:
+            events.append((observed_at, str(status), failure, reached))
+        if status == "succeeded" and observed_at:
+            successes.append(observed_at)
+        if failure is not None and observed_at:
+            failures.append((observed_at, str(failure)))
+    latest = max(events, default=None, key=lambda event: event[0])
+    latest_failure = max(failures, default=None, key=lambda event: event[0])
+    return {
+        "evidence_at": latest[0] if latest else None,
+        "latest_status": latest[1] if latest else None,
+        "latest_failure": latest[2] if latest else None,
+        "latest_reached": latest[3] if latest else None,
+        "last_success_at": max(successes, default=None),
+        "last_failure_class": latest_failure[1] if latest_failure else None,
+    }
+
+
+def _dimensions(
+    *,
+    configured: bool,
+    enabled: bool,
+    authenticated: bool | None,
+    authorized: bool,
+    reachable: bool | None,
+    usable: bool,
+    catalogued: bool = True,
+    deployed: bool = True,
+    installed: bool = True,
+    runtime_compatible: bool = True,
+    tool_visible: bool = True,
+) -> dict[str, bool | None]:
+    return {
+        "catalogued": catalogued,
+        "deployed": deployed,
+        "installed": installed,
+        "configured": configured,
+        "enabled": enabled,
+        "authenticated": authenticated,
+        "authorized": authorized,
+        "reachable": reachable,
+        "runtime_compatible": runtime_compatible,
+        "tool_visible": tool_visible,
+        "usable": usable,
+    }
+
+
+def _aggregate_dimensions(records: list[dict[str, Any]]) -> dict[str, bool | None]:
+    result: dict[str, bool | None] = {}
+    for dimension in DIMENSIONS:
+        values = [record["dimensions"][dimension] for record in records]
+        result[dimension] = (
+            True if True in values else False if False in values else None
+        )
+    return result
+
+
+def _readiness_status(
+    dimensions: dict[str, bool | None],
+    *,
+    ambiguous: bool,
+    cooldown: bool,
+    stale: bool,
+) -> str:
+    if not dimensions["configured"]:
+        return "unconfigured"
+    if dimensions["authenticated"] is False:
+        return "unauthenticated"
+    if ambiguous:
+        return "ambiguous"
+    if cooldown:
+        return "rate_limited"
+    if dimensions["reachable"] is False:
+        return "unreachable"
+    if stale:
+        return "stale"
+    if dimensions["usable"]:
+        return "usable"
+    if dimensions["authenticated"] is None or dimensions["reachable"] is None:
+        return "unknown"
+    if not dimensions["authorized"]:
+        return "awaiting_approval"
+    return "ready"
+
+
+def _next_action(status: str, mode: str = "aggregate") -> str:
+    if status == "usable" and mode == "read":
+        return "collect_enabled_stream"
+    return {
+        "unconfigured": "configure_selected_account",
+        "unauthenticated": "refresh_authentication",
+        "ambiguous": "reconcile_unknown_receipt",
+        "rate_limited": "wait_for_provider_reset",
+        "unreachable": "inspect_provider_availability",
+        "stale": "refresh_provider_health",
+        "usable": "execute_approved_intent",
+        "awaiting_approval": "create_and_approve_intent",
+        "ready": "wait_for_due_operation",
+        "partial": "inspect_account_evidence",
+        "unknown": "run_provider_preflight",
+    }[status]
+
+
+def _fallback(status: str) -> str:
+    if status == "rate_limited":
+        return "wait_without_retry"
+    if status == "ambiguous":
+        return "owner_reconciliation_required"
+    return "gated_no_mutation"
+
+
+def _authentication(
+    configured: bool, evidence: dict[str, Any]
+) -> tuple[bool | None, bool | None]:
+    if not configured:
+        return False, None
+    failure = evidence["latest_failure"]
+    if failure in ("authorization", "identity"):
+        return False, None
+    if evidence["latest_reached"] is True:
+        return True, True
+    if failure == "provider_unavailable":
+        return None, False
+    return None, None
+
+
+def _freshness(
+    evidence: dict[str, Any], now: int, stale_after: int
+) -> tuple[dict[str, int | bool | None], bool]:
+    evidence_at = evidence["evidence_at"]
+    lag = max(0, now - evidence_at) if evidence_at is not None else None
+    stale = lag is not None and lag > stale_after
+    return (
+        {
+            "evidence_at": evidence_at,
+            "lag_seconds": lag,
+            "stale_after_seconds": stale_after,
+            "stale": stale,
+        },
+        stale,
+    )
+
+
+def _read_action_record(
+    database: sqlite3.Connection,
+    connection_id: str,
+    action: str,
+    now: int,
+    configured: bool,
+    cooldown: bool,
+    quota: dict[str, int | bool | None],
+    stale_after: int,
+) -> dict[str, Any]:
+    evidence = _evidence(
+        _latest_stream_sync(database, connection_id, action), []
+    )
+    authenticated, reachable = _authentication(configured, evidence)
+    freshness, stale = _freshness(evidence, now, stale_after)
+    authorized = authenticated is True and reachable is True
+    usable = bool(authorized and not cooldown and not stale)
+    dimensions = _dimensions(
+        configured=configured,
+        enabled=True,
+        authenticated=authenticated,
+        authorized=authorized,
+        reachable=reachable,
+        usable=usable,
+    )
+    status = _readiness_status(
+        dimensions, ambiguous=False, cooldown=cooldown, stale=stale
+    )
+    return {
+        "action": action,
+        "mode": "read",
+        "dimensions": dimensions,
+        "queue": _queue([], now),
+        "quota": dict(quota),
+        "freshness": freshness,
+        "status": status,
+        "fallback": _fallback(status),
+        "next_action": _next_action(status, "read"),
+    }
+
+
+def _write_action_record(
+    provider: str,
+    action: str,
+    rows: list[dict[str, Any]],
+    now: int,
+    configured: bool,
+    enabled: bool,
+    cooldown: bool,
+    quota: dict[str, int | bool | None],
+    stale_after: int,
+) -> dict[str, Any]:
+    action_rows = [row for row in rows if row["action"] == action]
+    queue = _queue(action_rows, now)
+    evidence = _evidence(None, action_rows)
+    authenticated, reachable = _authentication(configured, evidence)
+    if provider in UNWIRED_WRITE_PROVIDERS:
+        reachable = False
+    freshness, stale = _freshness(evidence, now, stale_after)
+    authorized = any(
+        row["state"] in ("approved", "claimed") and row["has_current_approval"]
+        for row in action_rows
+    )
+    usable = bool(
+        queue["due"]
+        and configured
+        and authenticated is True
+        and reachable is True
+        and authorized
+        and not cooldown
+        and not stale
+        and queue["unknown"] == 0
+    )
+    dimensions = _dimensions(
+        configured=configured,
+        enabled=enabled,
+        authenticated=authenticated,
+        authorized=authorized,
+        reachable=reachable,
+        usable=usable,
+    )
+    status = _readiness_status(
+        dimensions,
+        ambiguous=queue["unknown"] > 0,
+        cooldown=cooldown,
+        stale=stale,
+    )
+    return {
+        "action": action,
+        "mode": "write",
+        "dimensions": dimensions,
+        "queue": queue,
+        "quota": dict(quota),
+        "freshness": dict(freshness),
+        "status": status,
+        "fallback": _fallback(status),
+        "next_action": _next_action(status),
+    }
+
+
+def _aggregate_status(records: list[dict[str, Any]]) -> str:
+    statuses = {str(record["status"]) for record in records}
+    if len(statuses) == 1:
+        return next(iter(statuses))
+    if statuses and statuses <= {"ready", "usable"}:
+        return "usable" if "usable" in statuses else "ready"
+    return "partial"
+
+
+def _account_record(
+    database: sqlite3.Connection,
+    row: sqlite3.Row,
+    operations: list[dict[str, Any]],
+    now: int,
+    fallback_stale_seconds: int,
+) -> dict[str, Any]:
+    read_actions = _json_array(str(row["enabled_streams"]), "enabled streams")
+    provider = str(row["provider"])
+    write_actions = list(OUTBOUND_PROVIDER_ACTIONS.get(provider, ()))
+    configured = row["auth_profile_ref"] is not None
+    enabled = bool(read_actions or write_actions or operations)
+    sync = _latest_sync(database, str(row["connection_id"]))
+    evidence = _evidence(sync, operations)
+    stale_after = _stale_seconds(row, fallback_stale_seconds)
+    freshness, stale = _freshness(evidence, now, stale_after)
+    cooldown_until = active_connection_cooldown(
+        database, str(row["connection_id"]), now
+    )
+    cooldown = cooldown_until is not None
+    quota: dict[str, int | bool | None] = {
+        "remaining": None,
+        "limit": None,
+        "reset_at": cooldown_until,
+        "cooldown": cooldown,
+    }
+    actions = [
+        _read_action_record(
+            database,
+            str(row["connection_id"]),
+            action,
+            now,
+            configured,
+            cooldown,
+            quota,
+            stale_after,
+        )
+        for action in read_actions
+    ]
+    actions.extend(
+        _write_action_record(
+            provider,
+            action,
+            operations,
+            now,
+            configured,
+            enabled,
+            cooldown,
+            quota,
+            stale_after,
+        )
+        for action in write_actions
+    )
+    queue = _queue(operations, now)
+    if actions:
+        dimensions = _aggregate_dimensions(actions)
+        status = _aggregate_status(actions)
+    else:
+        authenticated, reachable = _authentication(configured, evidence)
+        dimensions = _dimensions(
+            configured=configured,
+            enabled=enabled,
+            authenticated=authenticated,
+            authorized=False,
+            reachable=reachable,
+            usable=False,
+        )
+        status = _readiness_status(
+            dimensions,
+            ambiguous=queue["unknown"] > 0,
+            cooldown=cooldown,
+            stale=stale,
+        )
+    return {
+        "account_alias": str(row["connection_id"]),
+        "status": status,
+        "dimensions": dimensions,
+        "supported_actions": {
+            "read": read_actions,
+            "write": write_actions,
+        },
+        "actions": actions,
+        "queue": queue,
+        "quota": quota,
+        "freshness": freshness,
+        "last_success_at": evidence["last_success_at"],
+        "last_failure_class": evidence["last_failure_class"],
+        "fallback": _fallback(status),
+        "next_action": _next_action(
+            status, "read" if read_actions and not write_actions else "aggregate"
+        ),
+    }
+
+
+def _sum_queues(accounts: list[dict[str, Any]]) -> dict[str, int]:
+    keys = (*QUEUE_STATES, "due", "leased", "total")
+    return {
+        key: sum(int(account["queue"][key]) for account in accounts) for key in keys
+    }
+
+
+def _provider_dimensions(
+    provider: str, accounts: list[dict[str, Any]]
+) -> dict[str, bool | None]:
+    if not accounts:
+        spec = PROVIDERS.get(provider)
+        deployed = provider in OUTBOUND_PROVIDER_ACTIONS or (
+            spec is not None and spec.entrypoint is not None
+        )
+        return _dimensions(
+            configured=False,
+            enabled=False,
+            authenticated=None,
+            authorized=False,
+            reachable=None,
+            usable=False,
+            deployed=deployed,
+            installed=deployed,
+            tool_visible=deployed,
+        )
+    return _aggregate_dimensions(accounts)
+
+
+def _provider_status(accounts: list[dict[str, Any]]) -> str:
+    if not accounts:
+        return "unconfigured"
+    return _aggregate_status(accounts)
+
+
+def _provider_record(provider: str, accounts: list[dict[str, Any]]) -> dict[str, Any]:
+    status = _provider_status(accounts)
+    latest_account = max(
+        accounts,
+        default=None,
+        key=lambda account: account["freshness"]["evidence_at"] or 0,
+    )
+    read_actions = sorted(
+        {
+            action
+            for account in accounts
+            for action in account["supported_actions"]["read"]
+        }
+    )
+    reset_values = [
+        account["quota"]["reset_at"]
+        for account in accounts
+        if account["quota"]["reset_at"] is not None
+    ]
+    return {
+        "provider_id": provider,
+        "status": status,
+        "dimensions": _provider_dimensions(provider, accounts),
+        "supported_actions": {
+            "read": read_actions,
+            "write": list(OUTBOUND_PROVIDER_ACTIONS.get(provider, ())),
+        },
+        "accounts": accounts,
+        "queue": _sum_queues(accounts),
+        "quota": {
+            "remaining": None,
+            "limit": None,
+            "reset_at": max(reset_values, default=None),
+            "cooldown": bool(reset_values),
+        },
+        "freshness": (
+            dict(latest_account["freshness"])
+            if latest_account
+            else {
+                "evidence_at": None,
+                "lag_seconds": None,
+                "stale_after_seconds": None,
+                "stale": False,
+            }
+        ),
+        "last_success_at": max(
+            (
+                account["last_success_at"]
+                for account in accounts
+                if account["last_success_at"] is not None
+            ),
+            default=None,
+        ),
+        "last_failure_class": (
+            latest_account["last_failure_class"] if latest_account else None
+        ),
+        "fallback": _fallback(status),
+        "next_action": _next_action(
+            status,
+            "read"
+            if read_actions and provider not in OUTBOUND_PROVIDER_ACTIONS
+            else "aggregate",
+        ),
+    }
+
+
+def _global_status(providers: list[dict[str, Any]]) -> str:
+    configured = [
+        provider
+        for provider in providers
+        if provider["dimensions"]["configured"] is True
+    ]
+    if not configured:
+        return "unconfigured"
+    if any(provider["status"] == "partial" for provider in configured):
+        return "partial"
+    usable = [provider for provider in configured if provider["dimensions"]["usable"]]
+    if len(usable) == len(configured):
+        return "healthy"
+    if usable or len({provider["status"] for provider in configured}) > 1:
+        return "partial"
+    return "blocked"
+
+
+def build_health_report(
+    database: sqlite3.Connection,
+    principal_id: str,
+    now_epoch: int,
+    *,
+    stale_seconds: int = DEFAULT_STALE_SECONDS,
+    provider: str | None = None,
+) -> dict[str, Any]:
+    """Build one deterministic report from existing local content-free evidence."""
+    if now_epoch < 0:
+        raise SocialStoreError("health time must be a non-negative epoch")
+    if stale_seconds < 60:
+        raise SocialStoreError("health stale_seconds must be at least 60")
+    operation_rows = outbound_health_rows(database, principal_id, now_epoch)
+    by_connection: dict[str, list[dict[str, Any]]] = {}
+    for operation in operation_rows:
+        by_connection.setdefault(str(operation["connection_id"]), []).append(operation)
+    connections = _connections(database)
+    provider_catalogue = set(CATALOGUED_PROVIDER_IDS)
+    provider_catalogue.update(
+        _canonical_provider(str(connection["provider"])) for connection in connections
+    )
+    requested_provider = _canonical_provider(provider) if provider is not None else None
+    if requested_provider is not None and requested_provider not in provider_catalogue:
+        raise SocialStoreError("social health provider is unsupported")
+    accounts_by_provider: dict[str, list[dict[str, Any]]] = {
+        provider_id: [] for provider_id in provider_catalogue
+    }
+    for connection in connections:
+        provider_id = _canonical_provider(str(connection["provider"]))
+        account = _account_record(
+            database,
+            connection,
+            by_connection.get(str(connection["connection_id"]), []),
+            now_epoch,
+            stale_seconds,
+        )
+        accounts_by_provider[provider_id].append(account)
+    provider_ids = (
+        [requested_provider]
+        if requested_provider is not None
+        else sorted(accounts_by_provider)
+    )
+    providers = [
+        _provider_record(provider_id, accounts_by_provider[provider_id])
+        for provider_id in provider_ids
+    ]
+    status = _global_status(providers)
+    return {
+        "schema": SCHEMA,
+        "generated_at": now_epoch,
+        "status": status,
+        "partial": status == "partial",
+        "summary": {
+            "catalogued_providers": len(providers),
+            "configured_providers": sum(
+                provider_record["dimensions"]["configured"] is True
+                for provider_record in providers
+            ),
+            "usable_providers": sum(
+                provider_record["dimensions"]["usable"] is True
+                for provider_record in providers
+            ),
+            "queued_operations": sum(
+                provider_record["queue"]["total"] for provider_record in providers
+            ),
+            "unresolved_unknown_receipts": sum(
+                provider_record["queue"]["unknown"] for provider_record in providers
+            ),
+        },
+        "providers": providers,
+    }
+
+
+def connection_cooldowns(
+    database: sqlite3.Connection, now_epoch: int
+) -> dict[str, int]:
+    """Return active persisted reset boundaries by exact account connection."""
+    result: dict[str, int] = {}
+    for connection in _connections(database):
+        connection_id = str(connection["connection_id"])
+        reset_at = active_connection_cooldown(
+            database, connection_id, now_epoch
+        )
+        if reset_at is not None:
+            result[connection_id] = reset_at
+    return result
+
+
+def reconcile_provider_receipts(
+    database: sqlite3.Connection,
+    principal_id: str,
+    now_epoch: int,
+    *,
+    decisions: Iterable[ReconciliationRequest] = (),
+    cooldowns: Mapping[str, int] | None = None,
+    limit: int = 10,
+    per_provider_limit: int = 3,
+) -> dict[str, Any]:
+    """Run one bounded local reconciliation pass without provider mutation."""
+    active_cooldowns = (
+        connection_cooldowns(database, now_epoch) if cooldowns is None else cooldowns
+    )
+    return bounded_reconcile(
+        database,
+        principal_id,
+        now_epoch,
+        decisions=decisions,
+        cooldowns=active_cooldowns,
+        limit=limit,
+        per_provider_limit=per_provider_limit,
+    )
+
+
+def write_snapshot(path: Path, report: dict[str, Any]) -> None:
+    """Atomically persist an owner-only health snapshot."""
+    if path.exists() and path.is_symlink():
+        raise SocialStoreError("social provider health snapshot cannot be a symlink")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=".social-provider-health-", dir=path.parent
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def render_human(report: dict[str, Any]) -> str:
+    """Render a compact content-free operator summary."""
+    summary = report["summary"]
+    lines = [
+        f"Social provider health: {report['status']}",
+        (
+            "Providers: "
+            f"{summary['usable_providers']} usable / "
+            f"{summary['configured_providers']} configured / "
+            f"{summary['catalogued_providers']} catalogued"
+        ),
+        (
+            "Queue: "
+            f"{summary['queued_operations']} operations, "
+            f"{summary['unresolved_unknown_receipts']} unknown receipts"
+        ),
+    ]
+    for provider in report["providers"]:
+        lines.append(
+            f"- {provider['provider_id']}: {provider['status']} "
+            f"({provider['next_action']})"
+        )
+        for account in provider["accounts"]:
+            lines.append(
+                f"  - {account['account_alias']}: {account['status']} "
+                f"({account['next_action']})"
+            )
+    return "\n".join(lines)

--- a/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
+++ b/.agents/scripts/tests/test-social-linkedin-youtube-outbound.py
@@ -6,16 +6,25 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import secrets
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from email.message import Message
 from pathlib import Path
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 from _knowledge_social_linkedin_outbound_provider import LinkedInPreparedProvider
 from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import (
+    MAX_PROVIDER_RETRY_SECONDS,
+    ProviderRateLimitError,
+    provider_retry_seconds,
+    redirect_free_provider_open,
+)
 from _knowledge_social_youtube_outbound_provider import YouTubePreparedProvider
 
 FIXTURE_ACCESS_TOKEN = secrets.token_hex(24)
@@ -59,6 +68,32 @@ def claimed(provider: str, **values: str | None) -> ClaimedOperation:
 
 
 class OutboundProviderTests(unittest.TestCase):
+    def test_retry_after_duration_is_validated_and_bounded(self) -> None:
+        self.assertEqual(2, provider_retry_seconds("1.5"))
+        self.assertEqual(
+            MAX_PROVIDER_RETRY_SECONDS,
+            provider_retry_seconds(str(MAX_PROVIDER_RETRY_SECONDS * 2)),
+        )
+        self.assertIsNone(provider_retry_seconds("-1"))
+        self.assertIsNone(provider_retry_seconds("not-a-duration"))
+        current_time = datetime(2026, 8, 14, 11, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(
+            3600,
+            provider_retry_seconds(
+                "Fri, 14 Aug 2026 12:00:00 GMT", current_time=current_time
+            ),
+        )
+
+    def test_provider_defaults_reject_authorization_bearing_redirects(self) -> None:
+        self.assertIs(
+            redirect_free_provider_open,
+            LinkedInPreparedProvider(claimed("linkedin")).opener,
+        )
+        self.assertIs(
+            redirect_free_provider_open,
+            YouTubePreparedProvider(claimed("youtube")).opener,
+        )
+
     @patch.dict(os.environ, {"LINKEDIN_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_linkedin_identity_mismatch_prevents_post(self) -> None:
         calls: list[str] = []
@@ -71,6 +106,23 @@ class OutboundProviderTests(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "does not match"):
             provider.verify_identity()
         self.assertEqual(calls, ["GET"])
+
+    @patch.dict(os.environ, {"LINKEDIN_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
+    def test_linkedin_post_preserves_bounded_rate_limit_evidence(self) -> None:
+        responses = iter(
+            [
+                Response(200, b'{"elements":[{"member":"member_fixture"}]}'),
+                Response(429, b"", {"Retry-After": "300"}),
+            ]
+        )
+        provider = LinkedInPreparedProvider(
+            claimed("linkedin", account="member_fixture"),
+            lambda _request, **_kwargs: next(responses),
+        )
+        provider.verify_identity()
+        with self.assertRaises(ProviderRateLimitError) as raised:
+            provider.invoke()
+        self.assertEqual(300, raised.exception.retry_after_seconds)
 
     @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
     def test_youtube_upload_requires_exact_channel_and_bound_media(self) -> None:
@@ -129,6 +181,71 @@ class OutboundProviderTests(unittest.TestCase):
             )
             provider.verify_identity()
             self.assertEqual(provider.invoke(), (None, "validation"))
+
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
+    def test_youtube_upload_preserves_bounded_rate_limit_evidence(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
+            media.write(b"fixture video")
+            media.flush()
+            digest = hashlib.sha256(b"fixture video").hexdigest()
+            responses = iter(
+                [
+                    Response(200, b'{"items":[{"id":"channel_fixture"}]}'),
+                    Response(429, b"", {"Retry-After": "600"}),
+                ]
+            )
+            provider = YouTubePreparedProvider(
+                claimed(
+                    "youtube",
+                    media_path=media.name,
+                    media_sha256=digest,
+                    subject="Fixture video",
+                ),
+                lambda _request, **_kwargs: next(responses),
+            )
+            provider.verify_identity()
+            with self.assertRaises(ProviderRateLimitError) as raised:
+                provider.invoke()
+            self.assertEqual(600, raised.exception.retry_after_seconds)
+
+    @patch.dict(os.environ, {"YOUTUBE_FIXTURE_ACCESS_TOKEN": FIXTURE_ACCESS_TOKEN})
+    def test_youtube_quota_403_uses_the_rate_limit_path(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as media:
+            media.write(b"fixture video")
+            media.flush()
+            digest = hashlib.sha256(b"fixture video").hexdigest()
+            headers = Message()
+            quota_error = HTTPError(
+                "https://www.googleapis.com/upload/youtube/v3/videos",
+                403,
+                "quota",
+                headers,
+                io.BytesIO(b'{"error":{"errors":[{"reason":"quotaExceeded"}]}}'),
+            )
+            responses: list[Response | HTTPError] = [
+                Response(200, b'{"items":[{"id":"channel_fixture"}]}'),
+                quota_error,
+            ]
+
+            def opener(_request: object, **_kwargs: object) -> Response:
+                response = responses.pop(0)
+                if isinstance(response, HTTPError):
+                    raise response
+                return response
+
+            provider = YouTubePreparedProvider(
+                claimed(
+                    "youtube",
+                    media_path=media.name,
+                    media_sha256=digest,
+                    subject="Fixture video",
+                ),
+                opener,
+            )
+            provider.verify_identity()
+            with self.assertRaises(ProviderRateLimitError) as raised:
+                provider.invoke()
+            self.assertIsNone(raised.exception.retry_after_seconds)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/tests/test-social-provider-health.py
+++ b/.agents/scripts/tests/test-social-provider-health.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Health, redaction, cooldown, and reconciliation contract tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from _knowledge_collector_health import health_record
+from _knowledge_collector_model import Connection
+from _knowledge_social_outbound import (
+    OperationIntent,
+    approve_operation,
+    create_operation,
+)
+from _knowledge_social_outbound_provider import (
+    DEFAULT_PROVIDER_RETRY_SECONDS,
+    ProviderRateLimitError,
+)
+from _knowledge_social_outbound_reconciliation import ReconciliationRequest
+from _knowledge_social_outbound_runtime import (
+    AttemptOutcome,
+    ClaimRequest,
+    claim_operation,
+    defer_claim_for_cooldown,
+    due_operation_ids,
+    finalize_operation,
+    mark_provider_started,
+)
+from knowledge_corpus_catalog import provision
+from knowledge_social_operations import _execute_claimed
+from knowledge_social_store import SocialStoreError, connect, migrate
+from social_provider_health import (
+    build_health_report,
+    reconcile_provider_receipts,
+    render_human,
+    require_health_schema,
+    write_snapshot,
+)
+
+NOW = 2_000_000_000
+PRINCIPAL = "principal_fixture"
+
+
+class RateLimitedProvider:
+    """Fixture provider returning one structured post-boundary rate limit."""
+
+    @staticmethod
+    def verify_identity() -> None:
+        return None
+
+    @staticmethod
+    def invoke() -> tuple[str | None, str | None]:
+        raise ProviderRateLimitError(None)
+
+
+class SocialProviderHealthTests(unittest.TestCase):
+    """Exercise only local fixture state; no provider request is reachable."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.database = connect(self.root)
+        migrate(self.database)
+
+    def tearDown(self) -> None:
+        self.database.close()
+        self.temporary.cleanup()
+
+    def assert_schema(self, report: dict[str, object]) -> None:
+        report_path = self.root / "health-report.json"
+        report_path.write_text(json.dumps(report), encoding="utf-8")
+        schema_path = SCRIPTS.parent / "schemas" / "social-provider-health.schema.json"
+        script = (
+            "const fs=require('fs');"
+            "const Ajv=require('ajv/dist/2020').default;"
+            "const schema=JSON.parse(fs.readFileSync(process.argv[1]));"
+            "const data=JSON.parse(fs.readFileSync(process.argv[2]));"
+            "const validate=new Ajv({strict:false}).compile(schema);"
+            "if(!validate(data)){console.error(JSON.stringify(validate.errors));process.exit(1)}"
+        )
+        completed = subprocess.run(  # nosec B603 -- fixed Node schema validator
+            ["node", "-e", script, str(schema_path), str(report_path)],
+            cwd=SCRIPTS.parents[1],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+    @staticmethod
+    def downgrade_to_schema_seven(database: sqlite3.Connection) -> None:
+        database.execute("DROP TRIGGER outbound_reconciliations_no_update")
+        database.execute("DROP TRIGGER outbound_reconciliations_no_delete")
+        database.execute("DROP TRIGGER outbound_unknown_attempts_no_update")
+        database.execute("DROP TRIGGER outbound_unknown_attempts_no_delete")
+        database.execute("DROP TABLE outbound_reconciliations")
+        database.execute("PRAGMA user_version=7")
+
+    def connection(
+        self,
+        connection_id: str,
+        provider: str,
+        remote_account_id: str,
+        *,
+        configured: bool = True,
+        streams: tuple[str, ...] = ("authored",),
+    ) -> None:
+        self.database.execute(
+            "INSERT INTO connections(connection_id,provider,remote_account_id,"
+            "auth_profile_ref,enabled_streams,policy_json) VALUES(?,?,?,?,?,?)",
+            (
+                connection_id,
+                provider,
+                remote_account_id,
+                "profile_fixture" if configured else None,
+                json.dumps(streams),
+                json.dumps({"health_stale_seconds": 3600}),
+            ),
+        )
+
+    def operation(
+        self,
+        connection_id: str,
+        account_id: str,
+        operation_id: str,
+        *,
+        payload: str = "private fixture body",
+        approved: bool = True,
+        created_at: int = NOW - 30,
+    ) -> None:
+        provider = self.database.execute(
+            "SELECT provider FROM connections WHERE connection_id=?", (connection_id,)
+        ).fetchone()[0]
+        create_operation(
+            self.database,
+            OperationIntent(
+                connection_id=connection_id,
+                remote_account_id=account_id,
+                action="post",
+                target_remote_id=None,
+                destination_remote_id=(
+                    "fixture_subreddit" if provider == "reddit" else None
+                ),
+                payload=payload,
+                subject="Fixture title" if provider == "reddit" else None,
+                app_profile="profile_fixture",
+                username=None,
+                scheduled_at=created_at,
+                created_by=PRINCIPAL,
+                operation_id=operation_id,
+                created_at=created_at,
+            ),
+        )
+        if approved:
+            approve_operation(
+                self.database,
+                operation_id,
+                PRINCIPAL,
+                NOW + 3600,
+                approved_at=created_at + 1,
+            )
+
+    def finish(
+        self,
+        operation_id: str,
+        executor_id: str,
+        status: str,
+        *,
+        started_at: int = NOW - 20,
+    ) -> None:
+        claimed = claim_operation(
+            self.database,
+            ClaimRequest(operation_id, PRINCIPAL, executor_id, started_at, 300),
+        )
+        mark_provider_started(
+            self.database, claimed, executor_id, started_at=started_at + 1
+        )
+        outcome = AttemptOutcome(
+            status,
+            provider_remote_id="receipt_fixture",
+            failure_class="runtime" if status == "unknown" else None,
+            finished_at=started_at + 2,
+        )
+        finalize_operation(self.database, claimed, executor_id, outcome)
+
+    def test_readiness_is_multidimensional_and_partial(self) -> None:
+        self.connection("x_primary", "xapi", "private_x_account")
+        self.operation("x_primary", "private_x_account", "op_succeeded")
+        self.finish("op_succeeded", "executor_success", "succeeded")
+        self.operation("x_primary", "private_x_account", "op_ready")
+        self.connection("x_secondary", "xapi", "private_x_secondary")
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,"
+            "retry_after,stream,run_kind,started_at,completed_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                "run_x_secondary_rate_limit",
+                "x_secondary",
+                "paused",
+                "rate_limit",
+                str(NOW + 300),
+                "authored",
+                "sync",
+                NOW - 10,
+                NOW - 5,
+            ),
+        )
+
+        self.connection("reddit_primary", "reddit", "private_reddit_account")
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,"
+            "retry_after,stream,run_kind,started_at,completed_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                "run_rate_limit",
+                "reddit_primary",
+                "paused",
+                "rate_limit",
+                str(NOW + 600),
+                "authored",
+                "sync",
+                NOW - 10,
+                NOW - 5,
+            ),
+        )
+
+        report = build_health_report(self.database, PRINCIPAL, NOW)
+        self.assert_schema(report)
+        providers = {item["provider_id"]: item for item in report["providers"]}
+        x_accounts = {
+            item["account_alias"]: item for item in providers["xapi"]["accounts"]
+        }
+        x_account = x_accounts["x_primary"]
+        reddit_account = providers["reddit"]["accounts"][0]
+
+        self.assertEqual("partial", report["status"])
+        self.assertTrue(report["partial"])
+        self.assertEqual("x_primary", x_account["account_alias"])
+        self.assertTrue(x_account["dimensions"]["usable"])
+        self.assertEqual("partial", x_account["status"])
+        x_post = next(
+            item
+            for item in x_account["actions"]
+            if item["mode"] == "write" and item["action"] == "post"
+        )
+        self.assertEqual("usable", x_post["status"])
+        self.assertEqual("rate_limited", x_accounts["x_secondary"]["status"])
+        self.assertEqual("partial", providers["xapi"]["status"])
+        self.assertEqual("rate_limited", reddit_account["status"])
+        self.assertEqual(NOW + 600, reddit_account["quota"]["reset_at"])
+        self.assertEqual("unconfigured", providers["tiktok"]["status"])
+        self.assertIn("xapi", render_human(report))
+
+    def test_read_success_cannot_make_an_unwired_write_transport_usable(self) -> None:
+        self.connection("threads_primary", "meta_threads", "private_threads_account")
+        self.operation("threads_primary", "private_threads_account", "op_approved")
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,stream,run_kind,"
+            "started_at,completed_at) VALUES(?,?,?,?,?,?,?)",
+            (
+                "run_complete",
+                "threads_primary",
+                "complete",
+                "authored",
+                "sync",
+                NOW - 20,
+                NOW - 10,
+            ),
+        )
+
+        report = build_health_report(self.database, PRINCIPAL, NOW)
+        provider = next(
+            item for item in report["providers"] if item["provider_id"] == "meta_threads"
+        )
+        account = provider["accounts"][0]
+        post = next(item for item in account["actions"] if item["action"] == "post")
+        self.assertEqual("partial", account["status"])
+        self.assertEqual("unreachable", post["status"])
+        self.assertFalse(post["dimensions"]["usable"])
+
+    def test_output_redacts_private_values_and_isolates_accounts(self) -> None:
+        secret = "campaign-secret-that-must-never-leak"
+        self.connection("threads_one", "meta_threads", "private_account_one")
+        self.connection("threads_two", "meta_threads", "private_account_two")
+        self.operation(
+            "threads_one",
+            "private_account_one",
+            "op_unknown",
+            payload=secret,
+        )
+        self.finish("op_unknown", "executor_unknown", "unknown")
+        self.operation(
+            "threads_two",
+            "private_account_two",
+            "op_other",
+            payload="second-private-body",
+            approved=False,
+        )
+
+        report = build_health_report(self.database, PRINCIPAL, NOW)
+        encoded = json.dumps(report, sort_keys=True)
+        self.assertNotIn(secret, encoded)
+        self.assertNotIn("second-private-body", encoded)
+        self.assertNotIn("private_account_one", encoded)
+        self.assertNotIn("private_account_two", encoded)
+        self.assertNotIn("profile_fixture", encoded)
+
+        provider = next(
+            item for item in report["providers"] if item["provider_id"] == "meta_threads"
+        )
+        accounts = {item["account_alias"]: item for item in provider["accounts"]}
+        self.assertEqual(1, accounts["threads_one"]["queue"]["unknown"])
+        self.assertEqual(0, accounts["threads_two"]["queue"]["unknown"])
+        self.assertIsNone(accounts["threads_one"]["dimensions"]["authenticated"])
+        self.assertIsNot(accounts["threads_one"]["dimensions"]["reachable"], True)
+
+        snapshot = self.root / "state" / "provider-health.json"
+        write_snapshot(snapshot, report)
+        self.assertEqual(0o600, snapshot.stat().st_mode & 0o777)
+        self.assertEqual(report, json.loads(snapshot.read_text(encoding="utf-8")))
+
+    def test_reconciliation_is_bounded_cooldown_aware_and_never_requeues(self) -> None:
+        self.connection("x_primary", "xapi", "private_x_account")
+        self.operation("x_primary", "private_x_account", "op_unknown")
+        self.finish("op_unknown", "executor_unknown", "unknown")
+        self.operation(
+            "x_primary",
+            "private_x_account",
+            "op_undecided",
+            created_at=NOW - 100,
+        )
+        self.finish(
+            "op_undecided",
+            "executor_undecided",
+            "unknown",
+            started_at=NOW - 90,
+        )
+
+        self.connection("reddit_primary", "reddit", "private_reddit_account")
+        self.operation("reddit_primary", "private_reddit_account", "op_expired")
+        claim_operation(
+            self.database,
+            ClaimRequest("op_expired", PRINCIPAL, "executor_lost", NOW - 10, 1),
+        )
+        self.connection("reddit_secondary", "reddit", "private_reddit_secondary")
+        self.operation(
+            "reddit_secondary", "private_reddit_secondary", "op_secondary_unknown"
+        )
+        self.finish("op_secondary_unknown", "executor_secondary", "unknown")
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,"
+            "retry_after,stream,run_kind,started_at,completed_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                "run_old_rate_limit",
+                "reddit_primary",
+                "paused",
+                "rate_limit",
+                str(NOW + 600),
+                "authored",
+                "sync",
+                NOW - 100,
+                NOW - 90,
+            ),
+        )
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,stream,run_kind,"
+            "started_at,completed_at) VALUES(?,?,?,?,?,?,?)",
+            (
+                "run_later_success",
+                "reddit_primary",
+                "complete",
+                "authored",
+                "sync",
+                NOW - 20,
+                NOW - 10,
+            ),
+        )
+        health = build_health_report(self.database, PRINCIPAL, NOW)
+        reddit = next(
+            item for item in health["providers"] if item["provider_id"] == "reddit"
+        )
+        accounts = {item["account_alias"]: item for item in reddit["accounts"]}
+        self.assertEqual(NOW + 600, accounts["reddit_primary"]["quota"]["reset_at"])
+        self.assertIsNone(accounts["reddit_secondary"]["quota"]["reset_at"])
+        attempts_before = self.database.execute(
+            "SELECT COUNT(*) FROM outbound_attempts"
+        ).fetchone()[0]
+        unknown_evidence_before = self.database.execute(
+            "SELECT operation_id,status,failure_class,provider_remote_id,finished_at,diagnostics "
+            "FROM outbound_attempts WHERE operation_id IN (?,?) ORDER BY operation_id",
+            ("op_unknown", "op_secondary_unknown"),
+        ).fetchall()
+
+        result = reconcile_provider_receipts(
+            self.database,
+            PRINCIPAL,
+            NOW,
+            decisions=(
+                ReconciliationRequest(
+                    "op_unknown", PRINCIPAL, "succeeded", "remote_confirmed", NOW
+                ),
+                ReconciliationRequest(
+                    "op_expired", PRINCIPAL, "not-sent", None, NOW
+                ),
+                ReconciliationRequest(
+                    "op_secondary_unknown", PRINCIPAL, "not-sent", None, NOW
+                ),
+            ),
+            limit=3,
+            per_provider_limit=1,
+        )
+
+        states = dict(
+            self.database.execute(
+                "SELECT operation_id,state FROM outbound_operations"
+            ).fetchall()
+        )
+        attempts_after = self.database.execute(
+            "SELECT COUNT(*) FROM outbound_attempts"
+        ).fetchone()[0]
+        unknown_evidence_after = self.database.execute(
+            "SELECT operation_id,status,failure_class,provider_remote_id,finished_at,diagnostics "
+            "FROM outbound_attempts WHERE operation_id IN (?,?) ORDER BY operation_id",
+            ("op_unknown", "op_secondary_unknown"),
+        ).fetchall()
+        self.assertEqual("succeeded", states["op_unknown"])
+        self.assertEqual("unknown", states["op_undecided"])
+        self.assertEqual("unknown", states["op_expired"])
+        self.assertEqual("failed", states["op_secondary_unknown"])
+        self.assertEqual(attempts_before, attempts_after)
+        self.assertEqual(
+            [tuple(row) for row in unknown_evidence_before],
+            [tuple(row) for row in unknown_evidence_after],
+        )
+        self.assertEqual(["op_expired"], result["expired_claims"])
+        self.assertEqual(2, result["resolved_count"])
+        self.assertEqual("op_expired", result["skipped"][0]["operation_id"])
+        self.assertEqual("cooldown", result["skipped"][0]["reason"])
+        self.assertNotIn("approved", states.values())
+        reconciled_health = build_health_report(self.database, PRINCIPAL, NOW)
+        reconciled_providers = {
+            item["provider_id"]: item for item in reconciled_health["providers"]
+        }
+        x_account = reconciled_providers["xapi"]["accounts"][0]
+        reddit_accounts = {
+            item["account_alias"]: item
+            for item in reconciled_providers["reddit"]["accounts"]
+        }
+        self.assertEqual(NOW, x_account["last_success_at"])
+        self.assertTrue(x_account["dimensions"]["authenticated"])
+        self.assertTrue(x_account["dimensions"]["reachable"])
+        self.assertEqual(
+            "reconciled_not_sent",
+            reddit_accounts["reddit_secondary"]["last_failure_class"],
+        )
+        self.assertEqual(0, reddit_accounts["reddit_secondary"]["queue"]["unknown"])
+        self.assertEqual(1, reddit_accounts["reddit_secondary"]["queue"]["failed"])
+        audit_rows = self.database.execute(
+            "SELECT original_status,original_failure_class "
+            "FROM outbound_reconciliations ORDER BY operation_id"
+        ).fetchall()
+        self.assertEqual(
+            [("unknown", "runtime"), ("unknown", "runtime")],
+            [tuple(row) for row in audit_rows],
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.database.execute(
+                "UPDATE outbound_reconciliations SET outcome='not-sent'"
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.database.execute(
+                "UPDATE outbound_attempts SET failure_class='provider_unavailable' "
+                "WHERE operation_id='op_unknown'"
+            )
+
+    def test_read_only_provider_health_and_write_cooldown_fence(self) -> None:
+        self.connection(
+            "mastodon_primary",
+            "mastodon",
+            "private_mastodon_account",
+            streams=("authored_statuses",),
+        )
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,stream,run_kind,"
+            "started_at,completed_at) VALUES(?,?,?,?,?,?,?)",
+            (
+                "run_mastodon_complete",
+                "mastodon_primary",
+                "complete",
+                "authored_statuses",
+                "sync",
+                NOW - 20,
+                NOW - 10,
+            ),
+        )
+        mastodon_report = build_health_report(
+            self.database, PRINCIPAL, NOW, provider="mastodon"
+        )
+        self.assert_schema(mastodon_report)
+        mastodon = mastodon_report["providers"][0]
+        read_action = mastodon["accounts"][0]["actions"][0]
+        self.assertEqual("usable", mastodon["status"])
+        self.assertEqual([], mastodon["supported_actions"]["write"])
+        self.assertEqual("read", read_action["mode"])
+        self.assertTrue(read_action["dimensions"]["authorized"])
+        self.assertEqual("collect_enabled_stream", read_action["next_action"])
+
+        self.connection("x_cooldown", "xapi", "private_x_cooldown")
+        self.operation("x_cooldown", "private_x_cooldown", "op_cooldown")
+        self.connection("x_boundary", "xapi", "private_x_boundary")
+        self.operation("x_boundary", "private_x_boundary", "op_boundary")
+        boundary_claim = claim_operation(
+            self.database,
+            ClaimRequest("op_boundary", PRINCIPAL, "executor_boundary", NOW, 60),
+        )
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,"
+            "retry_after,stream,run_kind,started_at,completed_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                "run_write_cooldown",
+                "x_cooldown",
+                "paused",
+                "rate_limit",
+                str(NOW + 600),
+                "authored",
+                "sync",
+                NOW - 10,
+                NOW - 5,
+            ),
+        )
+        self.database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,"
+            "retry_after,stream,run_kind,started_at,completed_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                "run_boundary_cooldown",
+                "x_boundary",
+                "paused",
+                "rate_limit",
+                str(NOW + 600),
+                "authored",
+                "sync",
+                NOW - 10,
+                NOW - 5,
+            ),
+        )
+        self.assertEqual([], due_operation_ids(self.database, PRINCIPAL, NOW, 10))
+        with self.assertRaisesRegex(SocialStoreError, "provider cooldown"):
+            claim_operation(
+                self.database,
+                ClaimRequest("op_cooldown", PRINCIPAL, "executor_blocked", NOW, 60),
+            )
+        with self.assertRaisesRegex(SocialStoreError, "provider boundary"):
+            mark_provider_started(
+                self.database,
+                boundary_claim,
+                "executor_boundary",
+                started_at=NOW,
+            )
+        deferred = defer_claim_for_cooldown(
+            self.database, boundary_claim, "executor_boundary", NOW
+        )
+        self.assertEqual("approved", deferred["state"] if deferred else None)
+        self.assertEqual(
+            ("approved", "failed", "rate_limit", None),
+            tuple(
+                self.database.execute(
+                    "SELECT o.state,a.status,a.failure_class,a.provider_started_at "
+                    "FROM outbound_operations o JOIN outbound_attempts a "
+                    "ON a.attempt_id=o.last_attempt_id WHERE o.operation_id='op_boundary'"
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            ("approved", 0),
+            tuple(
+                self.database.execute(
+                    "SELECT state,(SELECT count(*) FROM outbound_attempts "
+                    "WHERE operation_id='op_cooldown') FROM outbound_operations "
+                    "WHERE operation_id='op_cooldown'"
+                ).fetchone()
+            ),
+        )
+
+    def test_provider_rate_limit_receipt_persists_exact_account_cooldown(self) -> None:
+        self.connection("linkedin_primary", "linkedin", "private_linkedin_account")
+        self.operation(
+            "linkedin_primary", "private_linkedin_account", "op_rate_limited"
+        )
+        self.operation("linkedin_primary", "private_linkedin_account", "op_same_account")
+        self.connection("linkedin_other", "linkedin", "private_linkedin_other")
+        self.operation("linkedin_other", "private_linkedin_other", "op_other_account")
+        claimed = claim_operation(
+            self.database,
+            ClaimRequest("op_rate_limited", PRINCIPAL, "executor_rate", NOW - 10, 60),
+        )
+        with patch.dict(os.environ, {"AIDEVOPS_TEST_MODE": "1"}), patch(
+            "knowledge_social_operations.prepare_provider",
+            return_value=RateLimitedProvider(),
+        ):
+            receipt = _execute_claimed(
+                self.database,
+                claimed,
+                "executor_rate",
+                argparse.Namespace(now_epoch=NOW),
+            )
+
+        reset_at = NOW + DEFAULT_PROVIDER_RETRY_SECONDS
+        self.assertEqual(reset_at, receipt["retry_after"])
+        self.assertEqual(
+            (
+                "linkedin_primary",
+                "paused",
+                "rate_limit",
+                str(reset_at),
+                "post",
+                "outbound",
+            ),
+            tuple(
+                self.database.execute(
+                    "SELECT connection_id,status,failure_class,retry_after,stream,run_kind "
+                    "FROM sync_runs WHERE run_kind='outbound'"
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            ["op_other_account"],
+            due_operation_ids(self.database, PRINCIPAL, NOW, 10),
+        )
+        with self.assertRaisesRegex(SocialStoreError, "provider cooldown"):
+            claim_operation(
+                self.database,
+                ClaimRequest(
+                    "op_same_account", PRINCIPAL, "executor_blocked", NOW, 60
+                ),
+            )
+        report = build_health_report(
+            self.database, PRINCIPAL, NOW, provider="linkedin"
+        )
+        accounts = {
+            item["account_alias"]: item for item in report["providers"][0]["accounts"]
+        }
+        self.assertEqual(reset_at, accounts["linkedin_primary"]["quota"]["reset_at"])
+        self.assertIsNone(accounts["linkedin_other"]["quota"]["reset_at"])
+
+    def test_expired_claim_cannot_finalize_as_succeeded(self) -> None:
+        self.connection("x_expired", "xapi", "private_x_expired")
+        self.operation("x_expired", "private_x_expired", "op_expired_success")
+        claimed = claim_operation(
+            self.database,
+            ClaimRequest(
+                "op_expired_success", PRINCIPAL, "executor_expired", NOW - 10, 5
+            ),
+        )
+        mark_provider_started(
+            self.database, claimed, "executor_expired", started_at=NOW - 9
+        )
+
+        receipt = finalize_operation(
+            self.database,
+            claimed,
+            "executor_expired",
+            AttemptOutcome(
+                "succeeded",
+                provider_remote_id="late_provider_receipt",
+                finished_at=NOW,
+            ),
+        )
+
+        self.assertEqual("unknown", receipt["state"])
+        self.assertEqual("executor_lost", receipt["failure_class"])
+        self.assertEqual("late_provider_receipt", receipt["provider_remote_id"])
+        stored = self.database.execute(
+            "SELECT o.state,a.status,a.failure_class,a.provider_remote_id "
+            "FROM outbound_operations o JOIN outbound_attempts a "
+            "ON a.attempt_id=o.last_attempt_id "
+            "WHERE o.operation_id='op_expired_success'"
+        ).fetchone()
+        self.assertEqual(
+            ("unknown", "unknown", "executor_lost", "late_provider_receipt"),
+            tuple(stored),
+        )
+
+    def test_expired_claims_consume_the_global_reconciliation_budget(self) -> None:
+        self.connection("x_budget", "xapi", "private_x_budget")
+        self.operation("x_budget", "private_x_budget", "op_budget_expired")
+        claim_operation(
+            self.database,
+            ClaimRequest(
+                "op_budget_expired", PRINCIPAL, "executor_lost", NOW - 10, 1
+            ),
+        )
+        self.operation("x_budget", "private_x_budget", "op_budget_unknown")
+        self.finish("op_budget_unknown", "executor_unknown", "unknown")
+
+        result = reconcile_provider_receipts(
+            self.database,
+            PRINCIPAL,
+            NOW,
+            decisions=(
+                ReconciliationRequest(
+                    "op_budget_unknown", PRINCIPAL, "not-sent", None, NOW
+                ),
+            ),
+            limit=1,
+            per_provider_limit=1,
+        )
+
+        self.assertEqual(["op_budget_expired"], result["expired_claims"])
+        self.assertEqual(0, result["resolved_count"])
+        self.assertEqual("global_budget", result["skipped"][0]["reason"])
+        state = self.database.execute(
+            "SELECT state FROM outbound_operations WHERE operation_id='op_budget_unknown'"
+        ).fetchone()[0]
+        self.assertEqual("unknown", state)
+        pending = reconcile_provider_receipts(
+            self.database,
+            PRINCIPAL,
+            NOW,
+            decisions=(),
+            limit=2,
+            per_provider_limit=1,
+        )
+        self.assertEqual(1, pending["unresolved_count"])
+
+    def test_schema_seven_remains_read_compatible_and_upgrades_explicitly(self) -> None:
+        self.downgrade_to_schema_seven(self.database)
+
+        require_health_schema(self.database)
+        report = build_health_report(self.database, PRINCIPAL, NOW)
+        self.assert_schema(report)
+        self.assertEqual("unconfigured", report["status"])
+
+        migrate(self.database)
+        self.assertEqual(
+            8, self.database.execute("PRAGMA user_version").fetchone()[0]
+        )
+
+    def test_cli_reads_schema_seven_and_collect_upgrades_with_manage_grant(self) -> None:
+        base = self.root / "cli-knowledge"
+        corpus = base / "_knowledge"
+        corpus.mkdir(parents=True)
+        provision(base)
+        database = connect(corpus)
+        migrate(database)
+        self.downgrade_to_schema_seven(database)
+        database.close()
+
+        command = SCRIPTS / "social-provider-health.py"
+        status = subprocess.run(  # nosec B603 -- fixed local health CLI
+            [sys.executable, str(command), "status", "--base", str(base)],
+            cwd=SCRIPTS.parents[1],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(0, status.returncode, status.stderr)
+        self.assert_schema(json.loads(status.stdout))
+        database_path = corpus / "index" / "social.db"
+        inspection = sqlite3.connect(
+            f"{database_path.as_uri()}?mode=ro&immutable=1", uri=True
+        )
+        self.assertEqual(7, inspection.execute("PRAGMA user_version").fetchone()[0])
+        inspection.close()
+
+        collect = subprocess.run(  # nosec B603 -- fixed local health CLI
+            [sys.executable, str(command), "collect", "--base", str(base)],
+            cwd=SCRIPTS.parents[1],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(0, collect.returncode, collect.stderr)
+        inspection = sqlite3.connect(
+            f"{database_path.as_uri()}?mode=ro&immutable=1", uri=True
+        )
+        self.assertEqual(8, inspection.execute("PRAGMA user_version").fetchone()[0])
+        inspection.close()
+        self.assertTrue((corpus / "state" / "social-provider-health.json").is_file())
+
+    def test_stale_evidence_blocks_usable_and_collector_record_is_public(self) -> None:
+        self.connection("x_primary", "xapi", "private_x_account")
+        self.operation(
+            "x_primary",
+            "private_x_account",
+            "op_old_success",
+            created_at=NOW - 10_000,
+        )
+        self.finish(
+            "op_old_success",
+            "executor_old",
+            "succeeded",
+            started_at=NOW - 9_000,
+        )
+        self.operation("x_primary", "private_x_account", "op_ready")
+
+        report = build_health_report(self.database, PRINCIPAL, NOW)
+        x_provider = next(
+            item for item in report["providers"] if item["provider_id"] == "xapi"
+        )
+        account = x_provider["accounts"][0]
+        self.assertEqual("partial", account["status"])
+        self.assertFalse(account["dimensions"]["usable"])
+        post = next(
+            item
+            for item in account["actions"]
+            if item["mode"] == "write" and item["action"] == "post"
+        )
+        self.assertEqual("stale", post["status"])
+
+        connection = Connection(
+            "social_fixture",
+            "social",
+            "poll",
+            (),
+            self.root,
+            None,
+            60,
+            60,
+            60,
+            300,
+            30,
+            2,
+            None,
+            True,
+        )
+        projected = health_record(
+            connection,
+            {"last_success": NOW - 10, "status": "complete"},
+            NOW,
+        )
+        self.assertEqual("healthy", projected["health"])
+        self.assertEqual("social_fixture", projected["connection_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -422,6 +422,7 @@ import sys
 
 with sqlite3.connect(sys.argv[1]) as database:
     database.execute("DROP TABLE notification_state")
+    database.execute("DROP TABLE outbound_reconciliations")
     database.execute("DROP TABLE outbound_attempts")
     database.execute("DROP TABLE outbound_approvals")
     database.execute("DROP TABLE outbound_operations")
@@ -430,8 +431,8 @@ with sqlite3.connect(sys.argv[1]) as database:
 PY
 "$HELPER" provision --base "$MIGRATION_BASE" >/dev/null
 assert_eq "schema v2 migrates additively to all local operation tables" \
-	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT (SELECT user_version FROM pragma_user_version) || ':' || count(*) FROM sqlite_master WHERE name IN ('outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" \
-	"7:4"
+	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT (SELECT user_version FROM pragma_user_version) || ':' || count(*) FROM sqlite_master WHERE name IN ('outbound_operations','outbound_approvals','outbound_attempts','outbound_reconciliations','notification_state')")" \
+	"8:5"
 assert_eq "schema v4 adds provider-neutral subject and destination fields" \
 	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT count(*) FROM pragma_table_info('outbound_operations') WHERE name IN ('destination_remote_id','subject','subject_sha256','intent_version')")" \
 	"4"

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -64,7 +64,7 @@ chmod 0700 "$BASE" "$ROOT"
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
 
 printf 'Social sync routine tests\n'
-assert_eq "current schema is active" "$(sql_value 'PRAGMA user_version')" "6"
+assert_eq "current schema is active" "$(sql_value 'PRAGMA user_version')" "8"
 assert_eq "lease and reconciliation tables are provisioned" \
 	"$(sql_value "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('collector_lease_generations','collector_leases','reconciliation_items')")" \
 	"3"
@@ -823,7 +823,7 @@ from knowledge_social_store import SocialStoreError, connect, migrate, write_raw
 database = connect(root)
 migrate(database)
 columns = {row[1] for row in database.execute("PRAGMA table_info(sync_runs)")}
-if database.execute("PRAGMA user_version").fetchone()[0] != 6:
+if database.execute("PRAGMA user_version").fetchone()[0] != 8:
     raise SystemExit("v1 database did not migrate to the current schema")
 required = {
     "stream",
@@ -1160,7 +1160,7 @@ connection.close()
 PY
 )
 assert_eq "existing stores migrate and repair projection provenance" \
-	"$migration_version" "6"
+	"$migration_version" "8"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -94,8 +94,8 @@ mkdir -p "$CORPUS_ROOT"
 chmod 0700 "$BASE" "$CORPUS_ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
-assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "6"
-assert_eq "all provider-neutral and local-operation tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts','outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" "16"
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "8"
+assert_eq "all provider-neutral and local-operation tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts','outbound_operations','outbound_approvals','outbound_attempts','outbound_reconciliations','notification_state')")" "17"
 
 first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
 first_hash=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["batch_id"])' "$first_result")
@@ -221,7 +221,7 @@ python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
 import sqlite3
 import sys
 connection = sqlite3.connect(sys.argv[1])
-connection.execute("PRAGMA user_version=6")
+connection.execute("PRAGMA user_version=8")
 connection.close()
 PY
 

--- a/todo/tasks/t18238-brief.md
+++ b/todo/tasks/t18238-brief.md
@@ -115,9 +115,9 @@ shellcheck .agents/scripts/knowledge-social-helper.sh
 
 ### Recoverability Checkpoint
 
-- [ ] Focused tests pass: health and shared outbound suites
-- [ ] WIP commit created before broad gates: `wip: add social provider health`
-- [ ] Evidence-triggered broad verification then run: `.agents/scripts/linters-local.sh --changed`
+- [x] Focused tests pass: health and shared outbound suites
+- [x] WIP commit created before broad gates: `276ac4c45` (`wip: add social provider health`)
+- [x] Evidence-triggered broad verification run: `.agents/scripts/linters-local.sh --changed`
 
 ### Safety-Stop Recovery
 


### PR DESCRIPTION
## Summary

Add privacy-safe provider/account/action readiness, immutable receipt reconciliation, exact-account cooldown fencing, and schema-v7 read compatibility.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/configs/capability-registry.json, .agents/configs/rate-limits.json.txt, .agents/reference/capability-registry.md, .agents/schemas/social-provider-health.schema.json, .agents/scripts/_knowledge_collector_health.py, .agents/scripts/_knowledge_social_linkedin_outbound_provider.py, .agents/scripts/_knowledge_social_outbound.py, .agents/scripts/_knowledge_social_outbound_provider.py, .agents/scripts/_knowledge_social_outbound_reconciliation.py, .agents/scripts/_knowledge_social_outbound_runtime.py, .agents/scripts/_knowledge_social_share_data.py, .agents/scripts/_knowledge_social_youtube_outbound_provider.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_operations.py, .agents/scripts/knowledge_social_store.py, .agents/scripts/social-provider-health.py, .agents/scripts/social_provider_health.py, .agents/scripts/tests/test-social-linkedin-youtube-outbound.py, .agents/scripts/tests/test-social-provider-health.py, .agents/tests/test-knowledge-social-operations.sh, .agents/tests/test-knowledge-social-sync.sh, .agents/tests/test-knowledge-social.sh, todo/tasks/t18238-brief.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: 11 provider-health tests, 9 LinkedIn/YouTube adapter tests, 56 outbound operation tests, social corpus/sync/registry/capability suites, and full local lint passed.

Resolves #30144


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.259 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 7h and 7,722,279 tokens on this with the user in an interactive session.