### PR TITLE
GH#30221: fix auto-dispatch retry on locked issues

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -289,11 +289,17 @@ lock_issue_for_worker() {
 
 	# aidevops:trust-boundary — never launch a worker when the mutable public
 	# instruction surface could not be frozen and independently re-read.
+	local lock_applied=0
 	if ! gh issue lock "$issue_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1; then
-		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
-		return 1
+		if ! _verify_issue_conversation_lock "$issue_num" "$slug"; then
+			echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
+			return 1
+		fi
+		echo "[pulse-wrapper] Reused existing verified conversation lock for #${issue_num} in ${slug} (GH#30180)" >>"$LOGFILE"
+	else
+		lock_applied=1
 	fi
-	if ! _verify_issue_conversation_lock "$issue_num" "$slug"; then
+	if [[ "$lock_applied" -eq 1 ]] && ! _verify_issue_conversation_lock "$issue_num" "$slug"; then
 		echo "[pulse-wrapper] Failed to verify conversation lock for #${issue_num} in ${slug}; dispatch remains blocked (GH#30180)" >>"$LOGFILE"
 		return 1
 	fi
@@ -712,20 +718,19 @@ _issue_thread_is_trusted_maintainer_only() {
 	local issue_author_association
 	local issue_author_login
 	issue_json=$(gh api "$issue_api_path" 2>/dev/null) || return 1
-	IFS=$'\t' read -r issue_author_association issue_author_login < <(printf '%s' "$issue_json" \
-		| jq -r '[.author_association // "NONE", (.user.login // .author.login // "")] | @tsv') || {
+	IFS=$'\t' read -r issue_author_association issue_author_login < <(printf '%s' "$issue_json" |
+		jq -r '[.author_association // "NONE", (.user.login // .author.login // "")] | @tsv') || {
 		issue_author_association=""
 		issue_author_login=""
 	}
 	case "$issue_author_association" in
-		OWNER | MEMBER)
-			;;
-		COLLABORATOR)
-			_issue_actor_has_repo_write_permission "$repo_slug" "$issue_author_login" || return 1
-			;;
-		*)
-			return 1
-			;;
+	OWNER | MEMBER) ;;
+	COLLABORATOR)
+		_issue_actor_has_repo_write_permission "$repo_slug" "$issue_author_login" || return 1
+		;;
+	*)
+		return 1
+		;;
 	esac
 
 	local comments_json
@@ -1245,8 +1250,8 @@ _is_bot_generated_cleanup_issue() {
 
 _dispatch_waiting_for_maintainer_permission() {
 	local issue_meta_json="$1"
-	printf '%s' "$issue_meta_json" \
-		| jq -e '.labels | map(.name) | index("needs-maintainer-permissions") != null' >/dev/null 2>&1
+	printf '%s' "$issue_meta_json" |
+		jq -e '.labels | map(.name) | index("needs-maintainer-permissions") != null' >/dev/null 2>&1
 	return $?
 }
 
@@ -1845,9 +1850,9 @@ _release_dispatch_claim_on_abort() {
 	# audit comment is preserved.
 	local _is_pre_launch_abort=0
 	case "$reason" in
-		worker_launch_rc_* | predispatch_validator_closed | eligibility_gate)
-			_is_pre_launch_abort=1
-			;;
+	worker_launch_rc_* | predispatch_validator_closed | eligibility_gate)
+		_is_pre_launch_abort=1
+		;;
 	esac
 
 	if [[ "$_is_pre_launch_abort" == "1" ]]; then
