### PR TITLE
perf: bound release tag discovery latency in status and release guards

### DIFF
--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -192,7 +192,9 @@ _full_loop_release_guard_existing() {
 	local receipt_path=""
 	local release_status=""
 	local existing_tag_rc=0
+	local guard_started=""
 
+	guard_started=$(_full_loop_release_timing_start release-existing-guard)
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$source_pr") || return 1
 	if [[ -f "$receipt_path" ]]; then
 		IFS= read -r release_status <"$receipt_path" || return 1
@@ -201,12 +203,14 @@ _full_loop_release_guard_existing() {
 	"$_FULL_LOOP_RELEASE_PUBLISHED")
 		full_loop_update_cleanup_release_status "$repo" "$source_pr" "$release_status" || return 1
 		printf 'release:published already recorded for PR #%s; skipping duplicate publication\n' "$source_pr"
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" receipt-published
 		return 0
 		;;
 	"$_FULL_LOOP_RELEASE_SUPERSEDED")
 		_full_loop_verify_superseded_release_receipt "$repo" "$source_pr" || return 1
 		full_loop_update_cleanup_release_status "$repo" "$source_pr" "$release_status" || return 1
 		printf 'release:superseded already recorded for PR #%s; skipping duplicate publication\n' "$source_pr"
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" receipt-superseded
 		return 0
 		;;
 	"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
@@ -216,6 +220,7 @@ _full_loop_release_guard_existing() {
 	"" | "$_FULL_LOOP_PHASE_FAILED") ;;
 	*)
 		printf 'Cannot replace unknown release:%s evidence for PR #%s\n' "$release_status" "$source_pr" >&2
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" failed
 		return 1
 		;;
 	esac
@@ -224,12 +229,22 @@ _full_loop_release_guard_existing() {
 	0)
 		_full_loop_release_validate_existing_tag_authorization "$repo" "$source_pr" "$expected_sources" || return 1
 		printf 'Existing signed release tag found for PR #%s; reconciling without another version bump\n' "$source_pr"
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" existing-tag
 		_full_loop_release_existing_command reconcile "$source_pr"
 		return $?
 		;;
-	1) return 1 ;;
-	2) return 2 ;;
-	*) return 1 ;;
+	1)
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" failed
+		return 1
+		;;
+	2)
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" no-tag
+		return 2
+		;;
+	*)
+		_full_loop_release_timing_finish release-existing-guard "$guard_started" failed
+		return 1
+		;;
 	esac
 }
 
@@ -251,6 +266,56 @@ EOF
 	return 0
 }
 
