### PR TITLE
GH#30226: fix: stop retained-lock prelaunch claim storms

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -332,6 +332,18 @@ _record_auto_dispatch_lock() {
 }
 
 #######################################
+# Return success when label policy requires the conversation to remain locked.
+# Args: comma-separated label names
+#######################################
+_auto_dispatch_lock_required() {
+	local labels_csv="$1"
+	if [[ ",$labels_csv," == *,auto-dispatch,* && ",$labels_csv," != *,no-auto-dispatch,* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Reconcile conversation locks for every visible auto-dispatch issue,
 # including blocked and queued work that cannot reach the launch path yet.
 # Only markers owned by this mechanism may trigger an unlock.
@@ -346,7 +358,7 @@ reconcile_auto_dispatch_issue_locks() {
 		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 		marker=$(_auto_dispatch_lock_marker "$issue_num" "$slug") || continue
 		labels_csv=",${labels},"
-		if [[ "$labels_csv" == *,auto-dispatch,* && "$labels_csv" != *,no-auto-dispatch,* ]]; then
+		if _auto_dispatch_lock_required "$labels"; then
 			lock_issue_for_worker "$issue_num" "$slug" || return 1
 		elif [[ -f "$marker" && "$labels_csv" != *,no-auto-dispatch,* ]]; then
 			gh issue unlock "$issue_num" --repo "$slug" >/dev/null 2>&1 || return 1
@@ -403,7 +415,7 @@ unlock_issue_after_worker() {
 	fi
 	# aidevops:trust-boundary — auto-dispatch remains authoritative across
 	# retries, so completion cleanup must not reopen its instruction surface.
-	if [[ ",$labels," == *,auto-dispatch,* && ",$labels," != *,no-auto-dispatch,* ]]; then
+	if _auto_dispatch_lock_required "$labels"; then
 		echo "[pulse-wrapper] Retained conversation lock for auto-dispatch #${issue_num} in ${slug} after worker handoff (GH#30180)" >>"$LOGFILE"
 		return 0
 	fi
@@ -1762,11 +1774,22 @@ _rollback_prelaunch_ownership() {
 	local repo_slug="$2"
 	local self_login="$3"
 	local claim_comment_id="$4"
-	local comments_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local comments_endpoint="repos/${repo_slug}/issues/${issue_number}/comments?per_page=100"
+	local comments_json=""
 	local latest_claim_id=""
 
-	latest_claim_id=$(gh api "$comments_endpoint" --paginate --jq \
-		'[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))] | last | (.id // "")' 2>/dev/null) || return 1
+	comments_json=$(gh api "$comments_endpoint" --paginate --slurp 2>/dev/null) || return 1
+	# #aidevops:trust-boundary — anchor the rollback fence to GitHub's
+	# authenticated comment author. Body text and bare association values cannot
+	# let an external commenter supersede this runner's exact claim.
+	latest_claim_id=$(printf '%s' "$comments_json" | jq -r --arg self "$self_login" '
+		(if type == "array" and ((.[0]? | type) == "array") then add else . end)
+		| [.[] | select(
+			((.user.login // .author.login // "") | ascii_downcase) == ($self | ascii_downcase)
+			and ((.body // "") | contains("DISPATCH_CLAIM nonce="))
+		)]
+		| last | (.id // "")
+	' 2>/dev/null) || return 1
 	if [[ -z "$latest_claim_id" || "$latest_claim_id" != "$claim_comment_id" ]]; then
 		echo "[dispatch_with_dedup] Pre-launch rollback skipped for #${issue_number}: claim ${claim_comment_id} is no longer current (latest=${latest_claim_id:-unknown})" >>"$LOGFILE"
 		return 1
@@ -1794,18 +1817,28 @@ _rollback_prelaunch_ownership() {
 
 	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
+	local final_labels=""
+	final_labels=$(printf '%s' "$issue_meta_json" | jq -r '[.labels[]?.name] | join(",")' 2>/dev/null) || return 1
+	local expected_locked=false
+	local lock_summary="issue unlocked"
+	if _auto_dispatch_lock_required "$final_labels"; then
+		expected_locked=true
+		lock_summary="required conversation lock retained"
+	fi
 	if ! printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
 		.state == "OPEN" and
 		(([.labels[].name] | index("status:queued")) == null) and
 		(([.labels[].name] | index("status:available")) != null) and
-		(([.assignees[].login] | index($self)) == null) and
-		(.locked != true)
+		(([.assignees[].login] | index($self)) == null)
+	' >/dev/null 2>&1 ||
+		! printf '%s' "$issue_meta_json" | jq -e --argjson expected_locked "$expected_locked" '
+		.locked == $expected_locked
 	' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Pre-launch rollback verification failed for #${issue_number}; retaining claim for stale recovery" >>"$LOGFILE"
 		return 1
 	fi
 
-	echo "[dispatch_with_dedup] Pre-launch rollback verified for #${issue_number}: queued ownership removed and issue unlocked" >>"$LOGFILE"
+	echo "[dispatch_with_dedup] Pre-launch rollback verified for #${issue_number}: queued ownership removed and ${lock_summary}" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1776,15 +1776,16 @@ _dispatch_launch_worker() {
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
 
-	_dlw_publish_queued_ownership "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || return $?
-
-	# t1894/t1934: Lock issue and linked PRs during worker execution.
+	# Freeze the worker-readable instruction surface before queued ownership is
+	# published. A lock failure must not create assignment/status notifications.
 	_ds_t0=$(_ds_now_ns)
 	if ! lock_issue_for_worker "$issue_number" "$repo_slug"; then
 		_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "conversation_lock_failed" 2 || return $?
 	fi
 	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
+
+	_dlw_publish_queued_ownership "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || return $?
 
 	_ds_t0=$(_ds_now_ns)
 	if ! worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \

--- a/.agents/scripts/pulse-dispatch-worker-prompt.sh
+++ b/.agents/scripts/pulse-dispatch-worker-prompt.sh
@@ -75,13 +75,89 @@ _dlw_zero_output_comment_count() {
 	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
 
 	local count=""
+	# #aidevops:trust-boundary — bare COLLABORATOR is ambiguous (read/triage
+	# access also receives it). This pure comment scan cannot perform the required
+	# permission lookup, so only authoritative OWNER/MEMBER evidence may fuse.
 	# shellcheck disable=SC2016  # jq program is intentionally single-quoted.
 	count=$(gh api --paginate "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
-		--jq '[.[] | select((.body // "") | test("'"${zero_output_pattern}"'"; "i"))] | length' 2>/dev/null | \
+		--jq 'def authoritative_association: (.author_association // "") as $a | ["OWNER", "MEMBER"] | index($a) != null; [.[] | select(authoritative_association and ((.body // "") | test("'"${zero_output_pattern}"'"; "i")))] | length' 2>/dev/null | \
 		awk '{ if ($1 ~ /^[0-9]+$/) { total += $1 } } END { printf "%d", total + 0 }') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	printf '%s' "$count"
 	return 0
+}
+
+#######################################
+# Compute comment-bloat metrics from one normalized or paginated comment JSON
+# snapshot. Claims older than the prelaunch grace with no authenticated ready
+# transition are zero-attempt infrastructure evidence.
+# Args: raw comments JSON, now epoch, orphan grace, zero-output regex,
+#       zero-attempt regex
+# Output: comments, ops, zero, chars, zero-attempt as a TSV row
+#######################################
+_dlw_comment_bloat_metrics_from_json() {
+	local raw_comments="$1"
+	local now_epoch="$2"
+	local orphan_grace="$3"
+	local zero_output_pattern="$4"
+	local zero_attempt_pattern="$5"
+
+	printf '%s' "$raw_comments" | jq -r \
+		--argjson now_epoch "$now_epoch" \
+		--argjson orphan_grace "$orphan_grace" \
+		--arg zero_output_pattern "$zero_output_pattern" \
+		--arg zero_attempt_pattern "$zero_attempt_pattern" '
+		def comments:
+			if type != "array" then []
+			elif length == 0 then []
+			elif all(.[]; type == "array") then add
+			else .
+			end;
+		def body_text: .body // "";
+		def marker_value($name):
+			try (body_text | capture($name + "=(?<value>[^ ]+)").value) catch "";
+		# Bare COLLABORATOR cannot authorize evidence without a permission lookup.
+		def authoritative_association:
+			(.author_association // "") as $association
+			| ["OWNER", "MEMBER"] | index($association) != null;
+		comments as $comments |
+		([$comments[] | select(body_text | test("ops:start|DISPATCH_CLAIM|CLAIM_RELEASED|dispatch-cooldown|Worker Watchdog Kill"; "i"))] | length) as $ops |
+		([$comments[] | select(authoritative_association and (body_text | test($zero_output_pattern; "i")))] | length) as $explicit_zero |
+		([$comments[] | select(authoritative_association and (body_text | test($zero_attempt_pattern; "i")) and (body_text | test("session_count=0"; "i")))] | length) as $explicit_zero_attempt |
+		([$comments[]
+			| select(authoritative_association)
+			| select(body_text | test("DISPATCH_CLAIM nonce="; "i"))
+			| select(body_text | contains("lease_token="))
+			| . as $claim
+			| ($claim | marker_value("lease_token")) as $token
+			| ($claim | marker_value("runner")) as $claim_runner
+			| ($claim | marker_value("device")) as $claim_device
+			| ($claim | marker_value("session")) as $claim_session
+			| (($claim.user.login // $claim.author // "")) as $claim_author
+			| ((try (($claim.created_at // "") | fromdateiso8601) catch 0) // 0) as $claim_epoch
+			| select($token != "" and $claim_author != "" and $claim_author == $claim_runner)
+			| select($claim_device != "" and $claim_session != "")
+			| select($claim_epoch > 0 and ($now_epoch - $claim_epoch) >= $orphan_grace)
+			| select([
+				$comments[]
+				| select(authoritative_association)
+				| select(body_text | test("DISPATCH_LEASE phase=ready"; "i"))
+				| select(marker_value("lease_token") == $token)
+				| select((.user.login // .author // "") == $claim_author)
+				| select(marker_value("device") == $claim_device)
+				| select(marker_value("session") == $claim_session)
+				| select([(.created_at // ""), ((.id | tonumber?) // 0)] >= [($claim.created_at // ""), (($claim.id | tonumber?) // 0)])
+			] | length == 0)
+		] | length) as $unmatched_claims |
+		[
+			($comments | length),
+			$ops,
+			($explicit_zero + $unmatched_claims),
+			([$comments[] | (body_text | length)] | add // 0),
+			($explicit_zero_attempt + $unmatched_claims)
+		] | @tsv
+	' 2>/dev/null
+	return $?
 }
 
 _dlw_comment_bloat_metrics() {
@@ -94,11 +170,19 @@ _dlw_comment_bloat_metrics() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || { printf '0\t0\t0\t0\t0'; return 0; }
 	[[ -n "$repo_slug" ]] || { printf '0\t0\t0\t0\t0'; return 0; }
 
+	local orphan_grace="${DISPATCH_CLAIM_ORPHAN_GRACE:-120}"
+	local now_epoch="${DLW_COMMENT_METRICS_NOW_EPOCH:-}"
+	local raw_comments=""
 	local metrics=""
-	# shellcheck disable=SC2016  # jq program is intentionally single-quoted.
-	metrics=$(gh api --paginate "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
-		--jq '[.[] | {body: (.body // "")}] | {comments: length, ops: ([.[] | select(.body | test("ops:start|DISPATCH_CLAIM|CLAIM_RELEASED|dispatch-cooldown|Worker Watchdog Kill"; "i"))] | length), zero: ([.[] | select(.body | test("'"${zero_output_pattern}"'"; "i"))] | length), chars: ([.[].body | length] | add // 0), zero_attempt: ([.[] | select((.body | test("'"${zero_attempt_pattern}"'"; "i")) and (.body | test("session_count=0"; "i")))] | length)} | [.comments, .ops, .zero, .chars, .zero_attempt] | @tsv' \
-		2>/dev/null | awk -F '\t' '{c+=$1; o+=$2; z+=$3; ch+=$4; za+=$5} END {printf "%d\t%d\t%d\t%d\t%d", c+0, o+0, z+0, ch+0, za+0}') || metrics="0	0	0	0	0"
+	[[ "$orphan_grace" =~ ^[0-9]+$ ]] || orphan_grace=120
+	[[ "$orphan_grace" -le 3600 ]] || orphan_grace=120
+	if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
+		now_epoch=$(date -u '+%s' 2>/dev/null || printf '0')
+	fi
+	raw_comments=$(gh api --paginate --slurp \
+		"repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || raw_comments="[]"
+	metrics=$(_dlw_comment_bloat_metrics_from_json "$raw_comments" "$now_epoch" "$orphan_grace" \
+		"$zero_output_pattern" "$zero_attempt_pattern") || metrics=$'0\t0\t0\t0\t0'
 	[[ -n "$metrics" ]] || metrics=$'0\t0\t0\t0\t0'
 	printf '%s' "$metrics"
 	return 0

--- a/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
+++ b/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
@@ -44,11 +44,13 @@ GH_LOCKED=true
 GH_LOCK_RC=0
 GH_API_RC=0
 gh() {
+	local command="${1:-}"
+	local subcommand="${2:-}"
 	printf '%s\n' "$*" >>"$GH_CALLS"
-	if [[ "$1" == "issue" && "$2" == "lock" ]]; then
+	if [[ "$command" == "issue" && "$subcommand" == "lock" ]]; then
 		return "$GH_LOCK_RC"
 	fi
-	if [[ "$1" == "api" ]]; then
+	if [[ "$command" == "api" ]]; then
 		local api_count
 		api_count=$(<"$GH_API_COUNT_FILE")
 		api_count=$((api_count + 1))
@@ -57,7 +59,9 @@ gh() {
 			return "$GH_API_RC"
 		fi
 		if [[ "$GH_LOCKED" == *,* ]]; then
-			printf '%s\n' "$GH_LOCKED" | cut -d, -f"$api_count"
+			local lock_states=()
+			IFS=',' read -r -a lock_states <<<"$GH_LOCKED"
+			printf '%s\n' "${lock_states[$((api_count - 1))]:-}"
 		else
 			printf '%s\n' "$GH_LOCKED"
 		fi

--- a/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
+++ b/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
@@ -175,10 +175,13 @@ gh() {
 		shift || true
 		case "$sub" in
 		comment)
-			# Capture the --body for assertions.
+			# Capture either inline or wrapper-normalized body-file content.
 			while [[ $# -gt 0 ]]; do
 				if [[ "$1" == "--body" ]]; then
 					printf '%s\n---END_COMMENT---\n' "$2" >>"$GH_COMMENT_LOG"
+					shift 2
+				elif [[ "$1" == "--body-file" && -f "${2:-}" ]]; then
+					printf '%s\n---END_COMMENT---\n' "$(<"$2")" >>"$GH_COMMENT_LOG"
 					shift 2
 				else
 					shift
@@ -193,6 +196,26 @@ gh() {
 		;;
 	*) ;;
 	esac
+	return 0
+}
+
+# Keep this lifecycle test focused on idempotency rather than the independent
+# signature/body-file transport wrapper exercised by its own test suite.
+gh_issue_comment() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body)
+			printf '%s\n---END_COMMENT---\n' "$2" >>"$GH_COMMENT_LOG"
+			shift 2
+			;;
+		--body-file)
+			[[ -f "${2:-}" ]] || return 1
+			printf '%s\n---END_COMMENT---\n' "$(<"$2")" >>"$GH_COMMENT_LOG"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 	return 0
 }
 
@@ -228,13 +251,18 @@ sleep() {
 }
 
 STATUS_MUTATION_FAIL=0
+RETAIN_AUTO_DISPATCH_LOCK=0
 set_issue_status() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local status_name="$3"
 	: "$issue_number" "$repo_slug" "$status_name"
 	[[ "$STATUS_MUTATION_FAIL" -eq 0 ]] || return 1
-	printf '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[],"locked":false}' >"$GH_ISSUE_RESPONSE"
+	if [[ "$RETAIN_AUTO_DISPATCH_LOCK" -eq 1 ]]; then
+		printf '{"state":"OPEN","labels":[{"name":"auto-dispatch"},{"name":"status:available"}],"assignees":[],"locked":true}' >"$GH_ISSUE_RESPONSE"
+	else
+		printf '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[],"locked":false}' >"$GH_ISSUE_RESPONSE"
+	fi
 	return 0
 }
 
@@ -340,15 +368,16 @@ fi
 
 reset_gh_state
 _claim_comment_id="claim-123"
-printf '[{"id":"claim-123","body":"DISPATCH_CLAIM nonce=test runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
-printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+printf '[{"id":"claim-123","body":"DISPATCH_CLAIM nonce=test runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"auto-dispatch"},{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+RETAIN_AUTO_DISPATCH_LOCK=1
 _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
 count_abort_release=$(count_gh_comments)
 if [[ "$count_abort_release" -eq 0 ]] &&
 	grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
-	print_result "Fix C: pre-launch abort deletes retained claim" 0
+	print_result "Fix C: pre-launch abort deletes claim while retaining required lock" 0
 else
-	print_result "Fix C: pre-launch abort deletes retained claim" 1 "log: $(cat "$GH_COMMENT_LOG")"
+	print_result "Fix C: pre-launch abort deletes claim while retaining required lock" 1 "log: $(cat "$GH_COMMENT_LOG")"
 fi
 
 if [[ -z "${_claim_comment_id:-}" ]]; then
@@ -357,15 +386,52 @@ else
 	print_result "Fix C: release helper clears retained claim id" 1 "claim id still set: ${_claim_comment_id}"
 fi
 
-if grep -q 'Pre-launch rollback verified' "$LOGFILE"; then
-	print_result "Fix C: pre-launch abort verifies queued ownership rollback" 0
+if grep -q 'Pre-launch rollback verified.*required conversation lock retained' "$LOGFILE"; then
+	print_result "Fix C: pre-launch abort verifies retained-lock ownership rollback" 0
 else
-	print_result "Fix C: pre-launch abort verifies queued ownership rollback" 1 "log: $(cat "$LOGFILE")"
+	print_result "Fix C: pre-launch abort verifies retained-lock ownership rollback" 1 "log: $(cat "$LOGFILE")"
 fi
 
 reset_gh_state
+_claim_comment_id="claim-unlocked"
+printf '[{"id":"claim-unlocked","body":"DISPATCH_CLAIM nonce=unlocked runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+RETAIN_AUTO_DISPATCH_LOCK=0
+_release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
+if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG" &&
+	jq -e '.locked == false' "$GH_ISSUE_RESPONSE" >/dev/null; then
+	print_result "Fix C: ordinary pre-launch rollback still requires an unlocked issue" 0
+else
+	print_result "Fix C: ordinary pre-launch rollback still requires an unlocked issue" 1 "state: $(cat "$GH_ISSUE_RESPONSE")"
+fi
+
+reset_gh_state
+_claim_comment_id="claim-paged"
+printf '[[{"id":"claim-page-1","body":"DISPATCH_CLAIM nonce=old runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}],[{"id":"claim-paged","body":"DISPATCH_CLAIM nonce=current runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}},{"id":"claim-forged","body":"DISPATCH_CLAIM nonce=forged runner=runner-a","author_association":"NONE","user":{"login":"external-user"}}]]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"auto-dispatch"},{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+RETAIN_AUTO_DISPATCH_LOCK=1
+_release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
+if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+	print_result "Fix C: paginated rollback ignores forged external claims and deletes its exact claim" 0
+else
+	print_result "Fix C: paginated rollback ignores forged external claims and deletes its exact claim" 1 "log: $(cat "$GH_COMMENT_LOG")"
+fi
+
+reset_gh_state
+_claim_comment_id="claim-before-assignment"
+printf '[{"id":"claim-before-assignment","body":"DISPATCH_CLAIM nonce=preassign runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"auto-dispatch"},{"name":"status:available"}],"assignees":[],"locked":true}' >"$GH_ISSUE_RESPONSE"
+_release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
+if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG" && jq -e '.locked == true' "$GH_ISSUE_RESPONSE" >/dev/null; then
+	print_result "Fix C: pre-assignment abort deletes its claim without reopening instructions" 0
+else
+	print_result "Fix C: pre-assignment abort deletes its claim without reopening instructions" 1 "state: $(cat "$GH_ISSUE_RESPONSE")"
+fi
+RETAIN_AUTO_DISPATCH_LOCK=0
+
+reset_gh_state
 _claim_comment_id="claim-old"
-printf '[{"id":"claim-old","body":"DISPATCH_CLAIM nonce=old runner=runner-a"},{"id":"claim-new","body":"DISPATCH_CLAIM nonce=new runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '[{"id":"claim-old","body":"DISPATCH_CLAIM nonce=old runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}},{"id":"claim-new","body":"DISPATCH_CLAIM nonce=new runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}]' >"$GH_API_COMMENTS_RESPONSE"
 printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
 if _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"; then
 	print_result "Fix C: older abort cannot clear a newer claim" 1 "rollback unexpectedly succeeded"
@@ -380,7 +446,7 @@ fi
 
 reset_gh_state
 _claim_comment_id="claim-failed-mutation"
-printf '[{"id":"claim-failed-mutation","body":"DISPATCH_CLAIM nonce=failed runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '[{"id":"claim-failed-mutation","body":"DISPATCH_CLAIM nonce=failed runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}]' >"$GH_API_COMMENTS_RESPONSE"
 printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
 STATUS_MUTATION_FAIL=1
 if _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"; then

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -754,8 +754,8 @@ lock_issue_for_worker() {
 }
 _dlw_post_launch_hooks() { return 0; }
 
-# Assignment failure occurs after deterministic gates and prompt preparation,
-# but still before the issue lock and runtime spawn.
+# Assignment failure occurs after deterministic gates, prompt preparation, and
+# verified issue locking, but still before runtime spawn.
 : >"$ORCHESTRATOR_CALLS_FILE"
 : >"${TMP}/setsid-calls.txt"
 STUB_ASSIGN_RC=1
@@ -769,10 +769,10 @@ else
 	fail "assignment failure returns explicit no-op rc=2" "got rc=$assignment_failure_rc"
 fi
 actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
-if [[ "$actual_calls" == "hold precreate final-gates prompt ownership-guard assign " && ! -s "${TMP}/setsid-calls.txt" ]]; then
-	pass "assignment failure occurs at final boundary before lock and spawn"
+if [[ "$actual_calls" == "hold precreate final-gates prompt lock ownership-guard assign " && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "assignment failure occurs after lock verification and before spawn"
 else
-	fail "assignment failure occurs at final boundary before lock and spawn" "calls='$actual_calls'"
+	fail "assignment failure occurs after lock verification and before spawn" "calls='$actual_calls'"
 fi
 STUB_ASSIGN_RC=0
 
@@ -784,10 +784,10 @@ lock_failure_rc=0
 _dispatch_launch_worker "77781" "owner/repo" "test-dispatch" "Test Issue" \
 	"testuser" "$FAKE_REPO" "test prompt" "session-key-lock-failure" "" "{}" || lock_failure_rc=$?
 actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
-if [[ "$lock_failure_rc" -eq 2 && "$actual_calls" == *"lock "* && ! -s "${TMP}/setsid-calls.txt" ]]; then
-	pass "conversation-lock failure blocks worker spawn"
+if [[ "$lock_failure_rc" -eq 2 && "$actual_calls" == "hold precreate final-gates prompt lock " && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "conversation-lock failure blocks ownership mutation and worker spawn"
 else
-	fail "conversation-lock failure blocks worker spawn" "rc=$lock_failure_rc calls='$actual_calls'"
+	fail "conversation-lock failure blocks ownership mutation and worker spawn" "rc=$lock_failure_rc calls='$actual_calls'"
 fi
 STUB_LOCK_RC=0
 
@@ -868,7 +868,8 @@ fi
 STUB_FINAL_GATES_RC=0
 
 # An interactive takeover after worktree precreation must stop before queued
-# assignment, issue lock, or runtime spawn, without removing the worktree.
+# assignment or runtime spawn, without removing the worktree. The issue is
+# already frozen before the final ownership guard reads it.
 : >"$ORCHESTRATOR_CALLS_FILE"
 : >"${TMP}/setsid-calls.txt"
 STUB_FINAL_OWNERSHIP_RC=1
@@ -876,11 +877,11 @@ ownership_fence_rc=0
 _dispatch_launch_worker "77783" "owner/repo" "test-dispatch" "Test Issue" \
 	"testuser" "$FAKE_REPO" "test prompt" "session-key-ownership-fence" "" "{}" || ownership_fence_rc=$?
 actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
-if [[ "$ownership_fence_rc" -eq 2 && "$actual_calls" == "hold precreate final-gates prompt ownership-guard " && \
+if [[ "$ownership_fence_rc" -eq 2 && "$actual_calls" == "hold precreate final-gates prompt lock ownership-guard " && \
 	! -s "${TMP}/setsid-calls.txt" && -d "$ORCHESTRATOR_WORKTREE" ]]; then
-	pass "final ownership fence preserves worktree and blocks assignment, lock, and spawn"
+	pass "final ownership fence preserves worktree and blocks assignment and spawn"
 else
-	fail "final ownership fence preserves worktree and blocks assignment, lock, and spawn" \
+	fail "final ownership fence preserves worktree and blocks assignment and spawn" \
 		"rc=$ownership_fence_rc calls='$actual_calls' worktree=$([[ -d "$ORCHESTRATOR_WORKTREE" ]] && printf present || printf missing)"
 fi
 if [[ "${_DLW_LAST_PRE_RUNTIME_FAILURE:-}" == "final_ownership_fence" ]]; then
@@ -897,7 +898,7 @@ success_rc=0
 _dispatch_launch_worker "77782" "owner/repo" "test-dispatch" "Test Issue" \
 	"testuser" "$FAKE_REPO" "test prompt" "session-key-success" "" "{}" || success_rc=$?
 actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
-if [[ "$success_rc" -eq 0 && "$actual_calls" == "hold precreate final-gates prompt ownership-guard assign lock spawn " && -s "${TMP}/setsid-calls.txt" ]]; then
+if [[ "$success_rc" -eq 0 && "$actual_calls" == "hold precreate final-gates prompt lock ownership-guard assign spawn " && -s "${TMP}/setsid-calls.txt" ]]; then
 	pass "successful launch acquires queued ownership at final boundary"
 else
 	fail "successful launch acquires queued ownership at final boundary" "rc=$success_rc calls='$actual_calls'"

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -19,6 +19,7 @@ source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"
 TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/dlw-comment-metrics-XXXXXX")"
 FAKE_BIN="${TEST_TMP}/bin"
 GH_CALLS_FILE="${TEST_TMP}/gh-calls"
+GH_COMMENTS_FIXTURE="${TEST_TMP}/gh-comments.json"
 mkdir -p "$FAKE_BIN" || exit 1
 
 cleanup() {
@@ -37,20 +38,17 @@ cat >"${FAKE_BIN}/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
 printf '%s\n' "$*" >>"${GH_CALLS_FILE:?}"
-case "$*" in
-*'issues/123/comments'*'@tsv'*)
-	printf '3\t0\t1\t120\t1\n'
-	;;
-*'issues/123/comments'*)
-	printf '1\n'
-	;;
-*)
-	printf 'unexpected gh call: %s\n' "$*" >&2
-	exit 1
-	;;
-esac
+cat "${GH_COMMENTS_FIXTURE:?}"
 EOF
 chmod +x "${FAKE_BIN}/gh" || fail "failed to make fake gh executable"
+
+cat >"$GH_COMMENTS_FIXTURE" <<'EOF'
+[[
+  {"id":1,"body":"CLAIM_RELEASED reason=worker_worktree_continuation_state_rejected session_count=0","created_at":"2026-08-14T00:00:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":2,"body":"ordinary comment","created_at":"2026-08-14T00:01:00Z","author_association":"NONE","user":{"login":"external-user"}},
+  {"id":3,"body":"another ordinary comment","created_at":"2026-08-14T00:02:00Z","author_association":"MEMBER","user":{"login":"runner-a"}}
+]]
+EOF
 
 OBJECTIVE_HELPER="${FAKE_BIN}/objective-reconciliation-helper.sh"
 cat >"$OBJECTIVE_HELPER" <<'EOF'
@@ -66,7 +64,7 @@ EOF
 chmod +x "$OBJECTIVE_HELPER" || fail "failed to make objective helper executable"
 
 PATH="${FAKE_BIN}:${PATH}"
-export GH_CALLS_FILE
+export GH_CALLS_FILE GH_COMMENTS_FIXTURE
 
 LOGFILE="${TEST_TMP}/pulse.log" \
 	CLEAN_ROOM_COMMENT_THRESHOLD=100 \
@@ -113,6 +111,49 @@ if LOGFILE="${TEST_TMP}/pulse.log" \
 	ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD=4 \
 	_dlw_hold_repeated_zero_output "123" "owner/repo" $'12\t12\t4\t60000\t0'; then
 	fail "clean-room mode stopped bypassing a generic zero-output brief rewrite"
+fi
+
+cat >"$GH_COMMENTS_FIXTURE" <<'EOF'
+[[
+  {"id":5,"body":"DISPATCH_CLAIM nonce=forged-1 runner=triage-user lease_token=forged-1 device=external-device session=issue-123 phase=prelaunch expires_at=1577836920","created_at":"2020-01-01T00:00:00Z","author_association":"COLLABORATOR","user":{"login":"triage-user"}},
+  {"id":6,"body":"DISPATCH_CLAIM nonce=forged-2 runner=triage-user lease_token=forged-2 device=external-device session=issue-123 phase=prelaunch expires_at=1577836980","created_at":"2020-01-01T00:01:00Z","author_association":"COLLABORATOR","user":{"login":"triage-user"}},
+  {"id":7,"body":"DISPATCH_CLAIM nonce=forged-3 runner=triage-user lease_token=forged-3 device=external-device session=issue-123 phase=prelaunch expires_at=1577837040","created_at":"2020-01-01T00:02:00Z","author_association":"COLLABORATOR","user":{"login":"triage-user"}},
+  {"id":8,"body":"DISPATCH_CLAIM nonce=forged-4 runner=triage-user lease_token=forged-4 device=external-device session=issue-123 phase=prelaunch expires_at=1577837100","created_at":"2020-01-01T00:03:00Z","author_association":"COLLABORATOR","user":{"login":"triage-user"}}
+]]
+EOF
+untrusted_claim_metrics=$(DLW_COMMENT_METRICS_NOW_EPOCH=1577837200 \
+	DISPATCH_CLAIM_ORPHAN_GRACE=120 _dlw_comment_bloat_metrics "123" "owner/repo")
+IFS=$'\t' read -r _untrusted_comments _untrusted_ops untrusted_zero _untrusted_chars untrusted_zero_attempt <<<"$untrusted_claim_metrics"
+if [[ "$untrusted_zero" != "0" || "$untrusted_zero_attempt" != "0" ]]; then
+	fail "bare-collaborator forged claims entered zero-attempt evidence: ${untrusted_claim_metrics}"
+fi
+if LOGFILE="${TEST_TMP}/pulse.log" ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD=4 \
+	_dlw_hold_repeated_zero_output "123" "owner/repo" "$untrusted_claim_metrics"; then
+	fail "bare-collaborator forged claims triggered the infrastructure hold"
+fi
+
+cat >"$GH_COMMENTS_FIXTURE" <<'EOF'
+[[
+  {"id":10,"body":"DISPATCH_CLAIM nonce=orphan-1 runner=runner-a lease_token=orphan-1 device=device-a session=issue-123 phase=prelaunch expires_at=1577836920","created_at":"2020-01-01T00:00:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":11,"body":"DISPATCH_CLAIM nonce=orphan-2 runner=runner-a lease_token=orphan-2 device=device-a session=issue-123 phase=prelaunch expires_at=1577836980","created_at":"2020-01-01T00:01:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":12,"body":"DISPATCH_CLAIM nonce=orphan-3 runner=runner-a lease_token=orphan-3 device=device-a session=issue-123 phase=prelaunch expires_at=1577837040","created_at":"2020-01-01T00:02:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":13,"body":"DISPATCH_CLAIM nonce=orphan-4 runner=runner-a lease_token=orphan-4 device=device-a session=issue-123 phase=prelaunch expires_at=1577837100","created_at":"2020-01-01T00:03:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":14,"body":"DISPATCH_CLAIM nonce=launched runner=runner-a lease_token=launched device=device-a session=issue-123 phase=prelaunch expires_at=1577837160","created_at":"2020-01-01T00:04:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":16,"body":"DISPATCH_CLAIM nonce=fresh runner=runner-a lease_token=fresh device=device-a session=issue-123 phase=prelaunch expires_at=1577837300","created_at":"2020-01-01T00:06:20Z","author_association":"MEMBER","user":{"login":"runner-a"}}
+], [
+  {"id":15,"body":"DISPATCH_LEASE phase=ready lease_token=launched device=device-a session=issue-123 expires_at=1577844000","created_at":"2020-01-01T00:05:00Z","author_association":"MEMBER","user":{"login":"runner-a"}},
+  {"id":17,"body":"DISPATCH_LEASE phase=ready lease_token=orphan-1-suffix device=device-a session=issue-123 expires_at=1577844000","created_at":"2020-01-01T00:05:30Z","author_association":"MEMBER","user":{"login":"runner-a"}}
+]]
+EOF
+claim_storm_metrics=$(DLW_COMMENT_METRICS_NOW_EPOCH=1577837200 \
+	DISPATCH_CLAIM_ORPHAN_GRACE=120 _dlw_comment_bloat_metrics "123" "owner/repo")
+IFS=$'\t' read -r _storm_comments _storm_ops storm_zero _storm_chars storm_zero_attempt <<<"$claim_storm_metrics"
+if [[ "$storm_zero" != "4" || "$storm_zero_attempt" != "4" ]]; then
+	fail "four unmatched prelaunch claims were not counted as zero-attempt failures: ${claim_storm_metrics}"
+fi
+if ! LOGFILE="${TEST_TMP}/pulse.log" ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD=4 \
+	_dlw_hold_repeated_zero_output "123" "owner/repo" "$claim_storm_metrics"; then
+	fail "unmatched prelaunch claims did not trigger the bounded infrastructure hold"
 fi
 
 LOGFILE="${TEST_TMP}/pulse.log" \
@@ -217,6 +258,8 @@ SCRIPT_DIR="$original_script_dir"
 printf 'PASS: dispatch prompt reuses comment metrics for zero-output fallback\n'
 printf 'PASS: zero-attempt evidence detection uses one shared pattern\n'
 printf 'PASS: zero-attempt infrastructure holds override clean-room brief bypasses\n'
+printf 'PASS: bare-collaborator forged claims cannot trigger the infrastructure hold\n'
+printf 'PASS: unmatched prelaunch claims trigger the bounded infrastructure hold\n'
 printf 'PASS: invalid clean-room snapshots cannot authorize implementation\n'
 printf 'PASS: retry context is bounded, deterministic, and excludes prior prose\n'
 printf 'PASS: registered live workers transition queued issues to in-progress\n'


### PR DESCRIPTION
## Summary

- preserve required auto-dispatch conversation locks while rolling back failed prelaunch ownership
- freeze the worker-readable issue before publishing queued assignment/status ownership
- delete only the exact authenticated runner claim and ignore forged external claim markers
- count old unmatched trusted prelaunch claims in the bounded infrastructure-failure fuse

## Implementation

- centralize the label policy that decides when an auto-dispatch lock must remain active
- normalize paginated comment snapshots and fence rollback to the current runner's authenticated GitHub login
- require OWNER/MEMBER evidence plus exact runner, device, session, and lease-token identity for unmatched-claim metrics
- keep ambiguous bare-COLLABORATOR and external comments from manufacturing hold evidence
- replace the lock-retry fixture's external CSV parser with Bash 3.2-compatible indexed parsing

## Verification

- `.agents/scripts/linters-local.sh --changed`
- ShellCheck on all seven changed shell files
- `test-auto-dispatch-conversation-lock.sh`: 8/8, including macOS Bash 3.2
- `test-dispatch-lifecycle-comms.sh`: 19/19, including macOS Bash 3.2
- `test-precreation-failure-skip.sh`: 48/48
- `test-pulse-dispatch-worker-launch-comment-metrics.sh`: pass, including macOS Bash 3.2
- `test-dispatch-atomic-lease.sh`: pass
- `test-pulse-dispatch-worker-launch-lock.sh`: pass
- independent review: no blocking findings
- bounded live audit: 100 recently updated closed issues plus all 634 comments on the only issue outside the 100-comment window; zero post-close `DISPATCH_CLAIM` or `DISPATCH_LEASE` markers

Resolves #30226

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.260 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 31m and 920,970 tokens on this with the user in an interactive session.