@@ -2173,8 +2178,8 @@ _ensure_issue_body_has_brief() {
 	# "## How" bodies ~5KB each; the old check treated them as stubs and
 	# force-enriched them into emptiness.
 	local current_body
-	if [[ -n "$pre_fetched_json" ]] \
-		&& printf '%s' "$pre_fetched_json" | jq -e '.body' >/dev/null 2>&1; then
+	if [[ -n "$pre_fetched_json" ]] &&
+		printf '%s' "$pre_fetched_json" | jq -e '.body' >/dev/null 2>&1; then
 		current_body=$(printf '%s' "$pre_fetched_json" | jq -r '.body // ""' 2>/dev/null) || current_body=""
 	else
 		# t3027: route through gh_issue_view wrapper for REST fallback under

--- a/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
+++ b/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
@@ -11,9 +11,10 @@ trap 'rm -rf "$TMP"' EXIT
 
 LOGFILE="${TMP}/pulse.log"
 GH_CALLS="${TMP}/gh-calls.log"
+GH_API_COUNT_FILE="${TMP}/gh-api-count"
 AIDEVOPS_AUTO_DISPATCH_LOCK_DIR="${TMP}/locks"
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=0
-export LOGFILE GH_CALLS AIDEVOPS_AUTO_DISPATCH_LOCK_DIR AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY
+export LOGFILE GH_CALLS GH_API_COUNT_FILE AIDEVOPS_AUTO_DISPATCH_LOCK_DIR AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -33,6 +34,12 @@ fail() {
 	return 0
 }
 
+reset_gh_calls() {
+	: >"$GH_CALLS"
+	printf '0\n' >"$GH_API_COUNT_FILE"
+	return 0
+}
+
 GH_LOCKED=true
 GH_LOCK_RC=0
 GH_API_RC=0
@@ -43,7 +50,9 @@ gh() {
 	fi
 	if [[ "$1" == "api" ]]; then
 		local api_count
-		api_count=$(grep -c -- '^api ' "$GH_CALLS" 2>/dev/null || true)
+		api_count=$(<"$GH_API_COUNT_FILE")
+		api_count=$((api_count + 1))
+		printf '%s\n' "$api_count" >"$GH_API_COUNT_FILE"
 		if [[ "$GH_API_RC" -ne 0 ]]; then
 			return "$GH_API_RC"
 		fi
@@ -66,7 +75,7 @@ export -f gh gh_pr_list
 # shellcheck source=../pulse-dispatch-core.sh
 source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
 
-: >"$GH_CALLS"
+reset_gh_calls
 if lock_issue_for_worker 41 owner/repo &&
 	grep -q -- 'issue lock 41 --repo owner/repo --reason resolved' "$GH_CALLS" &&
 	grep -q -- 'api repos/owner/repo/issues/41 --jq .locked == true' "$GH_CALLS" &&
@@ -76,7 +85,7 @@ else
 	fail "strict lock succeeds only after independent verification"
 fi
 
-: >"$GH_CALLS"
+reset_gh_calls
 GH_LOCKED=false,false,false
 if ! lock_issue_for_worker 42 owner/repo &&
 	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
@@ -86,7 +95,7 @@ else
 	fail "unverified issue lock fails closed"
 fi
 
-: >"$GH_CALLS"
+reset_gh_calls
 GH_LOCKED=false,true
 if lock_issue_for_worker 43 owner/repo &&
 	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 2 ]] &&
@@ -96,7 +105,21 @@ else
 	fail "stale lock read retries and then succeeds"
 fi
 
-: >"$GH_CALLS"
+reset_gh_calls
+GH_LOCK_RC=1
+GH_LOCKED=true
+if lock_issue_for_worker 46 owner/repo &&
+	grep -q -- 'issue lock 46 --repo owner/repo --reason resolved' "$GH_CALLS" &&
+	grep -q -- 'api repos/owner/repo/issues/46 --jq .locked == true' "$GH_CALLS" &&
+	grep -q -- 'Reused existing verified conversation lock' "$LOGFILE" &&
+	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-46" ]]; then
+	pass "already locked issue is accepted after independent verification"
+else
+	fail "already locked issue is accepted after independent verification"
+fi
+GH_LOCK_RC=0
+
+reset_gh_calls
 GH_LOCKED=false
 GH_API_RC=1
 if ! lock_issue_for_worker 44 owner/repo &&
@@ -107,7 +130,7 @@ else
 	fail "lock verification API errors exhaust retries and fail closed"
 fi
 
-: >"$GH_CALLS"
+reset_gh_calls
 GH_LOCKED=false,false,false
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS=999
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=999
@@ -120,7 +143,7 @@ fi
 unset AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=0
 
-: >"$GH_CALLS"
+reset_gh_calls
 GH_API_RC=0
 GH_LOCKED=true
 snapshot='[
@@ -143,7 +166,7 @@ else
 	fail "reconciliation covers blocked and queued issues without undoing lockdowns"
 fi
 
-: >"$GH_CALLS"
+reset_gh_calls
 gh() {
 	printf '%s\n' "$*" >>"$GH_CALLS"
 	if [[ "$1" == "api" ]]; then


### PR DESCRIPTION
## Summary

- Resolves #30221
- allow auto-dispatch to proceed when `gh issue lock` returns non-zero because the issue is already locked, provided REST verification confirms `locked=true`
- preserve fail-closed behavior when the lock cannot be independently verified
- add regression coverage for the already-locked retry path and stabilize the retry test's fake API sequence counter

## Evidence

`awardsapp/awardsapp` issues were repeatedly reaching prelaunch and then failing before worker runtime:

- `PRE_RUNTIME_FAILURE issue=9732 repo=awardsapp/awardsapp reason=conversation_lock_failed`
- `Failed to verify conversation lock for #9732 in awardsapp/awardsapp; dispatch remains blocked (GH#30180)`
- `gh issue lock 9732 --repo awardsapp/awardsapp --reason resolved` on an already locked issue prints `already locked` and returns non-zero
- REST confirms the issue is already frozen: `locked=true`, `active_lock_reason=resolved`

## Verification

- `bash .agents/scripts/tests/test-auto-dispatch-conversation-lock.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-auto-dispatch-conversation-lock.sh`
- `.agents/scripts/linters-local.sh --changed`

## Files

- `.agents/scripts/pulse-dispatch-core.sh`
- `.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.260 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.5 spent 1d 7h and 3,036,142 tokens on this with the user in an interactive session.