### PR TITLE
GH#30251: refactor: split marketing performance store persistence

### DIFF
--- a/.agents/scripts/_performance_store_evidence.py
+++ b/.agents/scripts/_performance_store_evidence.py
@@ -9,6 +9,8 @@ import stat
 from pathlib import Path
 from typing import Any
 
+from _performance_store_types import EvidenceWriteContext
+
 
 def ensure_private_directory(store: Any, path: Path) -> None:
     """Create one private directory without accepting a symlink."""
@@ -40,8 +42,13 @@ def regular_file_digest(store: Any, path: Path) -> str:
             os.close(descriptor)
 
 
-def write_raw(store: Any, source: str, account_ref: str, digest: str, suffix: str, raw_bytes: bytes) -> tuple[Path, bool]:
+def write_raw(store: Any, context: EvidenceWriteContext) -> tuple[Path, bool]:
     """Publish one content-addressed evidence artifact without replacement."""
+    source = context.source
+    account_ref = context.account_ref
+    digest = context.digest
+    suffix = context.suffix
+    raw_bytes = context.raw_bytes
     source_directory = store.paths.raw / source
     directory = source_directory / account_ref
     for private_directory in (store.paths.raw, source_directory, directory):

--- a/.agents/scripts/_performance_store_evidence.py
+++ b/.agents/scripts/_performance_store_evidence.py
@@ -1,0 +1,74 @@
+"""Private immutable evidence persistence for the performance store."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import stat
+from pathlib import Path
+from typing import Any
+
+
+def ensure_private_directory(store: Any, path: Path) -> None:
+    """Create one private directory without accepting a symlink."""
+    if path.is_symlink():
+        raise store.error_type("raw evidence directory is unsafe")
+    path.mkdir(parents=False, exist_ok=True, mode=0o700)
+    if path.is_symlink() or not path.is_dir():
+        raise store.error_type("raw evidence directory is unsafe")
+    os.chmod(path, 0o700)
+
+
+def regular_file_digest(store: Any, path: Path) -> str:
+    """Hash one regular file through a no-follow descriptor."""
+    descriptor = -1
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise store.error_type("raw evidence destination is not a regular file")
+        digest = hashlib.sha256()
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError as error:
+        raise store.error_type("raw evidence destination is not a readable regular file") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def write_raw(store: Any, source: str, account_ref: str, digest: str, suffix: str, raw_bytes: bytes) -> tuple[Path, bool]:
+    """Publish one content-addressed evidence artifact without replacement."""
+    source_directory = store.paths.raw / source
+    directory = source_directory / account_ref
+    for private_directory in (store.paths.raw, source_directory, directory):
+        ensure_private_directory(store, private_directory)
+    destination = directory / f"{digest}{suffix}"
+    if destination.is_symlink() or (destination.exists() and not destination.is_file()):
+        raise store.error_type("raw evidence destination is not a regular file")
+    if destination.exists():
+        if regular_file_digest(store, destination) != digest:
+            raise store.error_type("raw evidence digest collision")
+        return destination, False
+    temporary = directory / f".{digest}.{os.getpid()}.{secrets.token_hex(4)}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(raw_bytes)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, destination)
+            created = True
+        except FileExistsError:
+            created = False
+        temporary.unlink()
+        if regular_file_digest(store, destination) != digest:
+            raise store.error_type("raw evidence failed digest verification")
+        return destination, created
+    finally:
+        if temporary.exists():
+            temporary.unlink()

--- a/.agents/scripts/_performance_store_ingest.py
+++ b/.agents/scripts/_performance_store_ingest.py
@@ -1,0 +1,118 @@
+"""Transactional ingest orchestration for the performance store facade."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from performance_contract import utc_now, validate_batch_header
+from _performance_store_types import QuarantineContext
+
+
+def _complete_campaign_revision(adapter: str, events: list[dict[str, Any]], counts: dict[str, int], header: dict[str, Any]) -> bool:
+    if adapter != "campaign" or not events:
+        return False
+    if counts["inserted"] != len(events):
+        return False
+    if any(counts[name] for name in ("duplicate", "conflict", "quarantined")):
+        return False
+    return header["coverage"] == "complete" and not header["missing_scopes"]
+
+
+def _exact_replay(store: Any, events: list[dict[str, Any]], counts: dict[str, int], header: dict[str, Any], evidence_ref: str) -> bool:
+    if counts["duplicate"] != len(events) or counts["inserted"]:
+        return False
+    if counts["conflict"] or counts["quarantined"]:
+        return False
+    if not store._events_match_evidence(events, header, evidence_ref):
+        return False
+    return store._events_are_current(events, header)
+
+
+def _is_partial(header: dict[str, Any], counts: dict[str, int]) -> bool:
+    if header["coverage"] != "complete" or bool(header["missing_scopes"]):
+        return True
+    return any(counts[name] > 0 for name in ("conflict", "quarantined"))
+
+
+def _dry_run(header: dict[str, Any], events: list[dict[str, Any]], errors: list[dict[str, Any]], safe_errors: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema": "aidevops.marketing-performance-ingest/v1", "dry_run": True,
+        "source": header["source"], "account_ref": header["account_ref"],
+        "accepted": len(events), "quarantined": len(errors),
+        "coverage": "partial" if errors or header["missing_scopes"] else header["coverage"],
+        "errors": safe_errors,
+    }
+
+
+def _record_rejections(store: Any, errors: list[dict[str, Any]], context: tuple[str, str, str, str], counts: dict[str, int]) -> None:
+    source, account_ref, evidence_ref, recorded_at = context
+    for error in errors:
+        source_event_id = str(error.get("source_event_id", f"record-{error.get('index', 'unknown')}"))
+        store._quarantine(QuarantineContext(source, account_ref, source_event_id, "adapter_or_contract_rejected", evidence_ref, recorded_at, store._safe_error(error)))
+        counts["quarantined"] += 1
+
+
+def _record_cursor_conflict(store: Any, header: dict[str, Any], context: tuple[str, str, str, str], counts: dict[str, int], complete_campaign: bool) -> None:
+    if not store._checkpoint_conflicts(header) or complete_campaign:
+        return
+    if counts["conflict"] or counts["quarantined"]:
+        return
+    source, account_ref, evidence_ref, recorded_at = context
+    store._quarantine(QuarantineContext(source, account_ref, "batch-cursor", "same_watermark_cursor_conflict", evidence_ref, recorded_at, {"reason": "same_watermark_cursor_conflict"}))
+    counts["quarantined"] += 1
+
+
+def ingest(store: Any, adapter: str, result: Any, dry_run: bool = False) -> dict[str, Any]:
+    """Validate, lease, append, and advance one exact source/account cursor."""
+    header = validate_batch_header(result.batch)
+    if len(header["events"]) + len(result.errors) > int(store.config["max_batch_events"]):
+        raise store.error_type("batch exceeds configured event limit")
+    events, validation_errors = store._validate_events(header, result.errors)
+    safe_errors = [store._safe_error(error) for error in validation_errors]
+    if dry_run:
+        return _dry_run(header, events, validation_errors, safe_errors)
+    source, account_ref = header["source"], header["account_ref"]
+    lease_token = store._acquire_lease(source, account_ref)
+    evidence_ref, content_digest = store._evidence_ref(source, account_ref, result.raw_bytes)
+    raw_path: Path | None = None
+    try:
+        raw_path, _ = store._write_raw(source, account_ref, content_digest, result.suffix, result.raw_bytes)
+        recorded_at = utc_now()
+        store.connection.execute("BEGIN IMMEDIATE")
+        lease = store.connection.execute("SELECT token,expires_at FROM leases WHERE source=? AND account_ref=?", (source, account_ref)).fetchone()
+        if lease is None or str(lease["token"]) != lease_token or int(lease["expires_at"]) <= int(time.time()):
+            raise store.error_type("source/account lease expired before commit")
+        store.connection.execute(
+            "INSERT OR IGNORE INTO evidence(evidence_ref,source,account_ref,sha256,relative_path,observed_at,recorded_at) VALUES(?,?,?,?,?,?,?)",
+            (evidence_ref, source, account_ref, content_digest, raw_path.relative_to(store.paths.repo).as_posix(), header["observed_at"], recorded_at),
+        )
+        counts = {"inserted": 0, "duplicate": 0, "conflict": 0, "quarantined": 0}
+        for event in events:
+            counts[store._insert_event(event, header, evidence_ref, recorded_at)] += 1
+        context = (source, account_ref, evidence_ref, recorded_at)
+        _record_rejections(store, validation_errors, context, counts)
+        complete_campaign = _complete_campaign_revision(adapter, events, counts, header)
+        _record_cursor_conflict(store, header, context, counts, complete_campaign)
+        exact_replay = _exact_replay(store, events, counts, header, evidence_ref)
+        partial = _is_partial(header, counts)
+        cursor_advanced = store._update_source_state(adapter, header, evidence_ref, recorded_at, partial)
+        store.connection.execute("DELETE FROM leases WHERE source=? AND account_ref=? AND token=?", (source, account_ref, lease_token))
+        store.connection.commit()
+        return {
+            "schema": "aidevops.marketing-performance-ingest/v1", "dry_run": False,
+            "source": source, "account_ref": account_ref, "evidence_ref": evidence_ref,
+            "accepted": counts["inserted"], "duplicates": counts["duplicate"],
+            "quarantined": counts["quarantined"] + counts["conflict"],
+            "coverage": "partial" if partial else header["coverage"],
+            "cursor_advanced": cursor_advanced, "exact_replay": exact_replay, "errors": safe_errors,
+        }
+    except Exception:
+        store.connection.rollback()
+        try:
+            store._release_lease(source, account_ref, lease_token)
+        except sqlite3.Error:
+            pass
+        raise