+_full_loop_release_prepare_new() {
+	local repo="$1"
+	local source_pr="$2"
+	local release_path="$3"
+	local resolver="$4"
+	local expected_sources="$5"
+	local phase_started=""
+
+	phase_started=$(_full_loop_release_timing_start release-run-fetch-main)
+	if ! git -C "$REPO_ROOT" fetch origin main >/dev/null; then
+		_full_loop_release_timing_finish release-run-fetch-main "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-fetch-main "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-run-worktree-add)
+	if ! git -C "$REPO_ROOT" worktree add --detach "$release_path" origin/main >/dev/null; then
+		_full_loop_release_timing_finish release-run-worktree-add "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-worktree-add "$phase_started" ok
+	_FULL_LOOP_RELEASE_PATH="$release_path"
+	trap 'cleanup_release_worktree' EXIT
+
+	phase_started=$(_full_loop_release_timing_start release-run-capture-authorization)
+	if ! _full_loop_capture_release_authorization "$repo" "$source_pr" "$release_path" "$resolver" "$expected_sources"; then
+		_full_loop_release_timing_finish release-run-capture-authorization "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-capture-authorization "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-run-resolve-source)
+	if ! _full_loop_resolve_requested_release_source "$repo" "$source_pr" "$release_path" "$resolver" "$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"; then
+		_full_loop_release_timing_finish release-run-resolve-source "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-resolve-source "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-run-validate-candidates)
+	if ! _full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON"; then
+		_full_loop_release_timing_finish release-run-validate-candidates "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-validate-candidates "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-run-lane-preparing)
+	if ! release_lane_update "$repo" "$source_pr" "preparing"; then
+		_full_loop_release_timing_finish release-run-lane-preparing "$phase_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-lane-preparing "$phase_started" ok
+	return 0
+}
+
 _full_loop_release_run_new() {
 	local repo="$1"
 	local source_pr="$2"
@@ -262,21 +327,26 @@ _full_loop_release_run_new() {
 	local resolver=""
 	local version_manager=""
 	local release_rc=0
-	[[ -d "$worktree_base" ]] || return 1
-	git -C "$REPO_ROOT" fetch origin main >/dev/null || return 1
-	git -C "$REPO_ROOT" worktree add --detach "$release_path" origin/main >/dev/null || return 1
-	_FULL_LOOP_RELEASE_PATH="$release_path"
-	trap 'cleanup_release_worktree' EXIT
-
+	local run_started=""
+	local phase_started=""
+	run_started=$(_full_loop_release_timing_start release-run-new)
+	if [[ ! -d "$worktree_base" ]]; then
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
+		return 1
+	fi
 	resolver="${AIDEVOPS_FULL_LOOP_SOURCE_RESOLVER:-$release_path/.agents/scripts/release-provenance-helper.sh}"
-	_full_loop_capture_release_authorization "$repo" "$source_pr" "$release_path" "$resolver" "$expected_sources" || return 1
-	_full_loop_resolve_requested_release_source "$repo" "$source_pr" "$release_path" "$resolver" "$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES" || return 1
-	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
-	release_lane_update "$repo" "$source_pr" "preparing" || return 1
+	if ! _full_loop_release_prepare_new "$repo" "$source_pr" "$release_path" "$resolver" "$expected_sources"; then
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
+		return 1
+	fi
 
 	version_manager="${AIDEVOPS_FULL_LOOP_VERSION_MANAGER:-$release_path/.agents/scripts/version-manager.sh}"
 	[[ "$version_manager" = /* ]] || version_manager="$PWD/$version_manager"
-	[[ -f "$version_manager" ]] || return 1
+	if [[ ! -f "$version_manager" ]]; then
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
+		return 1
+	fi
+	phase_started=$(_full_loop_release_timing_start release-run-version-manager)
 	(
 		trap - EXIT
 		cd "$release_path" || exit 1
@@ -287,26 +357,42 @@ _full_loop_release_run_new() {
 			--expected-sources "$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"
 	) || release_rc=$?
 	if [[ "$release_rc" -eq 8 ]]; then
+		_full_loop_release_timing_finish release-run-version-manager "$phase_started" queued
 		local queued_tag=""
 		[[ -r "$release_path/VERSION" ]] && queued_tag="v$(tr -d '[:space:]' <"$release_path/VERSION")"
 		release_lane_update "$repo" "$source_pr" "remote-publication" "$queued_tag" || return 1
 		printf 'release:queued for PR #%s; publication continues remotely\n' "$source_pr"
 		printf 'Resume with: aidevops release reconcile %s\n' "$source_pr"
+		_full_loop_release_timing_finish release-run-new "$run_started" queued
 		return 8
 	fi
 	if [[ "$release_rc" -ne 0 ]]; then
+		_full_loop_release_timing_finish release-run-version-manager "$phase_started" failed
 		release_lane_update "$repo" "$source_pr" "reconcile-required" || true
 		_full_loop_write_release_failure_evidence "$repo" "$source_pr" "$_FULL_LOOP_RESOLVED_REQUESTED_MERGE" \
 			"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" "$_FULL_LOOP_RESOLVED_SOURCE_PR" || true
 		printf 'Publication may still be durable or queued. Reconcile without another version bump:\n' >&2
 		printf '  aidevops release status %s\n' "$source_pr" >&2
 		printf '  aidevops release reconcile %s\n' "$source_pr" >&2
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
 		return 1
 	fi
+	_full_loop_release_timing_finish release-run-version-manager "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-run-persist-success)
 	_full_loop_persist_release_success "$repo" "$release_path" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" \
-		"$_FULL_LOOP_RESOLVED_SOURCE_PR" "$_FULL_LOOP_RESOLVED_SOURCE_MERGE" || return 1
-	release_lane_finalize "$repo" "$source_pr" "published"
-	return $?
+		"$_FULL_LOOP_RESOLVED_SOURCE_PR" "$_FULL_LOOP_RESOLVED_SOURCE_MERGE" || {
+		_full_loop_release_timing_finish release-run-persist-success "$phase_started" failed
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
+		return 1
+	}
+	if ! release_lane_finalize "$repo" "$source_pr" "published"; then
+		_full_loop_release_timing_finish release-run-persist-success "$phase_started" failed
+		_full_loop_release_timing_finish release-run-new "$run_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-run-persist-success "$phase_started" ok
+	_full_loop_release_timing_finish release-run-new "$run_started" published
+	return 0
 }
 
 _full_loop_release_existing_with_lane() {

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -30,6 +30,45 @@ _FULL_LOOP_RELEASE_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2
 # shellcheck source=./version-manager-protected-main.sh
 source "${SCRIPT_DIR}/version-manager-protected-main.sh"
 
+_full_loop_release_epoch_seconds() {
+	date +%s 2>/dev/null
+	return $?
+}
+
+_full_loop_release_timing_start() {
+	local phase="$1"
+	local started_at=""
+
+	started_at=$(_full_loop_release_epoch_seconds || true)
+	[[ "$started_at" =~ ^[0-9]+$ ]] || started_at=0
+	printf 'RELEASE_TIMING phase=%s state=start\n' "$phase" >&2
+	printf '%s\n' "$started_at"
+	return 0
+}
+
+_full_loop_release_timing_finish() {
+	local phase="$1"
+	local started_at="$2"
+	local result="$3"
+	local item_count="${4:-}"
+	local finished_at=""
+	local elapsed_seconds=0
+
+	finished_at=$(_full_loop_release_epoch_seconds || true)
+	if [[ "$started_at" =~ ^[0-9]+$ && "$finished_at" =~ ^[0-9]+$ &&
+		"$finished_at" -ge "$started_at" ]]; then
+		elapsed_seconds=$((finished_at - started_at))
+	fi
+	if [[ "$item_count" =~ ^[0-9]+$ ]]; then
+		printf 'RELEASE_TIMING phase=%s state=finish elapsed_seconds=%s result=%s items=%s\n' \
+			"$phase" "$elapsed_seconds" "$result" "$item_count" >&2
+	else
+		printf 'RELEASE_TIMING phase=%s state=finish elapsed_seconds=%s result=%s\n' \
+			"$phase" "$elapsed_seconds" "$result" >&2
+	fi
+	return 0
+}
+
 _full_loop_release_tag_body() {
 	local tag_name="$1"
 	git -C "$REPO_ROOT" for-each-ref --format='%(contents)' "refs/tags/${tag_name}"
@@ -92,6 +131,49 @@ _full_loop_release_verify_candidate_tag_provenance() {
 	return 1
 }
 
+_full_loop_release_raw_candidate_tags_for_pr() {
+	local requested_pr="$1"
+	local legacy_source_lookup="$2"
+	local candidate_tag=""
+	local tag_body=""
+	local trailer=""
+	local source_merge=""
+	local legacy_source_marker=""
+	local matched=0
+	local pipeline_status=()
+
+	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
+	git -C "$REPO_ROOT" for-each-ref --sort=-version:refname \
+		--format='%(refname:short)%00%(contents)%00' 'refs/tags/v[0-9]*.[0-9]*.[0-9]*' |
+		while IFS= read -r -d '' candidate_tag && IFS= read -r -d '' tag_body; do
+			candidate_tag="${candidate_tag#$'\n'}"
+			[[ -n "$candidate_tag" ]] || continue
+			matched=0
+			source_merge=""
+			while IFS= read -r trailer; do
+				case "$trailer" in
+				"Aidevops-Source-PR: ${requested_pr}" | "Aidevops-Aggregated-Source: ${requested_pr}@"*)
+					matched=1
+					;;
+				"Aidevops-Source-Merge: "*)
+					source_merge="${trailer#Aidevops-Source-Merge: }"
+					;;
+				esac
+			done <<<"$tag_body"
+			if [[ "$matched" -eq 0 && -n "$source_merge" ]]; then
+				legacy_source_marker=",${source_merge},"
+				[[ "$legacy_source_lookup" == *"$legacy_source_marker"* ]] && matched=1
+			fi
+			if [[ "$matched" -eq 1 ]]; then
+				printf '%s\n' "$candidate_tag"
+			fi
+			true
+		done
+	pipeline_status=("${PIPESTATUS[@]}")
+	[[ "${pipeline_status[0]}" -eq 0 && "${pipeline_status[1]}" -eq 0 ]] || return 1
+	return 0
+}
+
 _full_loop_release_candidate_tags_for_pr() {
 	local requested_pr="$1"
 	local ref_format='%(refname:short)%1f'
@@ -134,10 +216,11 @@ _full_loop_release_candidate_tags_for_pr() {
 	if [[ "$emitted" -eq 0 ]]; then
 		# Some signed annotated tags do not expose parsed custom trailers through
 		# `for-each-ref %(trailers:...)` even though their raw tag body is valid and
-		# `_full_loop_release_source_json_from_tag` can verify it. Fall back to a full
-		# newest-first semver tag scan so recovery remains correct; the caller still
-		# performs strict body/provenance checks before accepting any tag.
-		git -C "$REPO_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname || return 1
+		# `_full_loop_release_source_json_from_tag` can verify it. Build one raw-body
+		# index and emit only tags with an exact direct, aggregate, or legacy source
+		# marker. The caller still reconstructs and verifies every emitted candidate,
+		# while no-match lookups avoid reconstructing every historical release.
+		_full_loop_release_raw_candidate_tags_for_pr "$requested_pr" "$legacy_source_lookup" || return 1
 	fi
 	return 0
 }
@@ -152,13 +235,40 @@ _full_loop_release_find_tag_for_pr() {
 	local source_json=""
 	local requested_present="false"
 	local textually_matched=0
+	local candidate_count=0
+	local candidate_number=0
+	local discovery_started=""
+	local phase_started=""
 
 	_FULL_LOOP_RELEASE_FOUND_TAG=""
-	git -C "$REPO_ROOT" fetch origin --tags --quiet || return 1
-	candidate_tags=$(_full_loop_release_candidate_tags_for_pr "$requested_pr") || return 1
+	discovery_started=$(_full_loop_release_timing_start release-tag-discovery)
+	phase_started=$(_full_loop_release_timing_start release-tag-fetch)
+	if ! git -C "$REPO_ROOT" fetch origin --tags --quiet; then
+		_full_loop_release_timing_finish release-tag-fetch "$phase_started" failed
+		_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed
+		return 1
+	fi
+	_full_loop_release_timing_finish release-tag-fetch "$phase_started" ok
+	phase_started=$(_full_loop_release_timing_start release-tag-candidate-index)
+	if ! candidate_tags=$(_full_loop_release_candidate_tags_for_pr "$requested_pr"); then
+		_full_loop_release_timing_finish release-tag-candidate-index "$phase_started" failed
+		_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed
+		return 1
+	fi
+	while IFS= read -r candidate_tag; do
+		[[ -n "$candidate_tag" ]] && candidate_count=$((candidate_count + 1))
+	done <<<"$candidate_tags"
+	_full_loop_release_timing_finish release-tag-candidate-index "$phase_started" ok "$candidate_count"
 	while IFS= read -r candidate_tag; do
 		[[ -n "$candidate_tag" ]] || continue
-		tag_body=$(_full_loop_release_tag_body "$candidate_tag") || return 1
+		candidate_number=$((candidate_number + 1))
+		phase_started=$(_full_loop_release_timing_start release-tag-candidate-body)
+		if ! tag_body=$(_full_loop_release_tag_body "$candidate_tag"); then
+			_full_loop_release_timing_finish release-tag-candidate-body "$phase_started" failed "$candidate_number"
+			_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed "$candidate_count"
+			return 1
+		fi
+		_full_loop_release_timing_finish release-tag-candidate-body "$phase_started" ok "$candidate_number"
 		textually_matched=0
 		while IFS= read -r trailer; do
 			case "$trailer" in
@@ -168,20 +278,38 @@ _full_loop_release_find_tag_for_pr() {
 				;;
 			esac
 		done <<<"$tag_body"
+		phase_started=$(_full_loop_release_timing_start release-tag-provenance-reconstruction)
 		if ! source_json=$(_full_loop_release_source_json_from_tag "$candidate_tag"); then
-			[[ "$textually_matched" -eq 0 ]] || return 1
+			_full_loop_release_timing_finish release-tag-provenance-reconstruction "$phase_started" invalid "$candidate_number"
+			if [[ "$textually_matched" -ne 0 ]]; then
+				_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed "$candidate_count"
+				return 1
+			fi
 			continue
 		fi
+		_full_loop_release_timing_finish release-tag-provenance-reconstruction "$phase_started" ok "$candidate_number"
 		requested_present=$(jq -r --argjson requested "$requested_pr" \
-			'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
+			'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || {
+			_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed "$candidate_count"
+			return 1
+		}
 		if [[ "$textually_matched" -eq 1 && "$requested_present" != "$_FULL_LOOP_RELEASE_TRUE" ]]; then
+			_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed "$candidate_count"
 			return 1
 		fi
 		[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || continue
-		_full_loop_release_verify_candidate_tag_provenance "$repo" "$candidate_tag" || return 1
+		phase_started=$(_full_loop_release_timing_start release-tag-signature-verification)
+		if ! _full_loop_release_verify_candidate_tag_provenance "$repo" "$candidate_tag"; then
+			_full_loop_release_timing_finish release-tag-signature-verification "$phase_started" failed "$candidate_number"
+			_full_loop_release_timing_finish release-tag-discovery "$discovery_started" failed "$candidate_count"
+			return 1
+		fi
+		_full_loop_release_timing_finish release-tag-signature-verification "$phase_started" ok "$candidate_number"
 		_FULL_LOOP_RELEASE_FOUND_TAG="$candidate_tag"
+		_full_loop_release_timing_finish release-tag-discovery "$discovery_started" found "$candidate_count"
 		return 0
 	done <<<"$candidate_tags"
+	_full_loop_release_timing_finish release-tag-discovery "$discovery_started" not-found "$candidate_count"
 	return 2
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -8,7 +8,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 mkdir -p "$ROOT/bin" "$ROOT/repo/linked-branch" "$ROOT/repo/.agents/scripts" \
-	"$ROOT/repo/.git" "$ROOT/worktrees" "$ROOT/cleanup"
+	"$ROOT/repo/.git" "$ROOT/worktrees" "$ROOT/cleanup" "$ROOT/state"
+export AIDEVOPS_STATE_DIR="$ROOT/state"
+export LANE_HEAD_FILE="$ROOT/lane-head"
+export LANE_STATE_FILE="$ROOT/lane-state.json"
 : >"$ROOT/repo/aidevops.sh"
 : >"$ROOT/repo/.agents/scripts/version-manager.sh"
 
@@ -41,6 +44,56 @@ chmod +x "$ROOT/bin/git"
 
 cat >"$ROOT/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "api" ]]; then
+	endpoint=""
+	for api_arg in "$@"; do
+		case "$api_arg" in repos/*) endpoint="$api_arg" ;; esac
+	done
+	case "$endpoint" in
+	"repos/marcusquinn/aidevops/git/ref/heads/aidevops/release-lane")
+		if [[ -f "${LANE_HEAD_FILE:?}" ]]; then
+			IFS= read -r lane_head <"$LANE_HEAD_FILE"
+			printf '%s\n' "$lane_head"
+			exit 0
+		fi
+		[[ "$*" == *"--include"* ]] && printf 'HTTP/2 404\n'
+		exit 1
+		;;
+	"repos/marcusquinn/aidevops/git/ref/heads/main")
+		printf '%040d\n' 0
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/git/commits/"*)
+		printf '%040d\n' 1
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/git/blobs")
+		payload=$(</dev/stdin)
+		jq -r '.content' <<<"$payload" >"${LANE_STATE_FILE:?}"
+		printf '%040d\n' 2
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/git/trees")
+		printf '%040d\n' 3
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/git/commits")
+		printf '%040d\n' 4
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/git/refs" | "repos/marcusquinn/aidevops/git/refs/heads/aidevops/release-lane")
+		printf '%040d\n' 4 >"${LANE_HEAD_FILE:?}"
+		exit 0
+		;;
+	"repos/marcusquinn/aidevops/contents/.aidevops-release-lane.json?ref="*)
+		[[ -f "${LANE_STATE_FILE:?}" ]] || exit 1
+		IFS= read -r lane_state <"$LANE_STATE_FILE"
+		printf '%s\n' "$lane_state"
+		exit 0
+		;;
+	esac
+	exit 1
+fi
 if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
 	printf 'repo-view-cwd=%s\n' "$PWD" >>"${GH_CALL_LOG:?}"
 	case "$PWD" in
@@ -192,6 +245,7 @@ if [[ "$pending_rc" -ne 8 ||
 	exit 1
 fi
 printf 'PASS durable queued release returns pending without false terminal evidence\n'
+rm -f "$LANE_HEAD_FILE" "$LANE_STATE_FILE"
 
 if (
 	cd "$ROOT/repo/linked-branch"
@@ -214,6 +268,7 @@ grep -qx 'failed' "$ROOT/receipts/marcusquinn_aidevops-43.status"
 jq -e '.status == "failed" and .requested_pr == 43 and .requested_merge == .current_head' \
 	"$ROOT/receipts/marcusquinn_aidevops-43.failure.json" >/dev/null
 printf 'PASS failed release persists actionable provenance without publication evidence\n'
+rm -f "$LANE_HEAD_FILE" "$LANE_STATE_FILE"
 
 if (
 	cd "$ROOT/repo/linked-branch"
@@ -232,6 +287,7 @@ jq -e '.requested_pr == 47 and .requested_merge == "0000000000000000000000000000
 	and .current_head == "0000000000000000000000000000000000000000" and .release_source_pr == null' \
 	"$ROOT/receipts/marcusquinn_aidevops-47.failure.json" >/dev/null
 printf 'PASS intervening main commit records both SHAs without publication\n'
+rm -f "$LANE_HEAD_FILE" "$LANE_STATE_FILE"
 
 printf '%s\n' not-requested >"$ROOT/receipts/marcusquinn_aidevops-44.status"
 cp "$ROOT/vm.log" "$ROOT/vm-before-skipped-release.log"

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -530,14 +530,19 @@ fallback_candidate_tags_file="${TEST_ROOT}/candidate-tags-fallback.txt"
 	git() {
 		local args="$*"
 		case "$args" in
+		*"%(refname:short)%00%(contents)%00"*)
+			printf 'v2.0.0\0Aidevops-Source-PR: 89\0\n'
+			printf 'v1.9.0\0Aidevops-Aggregated-Source: 89@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0\n'
+			printf 'v1.8.0\0Aidevops-Source-PR: 90\nAidevops-Source-Merge: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\0\n'
+			;;
 		*" for-each-ref "*)
 			printf '%b\n' \
 				'v2.0.0\x1f\x1f\x1f' \
-				'v1.9.0\x1f\x1f\x1f'
+				'v1.9.0\x1f\x1f\x1f' \
+				'v1.8.0\x1f\x1f\x1f'
 			;;
-		*" log --all --fixed-strings "*) return 0 ;;
-		*" tag --list "*)
-			printf '%s\n' v2.0.0 v1.9.0
+		*" log --all --fixed-strings "*)
+			printf '%s\n' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 			;;
 		*) return 1 ;;
 		esac
@@ -546,11 +551,11 @@ fallback_candidate_tags_file="${TEST_ROOT}/candidate-tags-fallback.txt"
 	_full_loop_release_candidate_tags_for_pr 89
 ) >"$fallback_candidate_tags_file"
 fallback_candidate_tags=$(<"$fallback_candidate_tags_file")
-if [[ "$fallback_candidate_tags" != $'v2.0.0\nv1.9.0' ]]; then
-	printf 'FAIL empty trailer index did not fall back to full tag scan\n'
+if [[ "$fallback_candidate_tags" != $'v2.0.0\nv1.9.0\nv1.8.0' ]]; then
+	printf 'FAIL empty trailer index did not build an exact raw-body candidate index\n'
 	exit 1
 fi
-printf 'PASS empty trailer index falls back to full tag scan\n'
+printf 'PASS empty trailer index covers direct, aggregate, and legacy raw-body candidates\n'
 
 fallback_find_tag_file="${TEST_ROOT}/find-tag-fallback.txt"
 (
@@ -558,11 +563,13 @@ fallback_find_tag_file="${TEST_ROOT}/find-tag-fallback.txt"
 		local args="$*"
 		case "$args" in
 		*" fetch origin --tags --quiet"*) return 0 ;;
+		*"%(refname:short)%00%(contents)%00"*)
+			printf 'v2.0.0\0Aidevops-Source-PR: 89\0\n'
+			;;
 		*" for-each-ref "*)
 			printf '%b\n' 'v2.0.0\x1f\x1f\x1f'
 			;;
 		*" log --all --fixed-strings "*) return 0 ;;
-		*" tag --list "*) printf '%s\n' v2.0.0 ;;
 		*) return 1 ;;
 		esac
 		return 0
@@ -589,6 +596,115 @@ if [[ "$fallback_find_tag" != "v2.0.0" ]]; then
 	exit 1
 fi
 printf 'PASS full tag fallback recovers a body-parseable signed tag\n'
+
+malformed_tag_log="${TEST_ROOT}/malformed-tag-timing.log"
+if (
+	git() {
+		local args="$*"
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*"%(refname:short)%00%(contents)%00"*)
+			printf 'v2.0.1\0Aidevops-Source-PR: 89\0\n'
+			;;
+		*" for-each-ref "*) printf '%b\n' 'v2.0.1\x1f\x1f\x1f' ;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v2.0.1" ]] || return 1
+		printf '%s\n' 'Aidevops-Source-PR: 89'
+		return 0
+	}
+	_full_loop_release_source_json_from_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v2.0.1" ]] || return 1
+		return 1
+	}
+	_full_loop_release_find_tag_for_pr test/repo 89 2>"$malformed_tag_log"
+); then
+	printf 'FAIL malformed matching tag was treated as a safe no-match\n'
+	exit 1
+fi
+if ! grep -q 'phase=release-tag-provenance-reconstruction .*result=invalid' "$malformed_tag_log"; then
+	printf 'FAIL malformed tag diagnostics did not identify provenance reconstruction\n'
+	exit 1
+fi
+printf 'PASS malformed matching tags fail closed with phase diagnostics\n'
+
+large_scan_log="${TEST_ROOT}/large-scan.log"
+large_body_log="${TEST_ROOT}/large-body.log"
+large_reconstruction_log="${TEST_ROOT}/large-reconstruction.log"
+large_timing_log="${TEST_ROOT}/large-timing.log"
+stale_receipt="${TEST_ROOT}/receipts/test_repo-89.status"
+printf '%s\n' "$_FULL_LOOP_PHASE_FAILED" >"$stale_receipt"
+(
+	_full_loop_resolve_repo() {
+		local requested_repo="$1"
+		printf '%s\n' "${requested_repo:-test/repo}"
+		return 0
+	}
+	_full_loop_release_receipt_path() {
+		local repo="$1"
+		local pr_number="$2"
+		printf '%s/receipts/%s-%s.status\n' "$TEST_ROOT" "${repo//\//_}" "$pr_number"
+		return 0
+	}
+	git() {
+		local args="$*"
+		local tag_number=0
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*"%(refname:short)%00%(contents)%00"*)
+			printf 'raw-index\n' >>"$large_scan_log"
+			for ((tag_number = 500; tag_number >= 1; tag_number--)); do
+				printf 'v9.%s.0\0Release without requested provenance\0\n' "$tag_number"
+			done
+			;;
+		*" for-each-ref "*)
+			for ((tag_number = 500; tag_number >= 1; tag_number--)); do
+				printf 'v9.%s.0\x1f\x1f\x1f\n' "$tag_number"
+			done
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*" tag --list "*)
+			printf 'unexpected-full-list\n' >>"$large_scan_log"
+			return 1
+			;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		printf '%s\n' "$tag_name" >>"$large_body_log"
+		return 1
+	}
+	_full_loop_release_source_json_from_tag() {
+		local tag_name="$1"
+		printf '%s\n' "$tag_name" >>"$large_reconstruction_log"
+		return 1
+	}
+	for lookup_mode in status reconcile status; do
+		lookup_rc=0
+		AIDEVOPS_FULL_LOOP_REPO=test/repo \
+			_full_loop_release_existing_command "$lookup_mode" 89 >/dev/null 2>>"$large_timing_log" || lookup_rc=$?
+		[[ "$lookup_rc" -eq 2 ]] || exit 1
+	done
+)
+if [[ "$(grep -c '^raw-index$' "$large_scan_log")" -ne 3 ]] ||
+	grep -q '^unexpected-full-list$' "$large_scan_log" ||
+	[[ -e "$large_body_log" || -e "$large_reconstruction_log" ]]; then
+	printf 'FAIL repeated large no-match lookups reconstructed historical tag provenance\n'
+	exit 1
+fi
+if [[ "$(grep -c 'phase=release-tag-candidate-index state=finish .*items=0$' "$large_timing_log")" -ne 3 ]]; then
+	printf 'FAIL repeated status/reconcile lookups did not report bounded zero-candidate scans\n'
+	exit 1
+fi
+printf 'PASS repeated status/reconcile no-match lookups use one raw index and zero reconstructions across 500 tags\n'
 
 if (
 	git() {


### PR DESCRIPTION
## Summary

Add credential-safe release phase timings and an exact raw annotated-tag body index so status and release guards reconstruct provenance only for candidates bound to the requested PR while retaining strict signature and provenance checks.

## Files Changed

.agents/scripts/full-loop-release-helper.sh, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-helper.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck, shfmt, Bash syntax, function-complexity regression, linters-local --no-cache, release helper/reconcile/aggregate/lane/provenance/version-manager suites, and repeated 500-tag status/reconcile no-match coverage.

Resolves #30247


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.262 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 24m and 406,964 tokens on this with the user in an interactive session.