### PR TITLE
GH#30232: Fix snapshot linked-worktree classification

### DIFF
--- a/.agents/scripts/canonical_git_management.py
+++ b/.agents/scripts/canonical_git_management.py
@@ -38,8 +38,27 @@ def _registered_roots() -> list[Path]:
     return roots
 
 
+def _gitdir_target(root: Path) -> Path | None:
+    dot_git = root / ".git"
+    if not dot_git.is_file():
+        return None
+    try:
+        marker = dot_git.read_text(encoding="utf-8").strip()
+        if not marker.startswith("gitdir:"):
+            return None
+        target = Path(marker.split(":", 1)[1].strip()).expanduser()
+        if not target.is_absolute():
+            target = root / target
+        return target.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
 def is_managed_root(repo_root: str) -> bool:
     root = Path(repo_root).resolve()
+    git_dir = _gitdir_target(root)
+    if git_dir and linked_worktree_root(str(git_dir)) == root:
+        return False
     return (root / ".aidevops.json").is_file() or root in _registered_roots()
 
 
@@ -49,19 +68,8 @@ def is_registered_common_dir(common_dir: str) -> bool:
         dot_git = root / ".git"
         if dot_git.is_dir() and dot_git.resolve() == common:
             return True
-        if not dot_git.is_file():
-            continue
-        try:
-            marker = dot_git.read_text(encoding="utf-8").strip()
-            if not marker.startswith("gitdir:"):
-                continue
-            target = Path(marker.split(":", 1)[1].strip()).expanduser()
-            if not target.is_absolute():
-                target = root / target
-            if target.resolve() == common:
-                return True
-        except (OSError, RuntimeError, ValueError):
-            continue
+        if _gitdir_target(root) == common:
+            return True
     return False
 
 

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -15,6 +15,7 @@ PASSWORD_REPO="${TEST_ROOT}/password-store"
 MARKED_REPO="${TEST_ROOT}/marked-repo"
 SEPARATE_REPO="${TEST_ROOT}/separate-repo"
 SEPARATE_GIT_DIR="${TEST_ROOT}/separate-repo-git"
+SNAPSHOT_REPO="${TEST_ROOT}/snapshot.git"
 TESTS=0
 FAILURES=0
 
@@ -165,6 +166,8 @@ assert_blocked "blocks git-dir-only mutation targeting a registered separate Git
 	"git -C '$PASSWORD_REPO' --git-dir='$SEPARATE_GIT_DIR' update-ref refs/heads/blocked '$INITIAL_HEAD'"
 assert_blocked "blocks an unrelated Git directory from mutating a managed worktree" \
 	"git --git-dir='$PASSWORD_REPO/.git' --work-tree='$MARKED_REPO' reset --hard"
+assert_blocked "blocks an unrelated Git directory from mutating a marker-managed separate-git-dir worktree" \
+	"git --git-dir='$PASSWORD_REPO/.git' --work-tree='$SEPARATE_REPO' reset --hard"
 assert_allowed "allows gopass-style Git mutation in an unrelated password store" "$REPO" \
 	"git -C '$PASSWORD_REPO' add test-secret.gpg"
 if (cd "$REPO" && env PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" -C "$PASSWORD_REPO" add test-secret.gpg); then
@@ -226,6 +229,9 @@ assert_allowed "allows unrelated writes in an unmanaged isolated bare temp repo"
 	"$REPO" "git -C '$PROSPECTIVE_REPO' update-ref refs/heads/main '$INITIAL_HEAD'"
 
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
+git init --bare -q "$SNAPSHOT_REPO"
+assert_allowed "allows an isolated snapshot repository to index a linked worktree" "$REPO" \
+	"git --git-dir='$SNAPSHOT_REPO' --work-tree='$LINKED' add --all --sparse"
 assert_allowed "allows canonical linked worktree removal" "$REPO" "git worktree remove --force '$LINKED'"
 assert_allowed "allows canonical linked worktree removal with option terminator" "$REPO" "git worktree remove -f -- '$LINKED'"
 assert_blocked "blocks canonical worktree removal of canonical root" "git worktree remove --force '$REPO'"


### PR DESCRIPTION
## Summary

Classify explicit snapshot work-tree targets by reciprocal linked-worktree metadata instead of the tracked aidevops marker alone, while retaining canonical protection for separate-git-dir repositories.

## Files Changed

.agents/scripts/canonical_git_management.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 93 canonical Git guard tests pass; Python compilation, ShellCheck, git diff check, and linters-local --changed pass.

Resolves #30232


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.261 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 28m and 181,799 tokens on this with the user in an interactive session.