--- a/.agents/scripts/_performance_store_leases.py
+++ b/.agents/scripts/_performance_store_leases.py
@@ -1,0 +1,50 @@
+"""Fenced source/account leases for performance ingestion."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+
+def acquire_lease(store: Any, source: str, account_ref: str) -> str:
+    """Acquire or replace only an expired exact source/account lease."""
+    token = secrets.token_hex(24)
+    now_epoch = int(time.time())
+    lease_seconds = int(store.config["lease_seconds"])
+    store.connection.execute("BEGIN IMMEDIATE")
+    try:
+        existing = store.connection.execute(
+            "SELECT expires_at FROM leases WHERE source=? AND account_ref=?",
+            (source, account_ref),
+        ).fetchone()
+        if existing is not None and int(existing["expires_at"]) > now_epoch:
+            raise store.error_type("exact source/account ingest is already leased")
+        store.connection.execute(
+            "INSERT INTO leases(source,account_ref,token,acquired_at,expires_at) "
+            "VALUES(?,?,?,?,?) ON CONFLICT(source,account_ref) DO UPDATE SET "
+            "token=excluded.token,acquired_at=excluded.acquired_at,expires_at=excluded.expires_at",
+            (source, account_ref, token, now_epoch, now_epoch + lease_seconds),
+        )
+        store.connection.commit()
+    except Exception:
+        store.connection.rollback()
+        raise
+    return token
+
+
+def release_lease(store: Any, source: str, account_ref: str, token: str) -> None:
+    store.connection.execute(
+        "DELETE FROM leases WHERE source=? AND account_ref=? AND token=?",
+        (source, account_ref, token),
+    )
+    store.connection.commit()
+
+
+def recover_expired_leases(store: Any) -> int:
+    """Remove only expired mutable lease projections."""
+    cursor = store.connection.execute(
+        "DELETE FROM leases WHERE expires_at <= ?", (int(time.time()),)
+    )
+    store.connection.commit()
+    return int(cursor.rowcount)

--- a/.agents/scripts/_performance_store_persistence.py
+++ b/.agents/scripts/_performance_store_persistence.py
@@ -1,0 +1,193 @@
+"""Event and governance persistence for the performance store facade."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any, Protocol
+
+from performance_contract import canonical_json, event_for_fingerprint
+from _performance_store_types import EventInsertContext, GovernanceContext, QuarantineContext
+
+if TYPE_CHECKING:
+    import sqlite3
+
+    class _StoreHost(Protocol):
+        connection: sqlite3.Connection
+
+        def pseudonym(self, prefix: str, *parts: str) -> str: ...
+        def _source_event_ref(self, source: str, account_ref: str, source_event_id: str) -> str: ...
+        def _subject_ref(self, source: str, account_ref: str, source_subject_ref: str) -> str: ...
+        def _record_ref(self, event_ref: str, revision: int) -> str: ...
+        def _storage_dimensions(self, source: str, account_ref: str, dimensions: dict[str, str | int | float | bool]) -> dict[str, str | int | float | bool]: ...
+        def _quarantine(self, context: QuarantineContext) -> str: ...
+        def _insert_governance(self, context: GovernanceContext) -> None: ...
+
+
+def quarantine(store: _StoreHost, context: QuarantineContext) -> str:
+    """Persist one pseudonymized quarantine record."""
+    source_event_ref = store._source_event_ref(
+        context.source, context.account_ref, context.source_event_id
+    )
+    digest = hashlib.sha256(
+        f"{context.source}\0{context.account_ref}\0{source_event_ref}\0{context.reason}\0{context.evidence_ref}".encode()
+    ).hexdigest()
+    quarantine_ref = f"mkt-quarantine-v1:{digest}"
+    store.connection.execute(
+        "INSERT OR IGNORE INTO quarantine("
+        "quarantine_ref,source,account_ref,source_event_ref,reason,evidence_ref,recorded_at,details_json"
+        ") VALUES(?,?,?,?,?,?,?,?)",
+        (
+            quarantine_ref, context.source, context.account_ref, source_event_ref,
+            context.reason, context.evidence_ref, context.recorded_at,
+            canonical_json(context.details),
+        ),
+    )
+    return quarantine_ref
+
+
+def insert_governance(store: _StoreHost, context: GovernanceContext) -> None:
+    """Persist consent and suppression ledger entries for one subject."""
+    if context.subject_id is None:
+        return
+    for index, consent in enumerate(context.event["governance"]["consent"]):
+        ledger_ref = store.pseudonym(
+            "mkt-consent-v1", context.record_ref, str(index), canonical_json(consent)
+        )
+        store.connection.execute(
+            "INSERT OR IGNORE INTO consent_ledger("
+            "ledger_ref,subject_id,purpose,state,lawful_basis,source,account_ref,effective_at,observed_at,evidence_ref"
+            ") VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (
+                ledger_ref, context.subject_id, consent["purpose"], consent["state"],
+                consent["lawful_basis"], context.source, context.account_ref,
+                consent["effective_at"], context.observed_at, context.evidence_ref,
+            ),
+        )
+    suppression = context.event["governance"]["suppression"]
+    if suppression is None:
+        return
+    ledger_ref = store.pseudonym(
+        "mkt-suppression-v1", context.record_ref, canonical_json(suppression)
+    )
+    store.connection.execute(
+        "INSERT OR IGNORE INTO suppression_ledger("
+        "ledger_ref,subject_id,state,reason,source,account_ref,effective_at,observed_at,evidence_ref"
+        ") VALUES(?,?,?,?,?,?,?,?,?)",
+        (
+            ledger_ref, context.subject_id, suppression["state"], suppression["reason"],
+            context.source, context.account_ref, suppression["effective_at"],
+            context.observed_at, context.evidence_ref,
+        ),
+    )
+
+
+def _correction_reason(
+    store: _StoreHost,
+    correction_ref: str,
+    event_ref: str,
+    values: dict[str, Any],
+) -> str | None:
+    target = store.connection.execute(
+        "SELECT * FROM events WHERE event_ref=? ORDER BY revision DESC LIMIT 1",
+        (correction_ref,),
+    ).fetchone()
+    fields = (
+        "subject_id", "campaign_id", "channel", "creative_id", "touchpoint_id",
+        "outcome_id", "dimensions_json", "metric_id", "unit", "aggregation",
+        "currency", "period_start", "period_end",
+    )
+    if target is None:
+        return "correction_target_pending"
+    if any(target[field] != values[field] for field in fields):
+        return "correction_target_mismatch"
+    existing = store.connection.execute(
+        "SELECT event_ref FROM events WHERE correction_ref=? LIMIT 1", (correction_ref,)
+    ).fetchone()
+    if existing is not None and str(existing["event_ref"]) != event_ref:
+        return "correction_target_already_corrected"
+    return None
+
+
+def insert_event(store: _StoreHost, context: EventInsertContext) -> str:
+    """Persist one immutable event, rejecting conflicts fail closed."""
+    header = context.header
+    event = {
+        **context.event,
+        "scope": {
+            **context.event["scope"],
+            "dimensions": store._storage_dimensions(
+                header["source"], header["account_ref"],
+                context.event["scope"]["dimensions"],
+            ),
+        },
+    }
+    source, account_ref = header["source"], header["account_ref"]
+    event_ref = store._source_event_ref(source, account_ref, event["source_event_id"])
+    record_ref = store._record_ref(event_ref, int(event["revision"]))
+    fingerprint = hashlib.sha256(
+        canonical_json(event_for_fingerprint(event)).encode()
+    ).hexdigest()
+    existing = store.connection.execute(
+        "SELECT payload_fingerprint FROM events WHERE record_ref=?", (record_ref,)
+    ).fetchone()
+    if existing is not None:
+        if str(existing["payload_fingerprint"]) == fingerprint:
+            return "duplicate"
+        store._quarantine(QuarantineContext(
+            source, account_ref, event["source_event_id"],
+            "same_revision_payload_conflict", context.evidence_ref,
+            context.recorded_at, {"reason": "same_revision_payload_conflict"},
+        ))
+        return "conflict"
+    subject = event["subject"]
+    if subject["identity_state"] == "ambiguous":
+        store._quarantine(QuarantineContext(
+            source, account_ref, event["source_event_id"], "identity_ambiguous",
+            context.evidence_ref, context.recorded_at,
+            {"reason": "identity_ambiguous", "candidate_count": len(subject["candidate_refs"])},
+        ))
+        return "quarantined"
+    subject_id = None
+    if subject["source_ref"] is not None:
+        subject_id = store._subject_ref(source, account_ref, subject["source_ref"])
+    correction_ref = None
+    if event["correction_of"] is not None:
+        correction_ref = store._source_event_ref(source, account_ref, event["correction_of"])
+    scope, measurement, quality = event["scope"], event["measurement"], event["quality"]
+    if correction_ref is not None:
+        values = {
+            "subject_id": subject_id, **scope, **measurement,
+            "dimensions_json": canonical_json(scope["dimensions"]),
+        }
+        reason = _correction_reason(store, correction_ref, event_ref, values)
+        if reason is not None:
+            store._quarantine(QuarantineContext(
+                source, account_ref, event["source_event_id"], reason,
+                context.evidence_ref, context.recorded_at, {"reason": reason},
+            ))
+            return "quarantined"
+    store.connection.execute(
+        "INSERT INTO events("
+        "record_ref,event_ref,source,account_ref,revision,correction_ref,event_type,occurred_at,observed_at,recorded_at,"
+        "source_observed_at,source_recorded_at,subject_id,subject_kind,identity_state,campaign_id,channel,creative_id,"
+        "touchpoint_id,outcome_id,dimensions_json,metric_id,value_text,unit,aggregation,currency,period_start,period_end,"
+        "confidence,completeness,source_type,collected_by,evidence_ref,payload_fingerprint"
+        ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            record_ref, event_ref, source, account_ref, event["revision"], correction_ref,
+            event["event_type"], event["occurred_at"], header["observed_at"], context.recorded_at,
+            event["source_observed_at"], event["source_recorded_at"], subject_id,
+            subject["kind"], subject["identity_state"], scope["campaign_id"], scope["channel"],
+            scope["creative_id"], scope["touchpoint_id"], scope["outcome_id"],
+            canonical_json(scope["dimensions"]), measurement["metric_id"], measurement["value"],
+            measurement["unit"], measurement["aggregation"], measurement["currency"],
+            measurement["period_start"], measurement["period_end"], quality["confidence"],
+            quality["completeness"], quality["source_type"], quality["collected_by"],
+            context.evidence_ref, fingerprint,
+        ),
+    )
+    store._insert_governance(GovernanceContext(
+        event, record_ref, subject_id, source, account_ref,
+        header["observed_at"], context.evidence_ref,
+    ))
+    return "inserted"

