### PR TITLE
GH#30223: fix: allow headless prompt attachment reads

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-safety-guards.mjs
+++ b/.agents/plugins/opencode-aidevops/config-safety-guards.mjs
@@ -49,6 +49,19 @@ const STABLE_MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.config/opencode/skills/**",
 ];
 
+function safeRuntimeManagedDirectory(value) {
+  if (typeof value !== "string") return "";
+  const normalized = value.replace(/\/+$/, "");
+  if (!normalized.startsWith("/") || normalized === "/") return "";
+  if (/[*?\n\r\0]/.test(normalized)) return "";
+  return normalized;
+}
+
+function runtimeManagedExternalDirectories(env) {
+  const promptDir = safeRuntimeManagedDirectory(env.AIDEVOPS_HEADLESS_PROMPT_DIR);
+  return promptDir ? [promptDir, `${promptDir}/**`] : [];
+}
+
 export function managedExternalDirectories(env = process.env) {
   const isConfigured = Object.hasOwn(env, "AIDEVOPS_WORKTREE_BASE_DIR");
   const configured = env.AIDEVOPS_WORKTREE_BASE_DIR;
@@ -60,6 +73,7 @@ export function managedExternalDirectories(env = process.env) {
     ...STABLE_MANAGED_EXTERNAL_DIRECTORIES,
     worktreeBase,
     `${worktreeBase}/**`,
+    ...runtimeManagedExternalDirectories(env),
     ...[...tempDirectories].sort().flatMap((path) => [path, `${path}/**`]),
   ];
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -59,6 +59,26 @@ test("registers the configured worktree base for global and agent permissions", 
   }
 });
 
+test("allows only the current headless prompt attachment directory", () => {
+  const promptDir = "/managed-runtime/aidevops-headless-prompt.abc123";
+  const rules = managedExternalDirectories({ AIDEVOPS_HEADLESS_PROMPT_DIR: `${promptDir}/` });
+
+  assert.ok(rules.includes(promptDir));
+  assert.ok(rules.includes(`${promptDir}/**`));
+  assert.equal(rules.includes("/managed-runtime"), false);
+  assert.equal(rules.includes("/managed-runtime/**"), false);
+});
+
+test("ignores unsafe headless prompt attachment directories", () => {
+  for (const value of ["", "/", "relative/path", "/tmp/aidevops-*", "/tmp/aidevops\nnext"]) {
+    assert.equal(
+      managedExternalDirectories({ AIDEVOPS_HEADLESS_PROMPT_DIR: value })
+        .some((path) => path.includes("aidevops-headless-prompt")),
+      false,
+    );
+  }
+});
+
 test("adds narrow managed-directory exceptions after a broad ask rule", () => {
   const config = {
     permission: {

--- a/.agents/scripts/headless-runtime-launch.sh
+++ b/.agents/scripts/headless-runtime-launch.sh
@@ -56,7 +56,7 @@ _headless_private_workload_enabled() {
 # never continue from or persist session/transcript-derived state afterward.
 _headless_run_is_ephemeral() {
 	local role="$1"
-	if _headless_private_workload_enabled || \
+	if _headless_private_workload_enabled ||
 		[[ "$role" == "${HEADLESS_ROLE_TRIAGE:-triage}" ]]; then
 		return 0
 	fi
@@ -167,6 +167,7 @@ _prepare_runtime_prompt_transport() {
 	_HEADLESS_RUN_PROMPT_ARG="$prompt_text"
 	_HEADLESS_RUN_PROMPT_FILE=""
 	_HEADLESS_CLAUDE_STDIN_FILE=""
+	unset AIDEVOPS_HEADLESS_PROMPT_DIR
 
 	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=8192
 	[[ "$force_file_transport" =~ ^[01]$ ]] || force_file_transport=0
@@ -188,6 +189,7 @@ _prepare_runtime_prompt_transport() {
 	local prompt_path="${prompt_dir}/seed-prompt.md"
 	if ! printf '%s' "$prompt_text" >"$prompt_path"; then
 		rm -rf "$prompt_dir" 2>/dev/null || true
+		unset AIDEVOPS_HEADLESS_PROMPT_DIR
 		[[ "$force_file_transport" -ne 1 ]] || return 1
 		return 0
 	fi
@@ -202,8 +204,12 @@ _prepare_runtime_prompt_transport() {
 	opencode | *)
 		# OpenCode has no stdin prompt mode in `opencode run --help`; attach the
 		# seed file and pass a short instruction, avoiding process-table bloat.
+		# The attached path is framework-generated and bounded to this attempt;
+		# expose only its directory to the OpenCode config hook so workers can read
+		# the attachment without a generic external_directory approval.
 		_HEADLESS_RUN_PROMPT_ARG="Read and execute the complete seed prompt attached as seed-prompt.md. Treat the attached file as the user prompt for this headless run."
 		_HEADLESS_RUN_PROMPT_FILE="$prompt_path"
+		export AIDEVOPS_HEADLESS_PROMPT_DIR="$prompt_dir"
 		;;
 	esac
 
@@ -372,7 +378,7 @@ _validate_private_workload_profile() {
 		print_error "--private-workload requires a regular .opencode/opencode.json profile"
 		return 1
 	fi
-	if [[ ! -f "$profile_validator" ]] || ! command -v python3 >/dev/null 2>&1 || \
+	if [[ ! -f "$profile_validator" ]] || ! command -v python3 >/dev/null 2>&1 ||
 		! python3 "$profile_validator" "$work_dir_value" "$expected_model" \
 			"$expected_agent" "$expected_provider" "$expected_profile_sha256" \
 			>/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-headless-runtime-database-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-database-tests.sh
@@ -976,7 +976,7 @@ test_opencode_project_table_migration_replay_detected() {
 	local project_table_error="table \`project\` already exists"
 	printf '%s\n' 'Error: Unexpected error' "$project_table_error" >"$output_file"
 
-	if _opencode_project_table_migration_replay_detected 1 "$output_file" && \
+	if _opencode_project_table_migration_replay_detected 1 "$output_file" &&
 		! _opencode_project_table_migration_replay_detected 0 "$output_file"; then
 		print_result "detects OpenCode project table migration replay startup failure" 0
 		return 0
@@ -990,12 +990,15 @@ test_opencode_project_table_migration_replay_detected() {
 test_large_opencode_prompt_uses_file_attachment() {
 	local prompt="large-seed-prompt-with-worker-contract"
 	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
+	local old_prompt_dir="${AIDEVOPS_HEADLESS_PROMPT_DIR:-}"
 	HEADLESS_PROMPT_FILE_THRESHOLD_BYTES=8
 
 	_prepare_runtime_prompt_transport "opencode" "$prompt"
 
 	local prompt_arg="$_HEADLESS_RUN_PROMPT_ARG"
 	local prompt_file="$_HEADLESS_RUN_PROMPT_FILE"
+	local prompt_dir="${prompt_file%/*}"
+	local observed_prompt_dir="${AIDEVOPS_HEADLESS_PROMPT_DIR:-}"
 	local cmd_text=""
 	cmd_text=$(
 		while IFS= read -r -d '' arg; do
@@ -1007,6 +1010,7 @@ test_large_opencode_prompt_uses_file_attachment() {
 	if [[ "$prompt_arg" != *"$prompt"* ]] &&
 		[[ -f "$prompt_file" ]] &&
 		[[ "$(<"$prompt_file")" == "$prompt" ]] &&
+		[[ "$observed_prompt_dir" == "$prompt_dir" ]] &&
 		[[ "$cmd_text" == *"<--file><${prompt_file}>"* ]] &&
 		[[ "$cmd_text" != *"$prompt"* ]]; then
 		_cleanup_headless_runtime_temp_paths
@@ -1014,6 +1018,11 @@ test_large_opencode_prompt_uses_file_attachment() {
 			HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
 		else
 			unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+		fi
+		if [[ -n "$old_prompt_dir" ]]; then
+			AIDEVOPS_HEADLESS_PROMPT_DIR="$old_prompt_dir"
+		else
+			unset AIDEVOPS_HEADLESS_PROMPT_DIR
 		fi
 		print_result "large opencode prompts use file attachment instead of argv" 0
 		return 0
@@ -1025,8 +1034,13 @@ test_large_opencode_prompt_uses_file_attachment() {
 	else
 		unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
 	fi
+	if [[ -n "$old_prompt_dir" ]]; then
+		AIDEVOPS_HEADLESS_PROMPT_DIR="$old_prompt_dir"
+	else
+		unset AIDEVOPS_HEADLESS_PROMPT_DIR
+	fi
 	print_result "large opencode prompts use file attachment instead of argv" 1 \
-		"prompt_arg=${prompt_arg} prompt_file=${prompt_file} cmd=${cmd_text}"
+		"prompt_arg=${prompt_arg} prompt_file=${prompt_file} prompt_dir=${observed_prompt_dir} cmd=${cmd_text}"
 	return 0
 }
 
@@ -1071,7 +1085,10 @@ test_public_triage_isolated_data_is_discarded() {
 	local lifecycle_state=""
 	lifecycle_state=$(
 		local merge_count=0 replay_count=0 preserve_count=0
-		_replay_preserved_worker_dbs() { replay_count=$((replay_count + 1)); return 0; }
+		_replay_preserved_worker_dbs() {
+			replay_count=$((replay_count + 1))
+			return 0
+		}
 		_merge_worker_db() {
 			local isolated_dir="$1"
 			: "$isolated_dir"
@@ -1123,8 +1140,8 @@ test_public_triage_cleanup_failure_is_reported() {
 	)
 	command rm -rf "$triage_dir"
 
-	if [[ "$lifecycle_state" == *"db_cleanup_failed"* && \
-		"$lifecycle_state" == *"guardian=retained"* && \
+	if [[ "$lifecycle_state" == *"db_cleanup_failed"* &&
+		"$lifecycle_state" == *"guardian=retained"* &&
 		"$lifecycle_state" == *"state=1|yes|"* ]]; then
 		print_result "public triage reports isolated-data cleanup failure" 0
 		return 0
@@ -1168,9 +1185,9 @@ test_public_triage_does_not_persist_session_or_failure_output() {
 		persisted_marker=1
 	fi
 
-	if [[ "$session_state" == "openai|issue-42|ses_worker|openai/test" && \
-		"$handle_status" -eq 75 && ! -f "$output_file" && \
-		"$stored_details" == "ephemeral workload details suppressed" && \
+	if [[ "$session_state" == "openai|issue-42|ses_worker|openai/test" &&
+		"$handle_status" -eq 75 && ! -f "$output_file" &&
+		"$stored_details" == "ephemeral workload details suppressed" &&
 		"$persisted_marker" -eq 0 ]]; then
 		print_result "public triage persists neither sessions nor transcript-derived failure output" 0
 		return 0
@@ -1277,7 +1294,7 @@ test_registered_temp_cleanup_failure_is_reported_and_retained() {
 	_HEADLESS_RUNTIME_TEMP_PATHS=""
 	command rm -rf "$temp_path"
 
-	if [[ "$state" == *"headless_runtime_temp_cleanup_failed"* && \
+	if [[ "$state" == *"headless_runtime_temp_cleanup_failed"* &&
 		"$state" == *"status=1 retained=${temp_path}"* ]]; then
 		print_result "registered temp cleanup reports and retains undeleted paths" 0
 		return 0
@@ -1306,7 +1323,7 @@ test_public_triage_output_temp_starts_cleanup_guardian() {
 	)
 	command rm -f "$output_path"
 
-	if [[ "$state" == *"guardian=${output_path}"* && \
+	if [[ "$state" == *"guardian=${output_path}"* &&
 		"$state" == *"registered=${output_path}"* ]]; then
 		print_result "public triage output temp starts a detached cleanup guardian" 0
 		return 0


### PR DESCRIPTION
## Summary

Implementation for issue #30223.

## Files Changed

.agents/plugins/opencode-aidevops/config-safety-guards.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs, .agents/scripts/headless-runtime-launch.sh, .agents/scripts/tests/test-headless-runtime-database-tests.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30223


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.260 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.5 spent 1d 8h and 3,310,025 tokens on this with the user in an interactive session.