### PR TITLE
GH#30233: fix: isolate cross-repo summary stderr files

### DIFF
--- a/.agents/scripts/contributor-activity-helper-activity.sh
+++ b/.agents/scripts/contributor-activity-helper-activity.sh
@@ -465,11 +465,13 @@ cross_repo_summary() {
 
 	# Collect JSON (with active_days_list) from each repo, then aggregate.
 	# Capture repo_count from stderr line "REPO_COUNT=N".
-	local all_json repo_count_line repo_count
-	all_json=$(_cross_repo_summary_collect_json "$period" "${repo_paths[@]}" 2>/tmp/_crs_stderr) || true
-	repo_count_line=$(grep '^REPO_COUNT=' /tmp/_crs_stderr 2>/dev/null || echo "REPO_COUNT=0")
+	local all_json repo_count_line repo_count stderr_file
+	stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-cross-repo-summary-XXXXXX") || return 1
+	trap 'rm -f "${stderr_file:-}"' RETURN
+	all_json=$(_cross_repo_summary_collect_json "$period" "${repo_paths[@]}" 2>"$stderr_file") || true
+	repo_count_line=$(grep '^REPO_COUNT=' "$stderr_file" 2>/dev/null || echo "REPO_COUNT=0")
 	repo_count="${repo_count_line#REPO_COUNT=}"
-	cat /tmp/_crs_stderr >&2 2>/dev/null || true
+	cat "$stderr_file" >&2 2>/dev/null || true
 
 	_cross_repo_summary_aggregate "$all_json" "$format" "$period" "$repo_count"
 	return 0


### PR DESCRIPTION
Fixes a stats scheduler failure observed in awardsapp/awardsapp#9656.

Resolves #30233.

The cross-repo activity collector used a global `/tmp/_crs_stderr`, so stale ownership or concurrent executions could produce `Permission denied` and feed empty JSON to the dashboard pipeline. Use a per-invocation `mktemp` file and remove it on function return.

## Regression Evidence

The defect depends on a stale root-owned host `/tmp/_crs_stderr` created outside the test process. The repository test harness cannot safely create that ownership state without elevated privileges. Verified instead with Bash syntax checks, ShellCheck, and a live `cross-repo-summary` JSON run using the isolated temporary file.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.261 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