--- a/.agents/scripts/_performance_store_state.py
+++ b/.agents/scripts/_performance_store_state.py
@@ -1,0 +1,67 @@
+"""Monotonic source-state transitions for the performance store."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from performance_contract import canonical_json, timestamp_epoch
+
+
+def _at_or_after(value: str, previous: object) -> bool:
+    return previous is None or timestamp_epoch(value) >= timestamp_epoch(str(previous))
+
+
+def _observation_fields(adapter: str, header: dict[str, Any], evidence_ref: str, partial: bool) -> tuple[str, str, str, str, str]:
+    return (
+        adapter,
+        "partial" if partial else "ready",
+        "partial" if partial else header["coverage"],
+        canonical_json(sorted(set(header["missing_scopes"]))),
+        evidence_ref,
+    )
+
+
+def _preserved_fields(existing: Any) -> tuple[str, str, str, str, object]:
+    return (
+        str(existing["adapter"]),
+        str(existing["status"]),
+        str(existing["coverage"]),
+        str(existing["missing_scopes_json"]),
+        existing["last_evidence_ref"],
+    )
+
+
+def update_source_state(store: Any, adapter: str, header: dict[str, Any], evidence_ref: str, recorded_at: str, partial: bool) -> bool:
+    """Advance only monotonic source observations and successful checkpoints."""
+    source = header["source"]
+    account_ref = header["account_ref"]
+    existing = store.connection.execute(
+        "SELECT * FROM sources WHERE source=? AND account_ref=?", (source, account_ref)
+    ).fetchone()
+    observed_at = header["observed_at"]
+    latest = existing is None or _at_or_after(observed_at, existing["last_observed_at"])
+    prior_success = None if existing is None else existing["last_success_at"]
+    successful = not partial and _at_or_after(observed_at, prior_success)
+    prior_cursor = None if existing is None else existing["cursor_ref"]
+    next_cursor = prior_cursor
+    if successful and header["cursor"] is not None:
+        next_cursor = store._cursor_ref(source, account_ref, header["cursor"])
+    cursor_advanced = bool(successful and header["cursor"] is not None and next_cursor != prior_cursor)
+    if existing is None or latest:
+        state = _observation_fields(adapter, header, evidence_ref, partial)
+    else:
+        state = _preserved_fields(existing)
+    last_observed_at = observed_at
+    if existing is not None and existing["last_observed_at"] is not None and not latest:
+        last_observed_at = str(existing["last_observed_at"])
+    last_success_at = observed_at if successful else prior_success
+    stale_map = store.config["source_stale_after_seconds"]
+    stale_after = int(stale_map.get(source, store.config["default_stale_after_seconds"]))
+    store.connection.execute(
+        "INSERT INTO sources(source,account_ref,adapter,status,coverage,missing_scopes_json,cursor_ref,last_observed_at,last_success_at,last_evidence_ref,stale_after_seconds,updated_at) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(source,account_ref) DO UPDATE SET "
+        "adapter=excluded.adapter,status=excluded.status,coverage=excluded.coverage,missing_scopes_json=excluded.missing_scopes_json,cursor_ref=excluded.cursor_ref,"
+        "last_observed_at=excluded.last_observed_at,last_success_at=excluded.last_success_at,last_evidence_ref=excluded.last_evidence_ref,stale_after_seconds=excluded.stale_after_seconds,updated_at=excluded.updated_at",
+        (source, account_ref, *state[:4], next_cursor, last_observed_at, last_success_at, state[4], stale_after, recorded_at),
+    )
+    return cursor_advanced

--- a/.agents/scripts/_performance_store_state.py
+++ b/.agents/scripts/_performance_store_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from performance_contract import canonical_json, timestamp_epoch
+from _performance_store_types import SourceStateContext
 
 
 def _at_or_after(value: str, previous: object) -> bool:
@@ -31,8 +32,13 @@ def _preserved_fields(existing: Any) -> tuple[str, str, str, str, object]:
     )
 
 
-def update_source_state(store: Any, adapter: str, header: dict[str, Any], evidence_ref: str, recorded_at: str, partial: bool) -> bool:
+def update_source_state(store: Any, context: SourceStateContext) -> bool:
     """Advance only monotonic source observations and successful checkpoints."""
+    adapter = context.adapter
+    header = context.header
+    evidence_ref = context.evidence_ref
+    recorded_at = context.recorded_at
+    partial = context.partial
     source = header["source"]
     account_ref = header["account_ref"]
     existing = store.connection.execute(

--- a/.agents/scripts/_performance_store_types.py
+++ b/.agents/scripts/_performance_store_types.py
@@ -1,0 +1,28 @@
+"""Bounded context values for performance-store persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class QuarantineContext:
+    source: str
+    account_ref: str
+    source_event_id: str
+    reason: str
+    evidence_ref: str
+    recorded_at: str
+    details: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GovernanceContext:
+    event: dict[str, Any]
+    record_ref: str
+    subject_id: str | None
+    source: str
+    account_ref: str
+    observed_at: str
+    evidence_ref: str

