### PR TITLE
GH#30236: docs: add source-level external-tool evaluation guidance

### DIFF
--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -52,7 +52,7 @@ Full index: `subagent-index.toon`.
 | Business | company ops, finance, invoice, receipts, strategy, runners | Company operations, financial ops, invoicing, receipts, runner configs, strategy |
 | Legal | legal, compliance, privacy policy, terms, contract, GDPR | Compliance, terms of service, privacy policy |
 | Vault | vault, encrypted memory, protected data, lock, unlock, rekey, device trust, remote lock, remote unlock, secure sync | Vault setup/management, protected-data routing, encrypted sync/fleet trust, remote lock/unlock-request, secure-message policy |
-| Research | research, compare, market, competitor, technical analysis | Tech research, competitive analysis, market research |
+| Research | research, compare, market, competitor, technical analysis, external tool, repository evaluation, do we already do this, adoption fit | Tech research, competitive analysis, market research, and external tool/repository evaluation; use `reference/external-tool-evaluation.md` for source-level adoption decisions |
 | Health | health, wellness, nutrition, fitness, medical lifestyle | Health and wellness content |
 
 For narrower domains such as Reports, App Stack, WordPress, Shopify, Cloudflare, Proxmox, Remotion, CalDAV, public relations, or browser/mobile work, read `reference/domain-index.md` and the relevant skill/subagent entry before defaulting to Build+. For repeatable browser operations or web data mining, route through `/auto-browse` and `.agents/workflows/auto-browse.md` so profile state, safety gates, and private/shareable artifact boundaries are handled consistently.

--- a/.agents/reference/external-tool-evaluation.md
+++ b/.agents/reference/external-tool-evaluation.md
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# External Tool Evaluation
+
+Use this reference when evaluating an external tool, product, framework, or
+repository against aidevops: for example, “do we already do this?”, “what can
+we learn?”, or “should we adopt it?”. Route those questions to Research; keep
+implementation as a separately authorised task.
+
+## Decision workflow
+
+1. State the inspection depth before making implementation claims:
+   documentation only; repository metadata; immutable source/test snapshot; or
+   operational issues and releases. Report unavailable sources as uncertainty.
+2. Start with official claims, then distinguish them from source behaviour and
+   operational reports. Do not execute installation commands or repository
+   code; scan untrusted external content and keep research read-only.
+3. Compare the upstream implementation with aidevops' actual code and
+   enforcement, not feature names or guidance alone. Classify overlap as
+   equivalent, partial, complementary, absent, or deliberately omitted.
+4. Assess marginal value: model/API-call amplification, serial or queue
+   latency, CPU/RAM/API pressure, retry and false-positive-verification cost,
+   human/agent attention, upgrade burden, and duplicate authority or state.
+5. Check failure semantics where decision-relevant: fail-open or blocking
+   behaviour, retry/convergence bounds, cancellation and crash recovery,
+   deduplication boundaries, sandboxing, and credential exposure.
+6. Choose one outcome: adopt, adapt existing machinery, reference-only, defer,
+   or reject/no action. Name evidence-backed reconsideration triggers such as
+   observed failures or measurable waste.
+
+## Evidence and decision guard
+
+Label conclusions as source-backed fact, maintainer claim, user issue report,
+inference, or absent evidence. Issue reports are reports, not confirmed defects
+without corroboration. Stop once the evidence can change the decision; source
+inspection is decision-relevant, not ceremonial archaeology.
+
+Parity is not value, and a missing feature is not automatically a gap. Do not
+recommend an implementation issue from another project's feature list alone:
+require an observed failure, measurable waste, or credible expected benefit.
+Deliberate omission, no action, and reusing already-sufficient machinery are
+successful outcomes. An experiment is justified only when its result can change
+the decision.

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -46,19 +46,20 @@ Stay in analyst mode. Answer with findings, evidence, and recommendations; do no
 3. Identify gaps, risks, and opportunities
 4. Report with evidence
 
-### Tool evaluation
+### External tool and repository evaluation
 
-1. Verify official docs and maintenance status
-2. Check adoption and ecosystem fit
-3. Compare realistic alternatives
-4. Recommend one option with rationale
+For questions about whether aidevops already duplicates an external tool or
+repository, what is worth learning, or whether to adopt it, use
+`reference/external-tool-evaluation.md`. State inspection depth, compare actual
+implementations, assess marginal cost/friction and failure boundaries, and make
+an evidence-backed recommendation that can reject or take no action.
 
 ### Output format
 
 - Decision
 - Options
 - Evidence/citations
-- Recommendation
+- Recommendation, including no action when warranted
 - Next steps
 
 Research informs implementation; it does not perform it.

--- a/.agents/tests/comprehension/reference--agent-routing.yaml
+++ b/.agents/tests/comprehension/reference--agent-routing.yaml
@@ -71,3 +71,24 @@ scenarios:
       delegation overhead would cost more than it saves.
     fast_fail_triggers:
       - refusal
+
+  - name: "routes external-tool adoption evaluation to Research"
+    prompt: "Someone sent https://example.invalid/tool. Do we already do this, is there value to learn, and is it worth adopting?"
+    expected:
+      contains:
+        - "Research"
+        - "source"
+        - "cost"
+        - "no action"
+      min_length: 70
+      max_length: 700
+    reference_answer: |
+      Route this to Research and use reference/external-tool-evaluation.md.
+      State the inspection depth, inspect source and tests when implementation
+      claims affect the recommendation, and compare the actual local
+      implementation rather than feature names. Assess marginal model/API cost,
+      latency, resource and maintenance friction, security and failure
+      boundaries, then allow an evidence-backed rejection or no action rather
+      than treating feature parity as value.
+    fast_fail_triggers:
+      - refusal


### PR DESCRIPTION
## Summary

Added a canonical source-level rubric for external tool and repository evaluations, then connected Research routing and comprehension coverage.

## Files Changed

.agents/reference/agent-routing.md, .agents/reference/external-tool-evaluation.md, .agents/research.md, .agents/tests/comprehension/reference--agent-routing.yaml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/linters-local.sh (passed); comprehension benchmark attempted but exceeded the 360-second command bound without reporting a result

Resolves #30236


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.261 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 15m and 65,519 tokens on this as a headless worker.