--- a/.agents/scripts/_performance_store_types.py
+++ b/.agents/scripts/_performance_store_types.py
@@ -44,3 +44,11 @@ class EvidenceWriteContext:
     digest: str
     suffix: str
     raw_bytes: bytes
+
+
+@dataclass(frozen=True)
+class EventInsertContext:
+    event: dict[str, Any]
+    header: dict[str, Any]
+    evidence_ref: str
+    recorded_at: str

--- a/.agents/scripts/_performance_store_types.py
+++ b/.agents/scripts/_performance_store_types.py
@@ -35,3 +35,12 @@ class SourceStateContext:
     evidence_ref: str
     recorded_at: str
     partial: bool
+
+
+@dataclass(frozen=True)
+class EvidenceWriteContext:
+    source: str
+    account_ref: str
+    digest: str
+    suffix: str
+    raw_bytes: bytes

--- a/.agents/scripts/_performance_store_types.py
+++ b/.agents/scripts/_performance_store_types.py
@@ -26,3 +26,12 @@ class GovernanceContext:
     account_ref: str
     observed_at: str
     evidence_ref: str
+
+
+@dataclass(frozen=True)
+class SourceStateContext:
+    adapter: str
+    header: dict[str, Any]
+    evidence_ref: str
+    recorded_at: str
+    partial: bool

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -35,7 +35,11 @@ from performance_store_schema import (
 )
 from _performance_store_ingest import ingest as _ingest
 from _performance_store_state import update_source_state as _update_source_state
-from _performance_store_types import GovernanceContext, QuarantineContext
+from _performance_store_types import (
+    GovernanceContext,
+    QuarantineContext,
+    SourceStateContext,
+)
 
 
 class PerformanceStoreError(PerformanceContractError):
@@ -567,7 +571,8 @@ class MarketingPerformanceStore:
     ) -> bool:
         """Advance only monotonic source observations and successful checkpoints."""
         return _update_source_state(
-            self, adapter, header, evidence_ref, recorded_at, partial
+            self,
+            SourceStateContext(adapter, header, evidence_ref, recorded_at, partial),
         )
 
     def _checkpoint_conflicts(self, header: dict[str, Any]) -> bool:

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import secrets
 import sqlite3
-import time
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +30,11 @@ from performance_store_schema import (
     resolve_paths,
 )
 from _performance_store_ingest import ingest as _ingest
+from _performance_store_leases import (
+    acquire_lease as _acquire_lease,
+    recover_expired_leases as _recover_expired_leases,
+    release_lease as _release_lease,
+)
 from _performance_store_evidence import (
     ensure_private_directory as _ensure_private_directory,
     regular_file_digest as _regular_file_digest,
@@ -148,35 +151,10 @@ class MarketingPerformanceStore:
         return f"mkt-evidence-v1:sha256:{scoped_digest}", content_digest
 
     def _acquire_lease(self, source: str, account_ref: str) -> str:
-        token = secrets.token_hex(24)
-        now_epoch = int(time.time())
-        lease_seconds = int(self.config["lease_seconds"])
-        self.connection.execute("BEGIN IMMEDIATE")
-        try:
-            existing = self.connection.execute(
-                "SELECT expires_at FROM leases WHERE source=? AND account_ref=?",
-                (source, account_ref),
-            ).fetchone()
-            if existing is not None and int(existing["expires_at"]) > now_epoch:
-                raise PerformanceStoreError("exact source/account ingest is already leased")
-            self.connection.execute(
-                "INSERT INTO leases(source,account_ref,token,acquired_at,expires_at) "
-                "VALUES(?,?,?,?,?) ON CONFLICT(source,account_ref) DO UPDATE SET "
-                "token=excluded.token,acquired_at=excluded.acquired_at,expires_at=excluded.expires_at",
-                (source, account_ref, token, now_epoch, now_epoch + lease_seconds),
-            )
-            self.connection.commit()
-        except Exception:
-            self.connection.rollback()
-            raise
-        return token
+        return _acquire_lease(self, source, account_ref)
 
     def _release_lease(self, source: str, account_ref: str, token: str) -> None:
-        self.connection.execute(
-            "DELETE FROM leases WHERE source=? AND account_ref=? AND token=?",
-            (source, account_ref, token),
-        )
-        self.connection.commit()
+        _release_lease(self, source, account_ref, token)
 
     @staticmethod
     def _ensure_private_directory(path: Path) -> None:
@@ -552,9 +530,4 @@ class MarketingPerformanceStore:
 
     def recover_expired_leases(self) -> int:
         """Remove only expired mutable lease projections."""
-        cursor = self.connection.execute(
-            "DELETE FROM leases WHERE expires_at <= ?",
-            (int(time.time()),),
-        )
-        self.connection.commit()
-        return int(cursor.rowcount)
+        return _recover_expired_leases(self)

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -18,7 +18,6 @@ from performance_contract import (
     PUBLIC_DIMENSION_KEYS,
     PerformanceContractError,
     canonical_json,
-    event_for_fingerprint,
     timestamp_epoch,
     validate_event,
 )
@@ -40,9 +39,15 @@ from _performance_store_evidence import (
     regular_file_digest as _regular_file_digest,
     write_raw as _write_raw,
 )
+from _performance_store_persistence import (
+    insert_event as _persist_event,
+    insert_governance as _persist_governance,
+    quarantine as _persist_quarantine,
+)
 from _performance_store_state import update_source_state as _update_source_state
 from _performance_store_types import (
     EvidenceWriteContext,
+    EventInsertContext,
     GovernanceContext,
     QuarantineContext,
     SourceStateContext,
@@ -191,77 +196,13 @@ class MarketingPerformanceStore:
         self,
         context: QuarantineContext,
     ) -> str:
-        source_event_ref = self._source_event_ref(
-            context.source, context.account_ref, context.source_event_id
-        )
-        digest = hashlib.sha256(
-            f"{context.source}\0{context.account_ref}\0{source_event_ref}\0{context.reason}\0{context.evidence_ref}".encode(
-                "utf-8"
-            )
-        ).hexdigest()
-        quarantine_ref = f"mkt-quarantine-v1:{digest}"
-        self.connection.execute(
-            "INSERT OR IGNORE INTO quarantine("
-            "quarantine_ref,source,account_ref,source_event_ref,reason,evidence_ref,recorded_at,details_json"
-            ") VALUES(?,?,?,?,?,?,?,?)",
-            (
-                quarantine_ref,
-                context.source,
-                context.account_ref,
-                source_event_ref,
-                context.reason,
-                context.evidence_ref,
-                context.recorded_at,
-                canonical_json(context.details),
-            ),
-        )
-        return quarantine_ref
+        return _persist_quarantine(self, context)
 
     def _insert_governance(
         self,
         context: GovernanceContext,
     ) -> None:
-        if context.subject_id is None:
-            return
-        for index, consent in enumerate(context.event["governance"]["consent"]):
-            ledger_ref = self.pseudonym("mkt-consent-v1", context.record_ref, str(index), canonical_json(consent))
-            self.connection.execute(
-                "INSERT OR IGNORE INTO consent_ledger("
-                "ledger_ref,subject_id,purpose,state,lawful_basis,source,account_ref,effective_at,observed_at,evidence_ref"
-                ") VALUES(?,?,?,?,?,?,?,?,?,?)",
-                (
-                    ledger_ref,
-                    context.subject_id,
-                    consent["purpose"],
-                    consent["state"],
-                    consent["lawful_basis"],
-                    context.source,
-                    context.account_ref,
-                    consent["effective_at"],
-                    context.observed_at,
-                    context.evidence_ref,
-                ),
-            )
-        suppression = context.event["governance"]["suppression"]
-        if suppression is None:
-            return
-        ledger_ref = self.pseudonym("mkt-suppression-v1", context.record_ref, canonical_json(suppression))
-        self.connection.execute(
-            "INSERT OR IGNORE INTO suppression_ledger("
-            "ledger_ref,subject_id,state,reason,source,account_ref,effective_at,observed_at,evidence_ref"
-            ") VALUES(?,?,?,?,?,?,?,?,?)",
-            (
-                ledger_ref,
-                context.subject_id,
-                suppression["state"],
-                suppression["reason"],
-                context.source,
-                context.account_ref,
-                suppression["effective_at"],
-                context.observed_at,
-                context.evidence_ref,
-            ),
-        )
+        _persist_governance(self, context)
 
     def _insert_event(
         self,
@@ -270,150 +211,9 @@ class MarketingPerformanceStore:
         evidence_ref: str,
         recorded_at: str,
     ) -> str:
-        event = {
-            **event,
-            "scope": {
-                **event["scope"],
-                "dimensions": self._storage_dimensions(
-                    header["source"],
-                    header["account_ref"],
-                    event["scope"]["dimensions"]
-                ),
-            },
-        }
-        source = header["source"]
-        account_ref = header["account_ref"]
-        event_ref = self._source_event_ref(source, account_ref, event["source_event_id"])
-        record_ref = self._record_ref(event_ref, int(event["revision"]))
-        fingerprint = hashlib.sha256(
-            canonical_json(event_for_fingerprint(event)).encode("utf-8")
-        ).hexdigest()
-        existing = self.connection.execute(
-            "SELECT payload_fingerprint FROM events WHERE record_ref=?",
-            (record_ref,),
-        ).fetchone()
-        if existing is not None:
-            if str(existing["payload_fingerprint"]) == fingerprint:
-                return "duplicate"
-            self._quarantine(QuarantineContext(
-                source, account_ref, event["source_event_id"],
-                "same_revision_payload_conflict", evidence_ref, recorded_at,
-                {"reason": "same_revision_payload_conflict"},
-            ))
-            return "conflict"
-        subject = event["subject"]
-        if subject["identity_state"] == "ambiguous":
-            self._quarantine(QuarantineContext(
-                source, account_ref, event["source_event_id"],
-                "identity_ambiguous", evidence_ref, recorded_at,
-                {"reason": "identity_ambiguous", "candidate_count": len(subject["candidate_refs"])},
-            ))
-            return "quarantined"
-        subject_id = None
-        if subject["source_ref"] is not None:
-            subject_id = self._subject_ref(source, account_ref, subject["source_ref"])
-        correction_ref = None
-        if event["correction_of"] is not None:
-            correction_ref = self._source_event_ref(source, account_ref, event["correction_of"])
-        scope = event["scope"]
-        measurement = event["measurement"]
-        quality = event["quality"]
-        if correction_ref is not None:
-            target = self.connection.execute(
-                "SELECT * FROM events WHERE event_ref=? ORDER BY revision DESC LIMIT 1",
-                (correction_ref,),
-            ).fetchone()
-            correction_fields = (
-                "subject_id",
-                "campaign_id",
-                "channel",
-                "creative_id",
-                "touchpoint_id",
-                "outcome_id",
-                "dimensions_json",
-                "metric_id",
-                "unit",
-                "aggregation",
-                "currency",
-                "period_start",
-                "period_end",
-            )
-            correction_values = {
-                "subject_id": subject_id,
-                **scope,
-                **measurement,
-                "dimensions_json": canonical_json(scope["dimensions"]),
-            }
-            reason = None
-            if target is None:
-                reason = "correction_target_pending"
-            elif any(target[field] != correction_values[field] for field in correction_fields):
-                reason = "correction_target_mismatch"
-            else:
-                existing_correction = self.connection.execute(
-                    "SELECT event_ref FROM events WHERE correction_ref=? LIMIT 1",
-                    (correction_ref,),
-                ).fetchone()
-                if (
-                    existing_correction is not None
-                    and str(existing_correction["event_ref"]) != event_ref
-                ):
-                    reason = "correction_target_already_corrected"
-            if reason is not None:
-                self._quarantine(QuarantineContext(
-                    source, account_ref, event["source_event_id"], reason,
-                    evidence_ref, recorded_at, {"reason": reason},
-                ))
-                return "quarantined"
-        self.connection.execute(
-            "INSERT INTO events("
-            "record_ref,event_ref,source,account_ref,revision,correction_ref,event_type,occurred_at,observed_at,recorded_at,"
-            "source_observed_at,source_recorded_at,"
-            "subject_id,subject_kind,identity_state,campaign_id,channel,creative_id,touchpoint_id,outcome_id,"
-            "dimensions_json,metric_id,value_text,unit,aggregation,currency,period_start,period_end,confidence,completeness,source_type,collected_by,evidence_ref,payload_fingerprint"
-            ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-            (
-                record_ref,
-                event_ref,
-                source,
-                account_ref,
-                event["revision"],
-                correction_ref,
-                event["event_type"],
-                event["occurred_at"],
-                header["observed_at"],
-                recorded_at,
-                event["source_observed_at"],
-                event["source_recorded_at"],
-                subject_id,
-                subject["kind"],
-                subject["identity_state"],
-                scope["campaign_id"],
-                scope["channel"],
-                scope["creative_id"],
-                scope["touchpoint_id"],
-                scope["outcome_id"],
-                canonical_json(scope["dimensions"]),
-                measurement["metric_id"],
-                measurement["value"],
-                measurement["unit"],
-                measurement["aggregation"],
-                measurement["currency"],
-                measurement["period_start"],
-                measurement["period_end"],
-                quality["confidence"],
-                quality["completeness"],
-                quality["source_type"],
-                quality["collected_by"],
-                evidence_ref,
-                fingerprint,
-            ),
+        return _persist_event(
+            self, EventInsertContext(event, header, evidence_ref, recorded_at)
         )
-        self._insert_governance(GovernanceContext(
-            event, record_ref, subject_id, source, account_ref,
-            header["observed_at"], evidence_ref,
-        ))
-        return "inserted"
 
     def _events_match_evidence(
         self,

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -39,6 +39,7 @@ from _performance_store_evidence import (
 )
 from _performance_store_state import update_source_state as _update_source_state
 from _performance_store_types import (
+    EvidenceWriteContext,
     GovernanceContext,
     QuarantineContext,
     SourceStateContext,
@@ -195,7 +196,9 @@ class MarketingPerformanceStore:
         suffix: str,
         raw_bytes: bytes,
     ) -> tuple[Path, bool]:
-        return _write_raw(self, source, account_ref, digest, suffix, raw_bytes)
+        return _write_raw(
+            self, EvidenceWriteContext(source, account_ref, digest, suffix, raw_bytes)
+        )
 
     @staticmethod
     def _safe_error(error: dict[str, Any]) -> dict[str, Any]:

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -24,8 +24,6 @@ from performance_contract import (
     canonical_json,
     event_for_fingerprint,
     timestamp_epoch,
-    utc_now,
-    validate_batch_header,
     validate_event,
 )
 from performance_store_schema import (
@@ -35,6 +33,9 @@ from performance_store_schema import (
     provision_plane,
     resolve_paths,
 )
+from _performance_store_ingest import ingest as _ingest
+from _performance_store_state import update_source_state as _update_source_state
+from _performance_store_types import GovernanceContext, QuarantineContext
 
 
 class PerformanceStoreError(PerformanceContractError):
@@ -43,6 +44,8 @@ class PerformanceStoreError(PerformanceContractError):
 
 class MarketingPerformanceStore:
     """Own source/account leases, immutable events, and rebuildable projections."""
+
+    error_type = PerformanceStoreError
 
     def __init__(
         self,
@@ -260,17 +263,13 @@ class MarketingPerformanceStore:
 
     def _quarantine(
         self,
-        source: str,
-        account_ref: str,
-        source_event_id: str,
-        reason: str,
-        evidence_ref: str,
-        recorded_at: str,
-        details: dict[str, Any],
+        context: QuarantineContext,
     ) -> str:
-        source_event_ref = self._source_event_ref(source, account_ref, source_event_id)
+        source_event_ref = self._source_event_ref(
+            context.source, context.account_ref, context.source_event_id
+        )
         digest = hashlib.sha256(
-            f"{source}\0{account_ref}\0{source_event_ref}\0{reason}\0{evidence_ref}".encode(
+            f"{context.source}\0{context.account_ref}\0{source_event_ref}\0{context.reason}\0{context.evidence_ref}".encode(
                 "utf-8"
             )
         ).hexdigest()
@@ -281,66 +280,60 @@ class MarketingPerformanceStore:
             ") VALUES(?,?,?,?,?,?,?,?)",
             (
                 quarantine_ref,
-                source,
-                account_ref,
+                context.source,
+                context.account_ref,
                 source_event_ref,
-                reason,
-                evidence_ref,
-                recorded_at,
-                canonical_json(details),
+                context.reason,
+                context.evidence_ref,
+                context.recorded_at,
+                canonical_json(context.details),
             ),
         )
         return quarantine_ref
 
     def _insert_governance(
         self,
-        event: dict[str, Any],
-        record_ref: str,
-        subject_id: str | None,
-        source: str,
-        account_ref: str,
-        observed_at: str,
-        evidence_ref: str,
+        context: GovernanceContext,
     ) -> None:
-        if subject_id is None:
+        if context.subject_id is None:
             return
-        for index, consent in enumerate(event["governance"]["consent"]):
-            ledger_ref = self.pseudonym("mkt-consent-v1", record_ref, str(index), canonical_json(consent))
+        for index, consent in enumerate(context.event["governance"]["consent"]):
+            ledger_ref = self.pseudonym("mkt-consent-v1", context.record_ref, str(index), canonical_json(consent))
             self.connection.execute(
                 "INSERT OR IGNORE INTO consent_ledger("
                 "ledger_ref,subject_id,purpose,state,lawful_basis,source,account_ref,effective_at,observed_at,evidence_ref"
                 ") VALUES(?,?,?,?,?,?,?,?,?,?)",
                 (
                     ledger_ref,
-                    subject_id,
+                    context.subject_id,
                     consent["purpose"],
                     consent["state"],
                     consent["lawful_basis"],
-                    source,
-                    account_ref,
+                    context.source,
+                    context.account_ref,
                     consent["effective_at"],
-                    observed_at,
-                    evidence_ref,
+                    context.observed_at,
+                    context.evidence_ref,
                 ),
             )
-        suppression = event["governance"]["suppression"]
+        suppression = context.event["governance"]["suppression"]
         if suppression is None:
             return
-        ledger_ref = self.pseudonym("mkt-suppression-v1", record_ref, canonical_json(suppression))
+        ledger_ref = self.pseudonym("mkt-suppression-v1", context.record_ref, canonical_json(suppression))
         self.connection.execute(
             "INSERT OR IGNORE INTO suppression_ledger("
             "ledger_ref,subject_id,state,reason,source,account_ref,effective_at,observed_at,evidence_ref"
             ") VALUES(?,?,?,?,?,?,?,?,?)",
             (
                 ledger_ref,
-                subject_id,
+                context.subject_id,
                 suppression["state"],
                 suppression["reason"],
-                source,
-                account_ref,
+                context.source,
+                context.account_ref,
                 suppression["effective_at"],
-                observed_at,
-                evidence_ref,
+                context.observed_at,
+                context.evidence_ref,
             ),
         )
 
@@ -376,27 +369,19 @@ class MarketingPerformanceStore:
         if existing is not None:
             if str(existing["payload_fingerprint"]) == fingerprint:
                 return "duplicate"
-            self._quarantine(
-                source,
-                account_ref,
-                event["source_event_id"],
-                "same_revision_payload_conflict",
-                evidence_ref,
-                recorded_at,
+            self._quarantine(QuarantineContext(
+                source, account_ref, event["source_event_id"],
+                "same_revision_payload_conflict", evidence_ref, recorded_at,
                 {"reason": "same_revision_payload_conflict"},
-            )
+            ))
             return "conflict"
         subject = event["subject"]
         if subject["identity_state"] == "ambiguous":
-            self._quarantine(
-                source,
-                account_ref,
-                event["source_event_id"],
-                "identity_ambiguous",
-                evidence_ref,
-                recorded_at,
+            self._quarantine(QuarantineContext(
+                source, account_ref, event["source_event_id"],
+                "identity_ambiguous", evidence_ref, recorded_at,
                 {"reason": "identity_ambiguous", "candidate_count": len(subject["candidate_refs"])},
-            )
+            ))
             return "quarantined"
         subject_id = None
         if subject["source_ref"] is not None:
@@ -449,15 +434,10 @@ class MarketingPerformanceStore:
                 ):
                     reason = "correction_target_already_corrected"
             if reason is not None:
-                self._quarantine(
-                    source,
-                    account_ref,
-                    event["source_event_id"],
-                    reason,
-                    evidence_ref,
-                    recorded_at,
-                    {"reason": reason},
-                )
+                self._quarantine(QuarantineContext(
+                    source, account_ref, event["source_event_id"], reason,
+                    evidence_ref, recorded_at, {"reason": reason},
+                ))
                 return "quarantined"
         self.connection.execute(
             "INSERT INTO events("
@@ -503,15 +483,10 @@ class MarketingPerformanceStore:
                 fingerprint,
             ),
         )
-        self._insert_governance(
-            event,
-            record_ref,
-            subject_id,
-            source,
-            account_ref,
-            header["observed_at"],
-            evidence_ref,
-        )
+        self._insert_governance(GovernanceContext(
+            event, record_ref, subject_id, source, account_ref,
+            header["observed_at"], evidence_ref,
+        ))
         return "inserted"
 
     def _events_match_evidence(
@@ -591,83 +566,9 @@ class MarketingPerformanceStore:
         partial: bool,
     ) -> bool:
         """Advance only monotonic source observations and successful checkpoints."""
-        source = header["source"]
-        account_ref = header["account_ref"]
-        existing = self.connection.execute(
-            "SELECT * FROM sources WHERE source=? AND account_ref=?",
-            (source, account_ref),
-        ).fetchone()
-        observed_at = header["observed_at"]
-        observed_epoch = timestamp_epoch(observed_at)
-        latest_observation = (
-            existing is None
-            or existing["last_observed_at"] is None
-            or observed_epoch >= timestamp_epoch(str(existing["last_observed_at"]))
+        return _update_source_state(
+            self, adapter, header, evidence_ref, recorded_at, partial
         )
-        prior_success = None if existing is None else existing["last_success_at"]
-        successful_checkpoint = (
-            not partial
-            and (
-                prior_success is None
-                or observed_epoch >= timestamp_epoch(str(prior_success))
-            )
-        )
-        prior_cursor = None if existing is None else existing["cursor_ref"]
-        next_cursor = prior_cursor
-        if successful_checkpoint and header["cursor"] is not None:
-            next_cursor = self._cursor_ref(source, account_ref, header["cursor"])
-        cursor_advanced = bool(
-            successful_checkpoint
-            and header["cursor"] is not None
-            and next_cursor != prior_cursor
-        )
-        if existing is None or latest_observation:
-            state_adapter = adapter
-            state_status = "partial" if partial else "ready"
-            state_coverage = "partial" if partial else header["coverage"]
-            missing_scopes = canonical_json(sorted(set(header["missing_scopes"])))
-            last_evidence_ref = evidence_ref
-        else:
-            state_adapter = str(existing["adapter"])
-            state_status = str(existing["status"])
-            state_coverage = str(existing["coverage"])
-            missing_scopes = str(existing["missing_scopes_json"])
-            last_evidence_ref = existing["last_evidence_ref"]
-        last_observed_at = observed_at
-        if existing is not None and existing["last_observed_at"] is not None:
-            if observed_epoch < timestamp_epoch(str(existing["last_observed_at"])):
-                last_observed_at = str(existing["last_observed_at"])
-        last_success_at = prior_success
-        if successful_checkpoint:
-            last_success_at = observed_at
-        stale_map = self.config["source_stale_after_seconds"]
-        stale_after = int(
-            stale_map.get(source, self.config["default_stale_after_seconds"])
-        )
-        self.connection.execute(
-            "INSERT INTO sources("
-            "source,account_ref,adapter,status,coverage,missing_scopes_json,cursor_ref,last_observed_at,last_success_at,last_evidence_ref,stale_after_seconds,updated_at"
-            ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(source,account_ref) DO UPDATE SET "
-            "adapter=excluded.adapter,status=excluded.status,coverage=excluded.coverage,"
-            "missing_scopes_json=excluded.missing_scopes_json,cursor_ref=excluded.cursor_ref,"
-            "last_observed_at=excluded.last_observed_at,last_success_at=excluded.last_success_at,"
-            "last_evidence_ref=excluded.last_evidence_ref,stale_after_seconds=excluded.stale_after_seconds,updated_at=excluded.updated_at",
-            (
-                source,
-                account_ref,
-                state_adapter,
-                state_status,
-                state_coverage,
-                missing_scopes,
-                next_cursor,
-                last_observed_at,
-                last_success_at,
-                last_evidence_ref,
-                stale_after,
-                recorded_at,
-            ),
-        )
-        return cursor_advanced
 
     def _checkpoint_conflicts(self, header: dict[str, Any]) -> bool:
         """Detect a conflicting opaque cursor at the same successful watermark."""
@@ -698,158 +599,7 @@ class MarketingPerformanceStore:
         dry_run: bool = False,
     ) -> dict[str, Any]:
         """Validate, lease, append, and advance one exact source/account cursor."""
-        header = validate_batch_header(result.batch)
-        total_records = len(header["events"]) + len(result.errors)
-        if total_records > int(self.config["max_batch_events"]):
-            raise PerformanceStoreError("batch exceeds configured event limit")
-        events, validation_errors = self._validate_events(header, result.errors)
-        safe_errors = [self._safe_error(error) for error in validation_errors]
-        if dry_run:
-            return {
-                "schema": "aidevops.marketing-performance-ingest/v1",
-                "dry_run": True,
-                "source": header["source"],
-                "account_ref": header["account_ref"],
-                "accepted": len(events),
-                "quarantined": len(validation_errors),
-                "coverage": (
-                    "partial"
-                    if validation_errors or header["missing_scopes"]
-                    else header["coverage"]
-                ),
-                "errors": safe_errors,
-            }
-        source = header["source"]
-        account_ref = header["account_ref"]
-        lease_token = self._acquire_lease(source, account_ref)
-        evidence_ref, content_digest = self._evidence_ref(source, account_ref, result.raw_bytes)
-        raw_path: Path | None = None
-        try:
-            raw_path, _ = self._write_raw(
-                source,
-                account_ref,
-                content_digest,
-                result.suffix,
-                result.raw_bytes,
-            )
-            recorded_at = utc_now()
-            now_epoch = int(time.time())
-            self.connection.execute("BEGIN IMMEDIATE")
-            lease = self.connection.execute(
-                "SELECT token,expires_at FROM leases WHERE source=? AND account_ref=?",
-                (source, account_ref),
-            ).fetchone()
-            if lease is None or str(lease["token"]) != lease_token or int(lease["expires_at"]) <= now_epoch:
-                raise PerformanceStoreError("source/account lease expired before commit")
-            relative_path = raw_path.relative_to(self.paths.repo).as_posix()
-            self.connection.execute(
-                "INSERT OR IGNORE INTO evidence("
-                "evidence_ref,source,account_ref,sha256,relative_path,observed_at,recorded_at"
-                ") VALUES(?,?,?,?,?,?,?)",
-                (
-                    evidence_ref,
-                    source,
-                    account_ref,
-                    content_digest,
-                    relative_path,
-                    header["observed_at"],
-                    recorded_at,
-                ),
-            )
-            counts = {"inserted": 0, "duplicate": 0, "conflict": 0, "quarantined": 0}
-            for event in events:
-                outcome = self._insert_event(event, header, evidence_ref, recorded_at)
-                counts[outcome] += 1
-            for error in validation_errors:
-                source_event_id = str(error.get("source_event_id", f"record-{error.get('index', 'unknown')}"))
-                safe_error = self._safe_error(error)
-                self._quarantine(
-                    source,
-                    account_ref,
-                    source_event_id,
-                    "adapter_or_contract_rejected",
-                    evidence_ref,
-                    recorded_at,
-                    safe_error,
-                )
-                counts["quarantined"] += 1
-            complete_campaign_revision = (
-                adapter == "campaign"
-                and bool(events)
-                and counts["inserted"] == len(events)
-                and counts["duplicate"] == 0
-                and counts["conflict"] == 0
-                and counts["quarantined"] == 0
-                and header["coverage"] == "complete"
-                and not header["missing_scopes"]
-            )
-            if (
-                self._checkpoint_conflicts(header)
-                and not complete_campaign_revision
-                and counts["conflict"] == 0
-                and counts["quarantined"] == 0
-            ):
-                self._quarantine(
-                    source,
-                    account_ref,
-                    "batch-cursor",
-                    "same_watermark_cursor_conflict",
-                    evidence_ref,
-                    recorded_at,
-                    {"reason": "same_watermark_cursor_conflict"},
-                )
-                counts["quarantined"] += 1
-            exact_replay = (
-                counts["duplicate"] == len(events)
-                and counts["inserted"] == 0
-                and counts["conflict"] == 0
-                and counts["quarantined"] == 0
-                and self._events_match_evidence(events, header, evidence_ref)
-                and self._events_are_current(events, header)
-            )
-            partial = (
-                header["coverage"] != "complete"
-                or bool(header["missing_scopes"])
-                or any(
-                    counts[name] > 0 for name in ("conflict", "quarantined")
-                )
-            )
-            cursor_advanced = self._update_source_state(
-                adapter,
-                header,
-                evidence_ref,
-                recorded_at,
-                partial,
-            )
-            self.connection.execute(
-                "DELETE FROM leases WHERE source=? AND account_ref=? AND token=?",
-                (source, account_ref, lease_token),
-            )
-            self.connection.commit()
-            return {
-                "schema": "aidevops.marketing-performance-ingest/v1",
-                "dry_run": False,
-                "source": source,
-                "account_ref": account_ref,
-                "evidence_ref": evidence_ref,
-                "accepted": counts["inserted"],
-                "duplicates": counts["duplicate"],
-                "quarantined": counts["quarantined"] + counts["conflict"],
-                "coverage": "partial" if partial else header["coverage"],
-                "cursor_advanced": cursor_advanced,
-                "exact_replay": exact_replay,
-                "errors": safe_errors,
-            }
-        except Exception:
-            self.connection.rollback()
-            try:
-                self._release_lease(source, account_ref, lease_token)
-            except sqlite3.Error:
-                pass
-            # Published raw evidence is content-addressed and immutable. Retain an
-            # unreferenced artifact after rollback so an expired worker cannot
-            # delete a file another fenced worker is about to reference.
-            raise
+        return _ingest(self, adapter, result, dry_run)
 
     def recover_expired_leases(self) -> int:
         """Remove only expired mutable lease projections."""

--- a/.agents/scripts/performance_store.py
+++ b/.agents/scripts/performance_store.py
@@ -8,10 +8,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import os
 import secrets
 import sqlite3
-import stat
 import time
 from pathlib import Path
 from typing import Any
@@ -34,6 +32,11 @@ from performance_store_schema import (
     resolve_paths,
 )
 from _performance_store_ingest import ingest as _ingest
+from _performance_store_evidence import (
+    ensure_private_directory as _ensure_private_directory,
+    regular_file_digest as _regular_file_digest,
+    write_raw as _write_raw,
+)
 from _performance_store_state import update_source_state as _update_source_state
 from _performance_store_types import (
     GovernanceContext,
@@ -177,39 +180,12 @@ class MarketingPerformanceStore:
     @staticmethod
     def _ensure_private_directory(path: Path) -> None:
         """Create one private directory without accepting a symlink."""
-        if path.is_symlink():
-            raise PerformanceStoreError("raw evidence directory is unsafe")
-        path.mkdir(parents=False, exist_ok=True, mode=0o700)
-        if path.is_symlink() or not path.is_dir():
-            raise PerformanceStoreError("raw evidence directory is unsafe")
-        os.chmod(path, 0o700)
+        _ensure_private_directory(MarketingPerformanceStore, path)
 
     @staticmethod
     def _regular_file_digest(path: Path) -> str:
         """Hash one regular file through a no-follow descriptor."""
-        descriptor = -1
-        try:
-            descriptor = os.open(
-                path,
-                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
-            )
-            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-                raise PerformanceStoreError(
-                    "raw evidence destination is not a regular file"
-                )
-            digest = hashlib.sha256()
-            with os.fdopen(descriptor, "rb") as handle:
-                descriptor = -1
-                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                    digest.update(chunk)
-            return digest.hexdigest()
-        except OSError as exc:
-            raise PerformanceStoreError(
-                "raw evidence destination is not a readable regular file"
-            ) from exc
-        finally:
-            if descriptor >= 0:
-                os.close(descriptor)
+        return _regular_file_digest(MarketingPerformanceStore, path)
 
     def _write_raw(
         self,
@@ -219,42 +195,7 @@ class MarketingPerformanceStore:
         suffix: str,
         raw_bytes: bytes,
     ) -> tuple[Path, bool]:
-        source_directory = self.paths.raw / source
-        directory = source_directory / account_ref
-        for private_directory in (
-            self.paths.raw,
-            source_directory,
-            directory,
-        ):
-            self._ensure_private_directory(private_directory)
-        destination = directory / f"{digest}{suffix}"
-        if destination.is_symlink() or (
-            destination.exists() and not destination.is_file()
-        ):
-            raise PerformanceStoreError("raw evidence destination is not a regular file")
-        if destination.exists():
-            if self._regular_file_digest(destination) != digest:
-                raise PerformanceStoreError("raw evidence digest collision")
-            return destination, False
-        temporary = directory / f".{digest}.{os.getpid()}.{secrets.token_hex(4)}.tmp"
-        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        try:
-            with os.fdopen(descriptor, "wb") as handle:
-                handle.write(raw_bytes)
-                handle.flush()
-                os.fsync(handle.fileno())
-            try:
-                os.link(temporary, destination)
-                created = True
-            except FileExistsError:
-                created = False
-            temporary.unlink()
-            if self._regular_file_digest(destination) != digest:
-                raise PerformanceStoreError("raw evidence failed digest verification")
-            return destination, created
-        finally:
-            if temporary.exists():
-                temporary.unlink()
+        return _write_raw(self, source, account_ref, digest, suffix, raw_bytes)
 
     @staticmethod
     def _safe_error(error: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Split evidence, event/governance, lease/source-state, and ingest orchestration behind compatibility-preserving private modules while retaining the MarketingPerformanceStore facade and immutable context values.

## Files Changed

.agents/scripts/_performance_store_evidence.py, .agents/scripts/_performance_store_ingest.py, .agents/scripts/_performance_store_leases.py, .agents/scripts/_performance_store_persistence.py, .agents/scripts/_performance_store_state.py, .agents/scripts/_performance_store_types.py, .agents/scripts/performance_store.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-marketing-performance-ingest.py; python3 -m py_compile on the store modules; git diff --check

Resolves #30251


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.263 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 7m and 87,493 tokens on this as a headless worker.