### PR TITLE
GH#30252: split performance reporting projections

### DIFF
--- a/.agents/scripts/_performance_reporting_events.py
+++ b/.agents/scripts/_performance_reporting_events.py
@@ -1,0 +1,91 @@
+"""Normalized event projections for performance reporting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from performance_contract import decimal_wire
+
+
+@dataclass(frozen=True)
+class EventQuery:
+    history: bool = False
+    source: str | None = None
+    account_ref: str | None = None
+    campaign_id: str | None = None
+    now_epoch: int | None = None
+
+    @classmethod
+    def from_options(cls, options: dict[str, Any]) -> "EventQuery":
+        allowed = {"history", "source", "account_ref", "campaign_id", "now_epoch"}
+        unknown = set(options) - allowed
+        if unknown:
+            raise TypeError(f"unknown event record options: {sorted(unknown)}")
+        return cls(**options)
+
+
+def _subject_projection(row: Any, subjects: dict[str, dict[str, Any]]) -> tuple[object, str, dict[str, Any]]:
+    subject_id = row["subject_id"]
+    if subject_id is None:
+        return None, str(row["identity_state"]), {"audience_eligible": False, "eligibility_reason": "aggregate"}
+    subject = next((item for item in subjects.values() if str(subject_id) in item["aliases"]), None)
+    canonical = subject["subject_id"] if subject else str(subject_id)
+    state = subject["identity_state"] if subject else str(row["identity_state"])
+    governance = {
+        "audience_eligible": bool(subject and subject["audience_eligible"]),
+        "eligibility_reason": subject["eligibility_reason"] if subject else "consent_unknown",
+    }
+    return canonical, state, governance
+
+
+def _source_record(row: Any, state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": str(row["source"]), "account_ref": str(row["account_ref"]),
+        "revision": int(row["revision"]), "observed_at": str(row["observed_at"]),
+        "recorded_at": str(row["recorded_at"]),
+        "source_observed_at": str(row["source_observed_at"]) if row["source_observed_at"] is not None else None,
+        "source_recorded_at": str(row["source_recorded_at"]) if row["source_recorded_at"] is not None else None,
+        "evidence_ref": str(row["evidence_ref"]), "coverage": state["coverage"],
+        "missing_scopes": state["missing_scopes"],
+    }
+
+
+def _scope_record(row: Any) -> dict[str, Any]:
+    fields = ("campaign_id", "channel", "creative_id", "touchpoint_id", "outcome_id")
+    return {**{field: row[field] for field in fields}, "dimensions": json.loads(str(row["dimensions_json"]))}
+
+
+def _measurement_record(row: Any) -> dict[str, Any]:
+    return {
+        "metric_id": str(row["metric_id"]), "value": decimal_wire(str(row["value_text"])),
+        "unit": str(row["unit"]), "aggregation": str(row["aggregation"]),
+        "currency": row["currency"], "period_start": row["period_start"], "period_end": row["period_end"],
+    }
+
+
+def _event_record(reporting: Any, row: Any, state: dict[str, Any], subjects: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    canonical, identity_state, governance = _subject_projection(row, subjects)
+    confidence = reporting._effective_confidence(str(row["confidence"]), state["status"], str(row["completeness"]), identity_state)
+    return {
+        "schema_version": 1, "record_ref": str(row["record_ref"]), "event_ref": str(row["event_ref"]),
+        "source": _source_record(row, state),
+        "event": {"type": str(row["event_type"]), "occurred_at": str(row["occurred_at"]), "correction_of": row["correction_ref"]},
+        "subject": {"subject_id": canonical, "kind": str(row["subject_kind"]), "identity_state": identity_state},
+        "scope": _scope_record(row), "measurement": _measurement_record(row),
+        "quality": {
+            "confidence": str(row["confidence"]), "effective_confidence": confidence,
+            "completeness": str(row["completeness"]), "source_type": str(row["source_type"]),
+            "collected_by": str(row["collected_by"]), "evidence_ref": str(row["evidence_ref"]),
+        },
+        "governance": governance,
+    }
+
+
+def event_records(reporting: Any, query: EventQuery) -> list[dict[str, Any]]:
+    """Return schema-valid pseudonymous event records."""
+    source_state = {(row["source"], row["account_ref"]): row for row in reporting._source_rows(query.now_epoch)}
+    subjects = {row["subject_id"]: row for row in reporting.subject_records(query.now_epoch)}
+    rows = reporting._effective_rows(history=query.history, source=query.source, account_ref=query.account_ref, campaign_id=query.campaign_id)
+    return [_event_record(reporting, row, source_state[(str(row["source"]), str(row["account_ref"]))], subjects) for row in rows]

--- a/.agents/scripts/_performance_reporting_queries.py
+++ b/.agents/scripts/_performance_reporting_queries.py
@@ -1,0 +1,108 @@
+"""Source, event, and identity queries for performance reporting."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import defaultdict
+from typing import Any
+
+from performance_contract import PerformanceContractError, timestamp_epoch
+
+
+def source_rows(reporting: Any, now_epoch: int | None = None) -> list[dict[str, Any]]:
+    now = int(time.time()) if now_epoch is None else now_epoch
+    resolutions = {
+        str(row["target_ref"])
+        for row in reporting.connection.execute("SELECT target_ref,effective_at FROM reconciliations WHERE action='resolve_quarantine'")
+        if timestamp_epoch(str(row["effective_at"])) <= now
+    }
+    event_refs = {str(row["event_ref"]) for row in reporting.connection.execute("SELECT DISTINCT event_ref FROM events")}
+    unresolved: dict[tuple[str, str], int] = defaultdict(int)
+    for row in reporting.connection.execute("SELECT * FROM quarantine"):
+        if str(row["quarantine_ref"]) in resolutions:
+            continue
+        resolved_pending = str(row["reason"]) == "correction_target_pending" and str(row["source_event_ref"]) in event_refs
+        if not resolved_pending:
+            unresolved[(str(row["source"]), str(row["account_ref"]))] += 1
+    active = {
+        (str(row["source"]), str(row["account_ref"]))
+        for row in reporting.connection.execute("SELECT source,account_ref FROM leases WHERE expires_at>?", (now,))
+    }
+    return [_source_record(row, now, unresolved, active) for row in reporting.connection.execute("SELECT * FROM sources ORDER BY source,account_ref")]
+
+
+def _source_record(row: Any, now: int, unresolved: dict[tuple[str, str], int], active: set[tuple[str, str]]) -> dict[str, Any]:
+    key = (str(row["source"]), str(row["account_ref"]))
+    observed_at = row["last_observed_at"]
+    lag_seconds = None if observed_at is None else int(max(0, now - timestamp_epoch(str(observed_at))))
+    stale = lag_seconds is not None and lag_seconds > int(row["stale_after_seconds"])
+    status = str(row["status"])
+    if unresolved.get(key, 0) > 0:
+        status = "partial"
+    elif key in active:
+        status = "leased"
+    elif stale:
+        status = "stale"
+    return {
+        "source": key[0], "account_ref": key[1], "adapter": str(row["adapter"]),
+        "status": status, "coverage": str(row["coverage"]),
+        "missing_scopes": json.loads(str(row["missing_scopes_json"])),
+        "cursor_present": row["cursor_ref"] is not None,
+        "last_observed_at": observed_at, "last_success_at": row["last_success_at"],
+        "stale_after_seconds": int(row["stale_after_seconds"]), "lag_seconds": lag_seconds,
+        "stale": stale, "unresolved_quarantine": unresolved.get(key, 0),
+    }
+
+
+def effective_rows(reporting: Any, history: bool = False, source: str | None = None, account_ref: str | None = None, campaign_id: str | None = None) -> list[Any]:
+    clauses: list[str] = []
+    parameters: list[str] = []
+    for field, value in (("source", source), ("account_ref", account_ref)):
+        if value is not None:
+            clauses.append(f"{field}=?")
+            parameters.append(value)
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    rows = list(reporting.connection.execute("SELECT * FROM events" + where + " ORDER BY occurred_at,recorded_at,record_ref", tuple(parameters)))
+    if history:
+        return [row for row in rows if campaign_id is None or row["campaign_id"] == campaign_id]
+    latest: dict[tuple[str, str, str], Any] = {}
+    for row in rows:
+        key = (str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))
+        if key not in latest or int(row["revision"]) > int(latest[key]["revision"]):
+            latest[key] = row
+    correction_refs = {str(row["correction_ref"]) for row in latest.values() if row["correction_ref"] is not None}
+    effective = [row for row in rows if latest.get((str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))) is row and str(row["event_ref"]) not in correction_refs]
+    return [row for row in effective if campaign_id is None or row["campaign_id"] == campaign_id]
+
+
+def current_links(reporting: Any, now_timestamp: str) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:
+    latest: dict[str, Any] = {}
+    keys: dict[str, tuple[float, float, str]] = {}
+    rows = list(reporting.connection.execute("SELECT * FROM identity_links"))
+    ordering = lambda row: (timestamp_epoch(str(row["effective_at"])), timestamp_epoch(str(row["recorded_at"])), str(row["link_ref"]))
+    history = [dict(row) for row in sorted(rows, key=ordering)]
+    boundary = timestamp_epoch(now_timestamp)
+    for row in rows:
+        member = str(row["member_subject_id"])
+        row_key = ordering(row)
+        if row_key[0] <= boundary and row_key > keys.get(member, (float("-inf"), float("-inf"), "")):
+            latest[member] = row
+            keys[member] = row_key
+    links: dict[str, str] = {}
+    states: dict[str, str] = {}
+    for member, row in latest.items():
+        action = str(row["action"])
+        states[member] = "linked" if action == "link" else "split"
+        if action == "link":
+            links[member] = str(row["canonical_subject_id"])
+    return links, states, history
+
+
+def assert_identity_graph_acyclic(reporting: Any, effective_at: str) -> None:
+    effective_epoch = timestamp_epoch(effective_at)
+    boundaries = [str(row["effective_at"]) for row in reporting.connection.execute("SELECT DISTINCT effective_at FROM identity_links") if timestamp_epoch(str(row["effective_at"])) >= effective_epoch]
+    for boundary in sorted(boundaries, key=timestamp_epoch):
+        links, _states, _history = reporting._current_links(boundary)
+        if any(reporting._canonical(subject_id, links)[1] for subject_id in links):
+            raise PerformanceContractError("identity reconciliation must not create a cyclic link graph")

--- a/.agents/scripts/_performance_reporting_queries.py
+++ b/.agents/scripts/_performance_reporting_queries.py
@@ -10,14 +10,19 @@ from typing import Any
 from performance_contract import PerformanceContractError, timestamp_epoch
 
 
-def source_rows(reporting: Any, now_epoch: int | None = None) -> list[dict[str, Any]]:
-    now = int(time.time()) if now_epoch is None else now_epoch
-    resolutions = {
+def _resolved_quarantine_refs(reporting: Any, now: int) -> set[str]:
+    return {
         str(row["target_ref"])
         for row in reporting.connection.execute("SELECT target_ref,effective_at FROM reconciliations WHERE action='resolve_quarantine'")
         if timestamp_epoch(str(row["effective_at"])) <= now
     }
-    event_refs = {str(row["event_ref"]) for row in reporting.connection.execute("SELECT DISTINCT event_ref FROM events")}
+
+
+def _known_event_refs(reporting: Any) -> set[str]:
+    return {str(row["event_ref"]) for row in reporting.connection.execute("SELECT DISTINCT event_ref FROM events")}
+
+
+def _unresolved_counts(reporting: Any, resolutions: set[str], event_refs: set[str]) -> dict[tuple[str, str], int]:
     unresolved: dict[tuple[str, str], int] = defaultdict(int)
     for row in reporting.connection.execute("SELECT * FROM quarantine"):
         if str(row["quarantine_ref"]) in resolutions:
@@ -25,10 +30,21 @@ def source_rows(reporting: Any, now_epoch: int | None = None) -> list[dict[str, 
         resolved_pending = str(row["reason"]) == "correction_target_pending" and str(row["source_event_ref"]) in event_refs
         if not resolved_pending:
             unresolved[(str(row["source"]), str(row["account_ref"]))] += 1
-    active = {
+    return unresolved
+
+
+def _active_leases(reporting: Any, now: int) -> set[tuple[str, str]]:
+    return {
         (str(row["source"]), str(row["account_ref"]))
         for row in reporting.connection.execute("SELECT source,account_ref FROM leases WHERE expires_at>?", (now,))
     }
+
+
+def source_rows(reporting: Any, now_epoch: int | None = None) -> list[dict[str, Any]]:
+    now = int(time.time()) if now_epoch is None else now_epoch
+    resolutions = _resolved_quarantine_refs(reporting, now)
+    unresolved = _unresolved_counts(reporting, resolutions, _known_event_refs(reporting))
+    active = _active_leases(reporting, now)
     return [_source_record(row, now, unresolved, active) for row in reporting.connection.execute("SELECT * FROM sources ORDER BY source,account_ref")]
 
 
@@ -55,25 +71,52 @@ def _source_record(row: Any, now: int, unresolved: dict[tuple[str, str], int], a
     }
 
 
-def effective_rows(reporting: Any, history: bool = False, source: str | None = None, account_ref: str | None = None, campaign_id: str | None = None) -> list[Any]:
-    clauses: list[str] = []
-    parameters: list[str] = []
-    for field, value in (("source", source), ("account_ref", account_ref)):
-        if value is not None:
-            clauses.append(f"{field}=?")
-            parameters.append(value)
-    where = " WHERE " + " AND ".join(clauses) if clauses else ""
-    rows = list(reporting.connection.execute("SELECT * FROM events" + where + " ORDER BY occurred_at,recorded_at,record_ref", tuple(parameters)))
-    if history:
-        return [row for row in rows if campaign_id is None or row["campaign_id"] == campaign_id]
+def _event_rows(reporting: Any, source: str | None, account_ref: str | None) -> list[Any]:
+    if source is not None and account_ref is not None:
+        return list(reporting.connection.execute(
+            "SELECT * FROM events WHERE source=? AND account_ref=? ORDER BY occurred_at,recorded_at,record_ref",
+            (source, account_ref),
+        ))
+    if source is not None:
+        return list(reporting.connection.execute(
+            "SELECT * FROM events WHERE source=? ORDER BY occurred_at,recorded_at,record_ref",
+            (source,),
+        ))
+    if account_ref is not None:
+        return list(reporting.connection.execute(
+            "SELECT * FROM events WHERE account_ref=? ORDER BY occurred_at,recorded_at,record_ref",
+            (account_ref,),
+        ))
+    return list(reporting.connection.execute("SELECT * FROM events ORDER BY occurred_at,recorded_at,record_ref"))
+
+
+def _latest_events(rows: list[Any]) -> dict[tuple[str, str, str], Any]:
     latest: dict[tuple[str, str, str], Any] = {}
     for row in rows:
         key = (str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))
         if key not in latest or int(row["revision"]) > int(latest[key]["revision"]):
             latest[key] = row
+    return latest
+
+
+def _current_events(rows: list[Any], latest: dict[tuple[str, str, str], Any]) -> list[Any]:
     correction_refs = {str(row["correction_ref"]) for row in latest.values() if row["correction_ref"] is not None}
-    effective = [row for row in rows if latest.get((str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))) is row and str(row["event_ref"]) not in correction_refs]
-    return [row for row in effective if campaign_id is None or row["campaign_id"] == campaign_id]
+    return [
+        row for row in rows
+        if latest.get((str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))) is row
+        and str(row["event_ref"]) not in correction_refs
+    ]
+
+
+def _campaign_events(rows: list[Any], campaign_id: str | None) -> list[Any]:
+    return [row for row in rows if campaign_id is None or row["campaign_id"] == campaign_id]
+
+
+def effective_rows(reporting: Any, history: bool = False, source: str | None = None, account_ref: str | None = None, campaign_id: str | None = None) -> list[Any]:
+    rows = _event_rows(reporting, source, account_ref)
+    if history:
+        return _campaign_events(rows, campaign_id)
+    return _campaign_events(_current_events(rows, _latest_events(rows)), campaign_id)
 
 
 def current_links(reporting: Any, now_timestamp: str) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:

--- a/.agents/scripts/_performance_reporting_reconciliation.py
+++ b/.agents/scripts/_performance_reporting_reconciliation.py
@@ -34,6 +34,14 @@ class ActionResult:
     evidence_ref: str
 
 
+@dataclass(frozen=True)
+class ReconciliationContext:
+    action_type: str
+    effective_at: str
+    evidence_ref: str
+    recorded_at: str
+
+
 def _document_actions(document: Any) -> list[dict[str, Any]]:
     if not isinstance(document, dict) or document.get("schema") != "aidevops.marketing-performance-reconciliation/v1":
         raise PerformanceContractError("unsupported reconciliation schema")
@@ -58,7 +66,10 @@ def _common(action: Any) -> tuple[str, str, str]:
     return action_type, effective_at, evidence_ref
 
 
-def _identity_action(reporting: Any, action: dict[str, Any], action_type: str, effective_at: str, evidence_ref: str, recorded_at: str) -> ActionResult:
+def _identity_action(reporting: Any, action: dict[str, Any], context: ReconciliationContext) -> ActionResult:
+    action_type = context.action_type
+    effective_at = context.effective_at
+    evidence_ref = context.evidence_ref
     canonical = action.get("canonical_subject_id")
     member = action.get("member_subject_id")
     if not isinstance(canonical, str) or not SUBJECT_REF_RE.fullmatch(canonical):
@@ -77,14 +88,17 @@ def _identity_action(reporting: Any, action: dict[str, Any], action_type: str, e
     link_ref = reporting.store.pseudonym("mkt-link-v1", action_type, canonical, member, effective_at, evidence_ref)
     reporting.connection.execute(
         "INSERT OR IGNORE INTO identity_links(link_ref,action,canonical_subject_id,member_subject_id,evidence_ref,effective_at,recorded_at) VALUES(?,?,?,?,?,?,?)",
-        (link_ref, action_type, canonical, member, evidence_ref, effective_at, recorded_at),
+        (link_ref, action_type, canonical, member, evidence_ref, effective_at, context.recorded_at),
     )
     if action_type == "link":
         reporting._assert_identity_graph_acyclic_from(effective_at)
     return ActionResult(action_type, member, action_type, (action_type, canonical, member), effective_at, evidence_ref)
 
 
-def _quarantine_action(reporting: Any, action: dict[str, Any], action_type: str, effective_at: str, evidence_ref: str) -> ActionResult:
+def _quarantine_action(reporting: Any, action: dict[str, Any], context: ReconciliationContext) -> ActionResult:
+    action_type = context.action_type
+    effective_at = context.effective_at
+    evidence_ref = context.evidence_ref
     target_ref = action.get("quarantine_ref")
     resolution = action.get("resolution")
     if not isinstance(target_ref, str) or not QUARANTINE_REF_RE.fullmatch(target_ref):
@@ -98,10 +112,11 @@ def _quarantine_action(reporting: Any, action: dict[str, Any], action_type: str,
 
 def _apply_action(reporting: Any, action: dict[str, Any], recorded_at: str) -> int:
     action_type, effective_at, evidence_ref = _common(action)
+    context = ReconciliationContext(action_type, effective_at, evidence_ref, recorded_at)
     if action_type in {"link", "split"}:
-        result = _identity_action(reporting, action, action_type, effective_at, evidence_ref, recorded_at)
+        result = _identity_action(reporting, action, context)
     else:
-        result = _quarantine_action(reporting, action, action_type, effective_at, evidence_ref)
+        result = _quarantine_action(reporting, action, context)
     reconciliation_ref = reporting.store.pseudonym("mkt-reconciliation-v1", *result.reference_parts, effective_at, evidence_ref)
     payload = {key: value for key, value in action.items() if key != "evidence_ref"}
     cursor = reporting.connection.execute(

--- a/.agents/scripts/_performance_reporting_reconciliation.py
+++ b/.agents/scripts/_performance_reporting_reconciliation.py
@@ -66,10 +66,7 @@ def _common(action: Any) -> tuple[str, str, str]:
     return action_type, effective_at, evidence_ref
 
 
-def _identity_action(reporting: Any, action: dict[str, Any], context: ReconciliationContext) -> ActionResult:
-    action_type = context.action_type
-    effective_at = context.effective_at
-    evidence_ref = context.evidence_ref
+def _identity_refs(action: dict[str, Any]) -> tuple[str, str]:
     canonical = action.get("canonical_subject_id")
     member = action.get("member_subject_id")
     if not isinstance(canonical, str) or not SUBJECT_REF_RE.fullmatch(canonical):
@@ -78,13 +75,29 @@ def _identity_action(reporting: Any, action: dict[str, Any], context: Reconcilia
         raise PerformanceContractError("member_subject_id is invalid")
     if canonical == member:
         raise PerformanceContractError("identity reconciliation requires distinct subjects")
+    return canonical, member
+
+
+def _require_known_subjects(reporting: Any, canonical: str, member: str) -> None:
     known = int(reporting.connection.execute("SELECT COUNT(DISTINCT subject_id) FROM events WHERE subject_id IN (?,?)", (canonical, member)).fetchone()[0])
     if known < 2:
         raise PerformanceContractError("identity reconciliation subjects must already exist")
+
+
+def _reject_competing_link(reporting: Any, action_type: str, canonical: str, member: str, effective_at: str) -> None:
     competing = list(reporting.connection.execute("SELECT action,canonical_subject_id FROM identity_links WHERE member_subject_id=? AND effective_at=?", (member, effective_at)))
     conflict = any(str(row["action"]) != action_type or str(row["canonical_subject_id"]) != canonical for row in competing)
     if conflict:
         raise PerformanceContractError("identity reconciliation conflicts at the same effective time")
+
+
+def _identity_action(reporting: Any, action: dict[str, Any], context: ReconciliationContext) -> ActionResult:
+    action_type = context.action_type
+    effective_at = context.effective_at
+    evidence_ref = context.evidence_ref
+    canonical, member = _identity_refs(action)
+    _require_known_subjects(reporting, canonical, member)
+    _reject_competing_link(reporting, action_type, canonical, member, effective_at)
     link_ref = reporting.store.pseudonym("mkt-link-v1", action_type, canonical, member, effective_at, evidence_ref)
     reporting.connection.execute(
         "INSERT OR IGNORE INTO identity_links(link_ref,action,canonical_subject_id,member_subject_id,evidence_ref,effective_at,recorded_at) VALUES(?,?,?,?,?,?,?)",

--- a/.agents/scripts/_performance_reporting_reconciliation.py
+++ b/.agents/scripts/_performance_reporting_reconciliation.py
@@ -1,0 +1,125 @@
+"""Append-only owner reconciliation for performance reporting."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from performance_contract import (
+    PerformanceContractError,
+    canonical_json,
+    parse_timestamp,
+    require_alias,
+    utc_now,
+)
+
+SUBJECT_REF_RE = re.compile(r"^mkt-subj-v1:[a-f0-9]{64}$")
+QUARANTINE_REF_RE = re.compile(r"^mkt-quarantine-v1:[a-f0-9]{64}$")
+ACTION_FIELDS = {
+    "link": {"action", "canonical_subject_id", "member_subject_id", "effective_at", "evidence_ref"},
+    "split": {"action", "canonical_subject_id", "member_subject_id", "effective_at", "evidence_ref"},
+    "resolve_quarantine": {"action", "quarantine_ref", "resolution", "effective_at", "evidence_ref"},
+}
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    action_type: str
+    target_ref: str
+    resolution: str
+    reference_parts: tuple[str, ...]
+    effective_at: str
+    evidence_ref: str
+
+
+def _document_actions(document: Any) -> list[dict[str, Any]]:
+    if not isinstance(document, dict) or document.get("schema") != "aidevops.marketing-performance-reconciliation/v1":
+        raise PerformanceContractError("unsupported reconciliation schema")
+    actions = document.get("actions")
+    if not isinstance(actions, list) or not actions:
+        raise PerformanceContractError("reconciliation actions must be a non-empty array")
+    return actions
+
+
+def _common(action: Any) -> tuple[str, str, str]:
+    if not isinstance(action, dict):
+        raise PerformanceContractError("reconciliation action must be an object")
+    action_type = str(action.get("action"))
+    expected = ACTION_FIELDS.get(action_type)
+    if expected is None:
+        raise PerformanceContractError("reconciliation action is unsupported")
+    if set(action) != expected:
+        raise PerformanceContractError("reconciliation action fields do not match the action contract")
+    effective_at = parse_timestamp(action.get("effective_at"), "reconciliation.effective_at")
+    evidence = require_alias(action.get("evidence_ref"), "reconciliation.evidence_ref")
+    evidence_ref = "mkt-evidence-v1:sha256:" + hashlib.sha256(evidence.encode("utf-8")).hexdigest()
+    return action_type, effective_at, evidence_ref
+
+
+def _identity_action(reporting: Any, action: dict[str, Any], action_type: str, effective_at: str, evidence_ref: str, recorded_at: str) -> ActionResult:
+    canonical = action.get("canonical_subject_id")
+    member = action.get("member_subject_id")
+    if not isinstance(canonical, str) or not SUBJECT_REF_RE.fullmatch(canonical):
+        raise PerformanceContractError("canonical_subject_id is invalid")
+    if not isinstance(member, str) or not SUBJECT_REF_RE.fullmatch(member):
+        raise PerformanceContractError("member_subject_id is invalid")
+    if canonical == member:
+        raise PerformanceContractError("identity reconciliation requires distinct subjects")
+    known = int(reporting.connection.execute("SELECT COUNT(DISTINCT subject_id) FROM events WHERE subject_id IN (?,?)", (canonical, member)).fetchone()[0])
+    if known < 2:
+        raise PerformanceContractError("identity reconciliation subjects must already exist")
+    competing = list(reporting.connection.execute("SELECT action,canonical_subject_id FROM identity_links WHERE member_subject_id=? AND effective_at=?", (member, effective_at)))
+    conflict = any(str(row["action"]) != action_type or str(row["canonical_subject_id"]) != canonical for row in competing)
+    if conflict:
+        raise PerformanceContractError("identity reconciliation conflicts at the same effective time")
+    link_ref = reporting.store.pseudonym("mkt-link-v1", action_type, canonical, member, effective_at, evidence_ref)
+    reporting.connection.execute(
+        "INSERT OR IGNORE INTO identity_links(link_ref,action,canonical_subject_id,member_subject_id,evidence_ref,effective_at,recorded_at) VALUES(?,?,?,?,?,?,?)",
+        (link_ref, action_type, canonical, member, evidence_ref, effective_at, recorded_at),
+    )
+    if action_type == "link":
+        reporting._assert_identity_graph_acyclic_from(effective_at)
+    return ActionResult(action_type, member, action_type, (action_type, canonical, member), effective_at, evidence_ref)
+
+
+def _quarantine_action(reporting: Any, action: dict[str, Any], action_type: str, effective_at: str, evidence_ref: str) -> ActionResult:
+    target_ref = action.get("quarantine_ref")
+    resolution = action.get("resolution")
+    if not isinstance(target_ref, str) or not QUARANTINE_REF_RE.fullmatch(target_ref):
+        raise PerformanceContractError("quarantine_ref is invalid")
+    if resolution not in {"discarded", "superseded"}:
+        raise PerformanceContractError("quarantine resolution is unsupported")
+    if reporting.connection.execute("SELECT 1 FROM quarantine WHERE quarantine_ref=?", (target_ref,)).fetchone() is None:
+        raise PerformanceContractError("quarantine target does not exist")
+    return ActionResult(action_type, target_ref, str(resolution), (action_type, target_ref, str(resolution)), effective_at, evidence_ref)
+
+
+def _apply_action(reporting: Any, action: dict[str, Any], recorded_at: str) -> int:
+    action_type, effective_at, evidence_ref = _common(action)
+    if action_type in {"link", "split"}:
+        result = _identity_action(reporting, action, action_type, effective_at, evidence_ref, recorded_at)
+    else:
+        result = _quarantine_action(reporting, action, action_type, effective_at, evidence_ref)
+    reconciliation_ref = reporting.store.pseudonym("mkt-reconciliation-v1", *result.reference_parts, effective_at, evidence_ref)
+    payload = {key: value for key, value in action.items() if key != "evidence_ref"}
+    cursor = reporting.connection.execute(
+        "INSERT OR IGNORE INTO reconciliations(reconciliation_ref,action,target_ref,resolution,evidence_ref,effective_at,recorded_at,payload_json) VALUES(?,?,?,?,?,?,?,?)",
+        (reconciliation_ref, action_type, result.target_ref, result.resolution, evidence_ref, effective_at, recorded_at, canonical_json(payload)),
+    )
+    return int(cursor.rowcount > 0)
+
+
+def reconcile(reporting: Any, document: Any) -> dict[str, Any]:
+    """Append explicit owner identity or quarantine decisions."""
+    actions = _document_actions(document)
+    recorded_at = utc_now()
+    reporting.connection.execute("BEGIN IMMEDIATE")
+    try:
+        applied = sum(_apply_action(reporting, action, recorded_at) for action in actions)
+        reporting.connection.commit()
+    except Exception:
+        reporting.connection.rollback()
+        raise
+    return {"schema": "aidevops.marketing-performance-reconciliation-result/v1", "applied": applied}

--- a/.agents/scripts/_performance_reporting_subjects.py
+++ b/.agents/scripts/_performance_reporting_subjects.py
@@ -1,0 +1,121 @@
+"""Privacy-safe subject projections for performance reporting."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from performance_contract import timestamp_epoch, utc_now
+
+
+def _now_timestamp(now_epoch: int | None) -> str:
+    if now_epoch is None:
+        return utc_now()
+    return datetime.fromtimestamp(now_epoch, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _facts(reporting: Any, identity_history: list[dict[str, Any]]) -> tuple[set[str], dict[str, str], dict[str, str]]:
+    subjects: set[str] = set()
+    kinds: dict[str, str] = {}
+    states: dict[str, str] = {}
+    for row in reporting.connection.execute("SELECT subject_id,subject_kind,identity_state FROM events WHERE subject_id IS NOT NULL"):
+        subject_id = str(row["subject_id"])
+        subjects.add(subject_id)
+        kinds.setdefault(subject_id, str(row["subject_kind"]))
+        states.setdefault(subject_id, str(row["identity_state"]))
+    for row in identity_history:
+        subjects.update((str(row["canonical_subject_id"]), str(row["member_subject_id"])))
+    return subjects, kinds, states
+
+
+def _groups(reporting: Any, subjects: set[str], links: dict[str, str]) -> tuple[dict[str, set[str]], set[str]]:
+    groups: dict[str, set[str]] = defaultdict(set)
+    cycles: set[str] = set()
+    for subject_id in subjects:
+        canonical, cycle = reporting._canonical(subject_id, links)
+        groups[canonical].add(subject_id)
+        if cycle:
+            cycles.add(canonical)
+    return groups, cycles
+
+
+def _ledger_rows(reporting: Any, table: str) -> list[dict[str, Any]]:
+    rows = [dict(row) for row in reporting.connection.execute(f"SELECT * FROM {table}")]
+    return sorted(rows, key=lambda row: (timestamp_epoch(str(row["effective_at"])), timestamp_epoch(str(row["observed_at"])), str(row["ledger_ref"])))
+
+
+def _latest_consent(rows: list[dict[str, Any]], boundary: float) -> dict[tuple[str, str], dict[str, Any]]:
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    keys: dict[tuple[str, str], tuple[float, float, str]] = {}
+    for row in rows:
+        key = (str(row["subject_id"]), str(row["purpose"]))
+        order = (timestamp_epoch(str(row["effective_at"])), timestamp_epoch(str(row["observed_at"])), str(row["ledger_ref"]))
+        if order[0] <= boundary and order > keys.get(key, (float("-inf"), float("-inf"), "")):
+            latest[key] = row
+            keys[key] = order
+    return latest
+
+
+def _latest_suppression(rows: list[dict[str, Any]], boundary: float) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    keys: dict[str, tuple[float, float, str]] = {}
+    for row in rows:
+        key = str(row["subject_id"])
+        order = (timestamp_epoch(str(row["effective_at"])), timestamp_epoch(str(row["observed_at"])), str(row["ledger_ref"]))
+        if order[0] <= boundary and order > keys.get(key, (float("-inf"), float("-inf"), "")):
+            latest[key] = row
+            keys[key] = order
+    return latest
+
+
+def _eligibility(cycle: bool, states: list[str], suppressions: dict[str, dict[str, Any]]) -> tuple[bool, str]:
+    if cycle:
+        return False, "identity_ambiguous"
+    if any(str(row["state"]) == "suppressed" for row in suppressions.values()):
+        return False, "suppressed"
+    if "denied" in states:
+        return False, "consent_denied"
+    if states and all(state == "granted" for state in states):
+        return True, "eligible"
+    return False, "consent_unknown"
+
+
+def _group_record(reporting: Any, canonical: str, members: set[str], context: dict[str, Any]) -> dict[str, Any]:
+    consent_rows = [row for row in context["consent_rows"] if str(row["subject_id"]) in members]
+    suppression_rows = [row for row in context["suppression_rows"] if str(row["subject_id"]) in members]
+    latest_consent = _latest_consent(consent_rows, context["boundary"])
+    latest_suppression = _latest_suppression(suppression_rows, context["boundary"])
+    audience_states = [str(latest_consent[(member, "audience")]["state"]) if (member, "audience") in latest_consent else "unknown" for member in members]
+    cycle = canonical in context["cycles"]
+    eligible, reason = _eligibility(cycle, audience_states, latest_suppression)
+    history = [row for row in context["identity_history"] if str(row["member_subject_id"]) in members]
+    states = context["states"]
+    identity_states = context["identity_states"]
+    state = "ambiguous" if cycle else "linked" if len(members) > 1 else states.get(canonical, identity_states.get(canonical, "isolated"))
+    kinds = context["kinds"]
+    kind = kinds.get(canonical) or next((kinds[item] for item in sorted(members) if item in kinds), "anonymous")
+    return {
+        "schema_version": 1, "subject_id": canonical, "kind": kind,
+        "identity_state": state, "canonical_subject_id": canonical, "aliases": sorted(members),
+        "consent": [reporting._consent_record(row) for row in consent_rows],
+        "suppression": [reporting._suppression_record(row) for row in suppression_rows],
+        "identity_history": [reporting._identity_record(row) for row in history],
+        "audience_eligible": eligible, "eligibility_reason": reason,
+    }
+
+
+def subject_records(reporting: Any, now_epoch: int | None = None) -> list[dict[str, Any]]:
+    """Project subjects conservatively across explicit link/split history."""
+    now_timestamp = _now_timestamp(now_epoch)
+    links, states, identity_history = reporting._current_links(now_timestamp)
+    subjects, kinds, identity_states = _facts(reporting, identity_history)
+    groups, cycles = _groups(reporting, subjects, links)
+    context = {
+        "states": states, "identity_history": identity_history, "kinds": kinds,
+        "identity_states": identity_states, "cycles": cycles,
+        "consent_rows": _ledger_rows(reporting, "consent_ledger"),
+        "suppression_rows": _ledger_rows(reporting, "suppression_ledger"),
+        "boundary": timestamp_epoch(now_timestamp),
+    }
+    return [_group_record(reporting, canonical, members, context) for canonical, members in sorted(groups.items())]

--- a/.agents/scripts/_performance_reporting_subjects.py
+++ b/.agents/scripts/_performance_reporting_subjects.py
@@ -3,10 +3,23 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from performance_contract import timestamp_epoch, utc_now
+
+
+@dataclass(frozen=True)
+class SubjectContext:
+    states: dict[str, str]
+    identity_history: list[dict[str, Any]]
+    kinds: dict[str, str]
+    identity_states: dict[str, str]
+    cycles: set[str]
+    consent_rows: list[dict[str, Any]]
+    suppression_rows: list[dict[str, Any]]
+    boundary: float
 
 
 def _now_timestamp(now_epoch: int | None) -> str:
@@ -40,9 +53,16 @@ def _groups(reporting: Any, subjects: set[str], links: dict[str, str]) -> tuple[
     return groups, cycles
 
 
-def _ledger_rows(reporting: Any, table: str) -> list[dict[str, Any]]:
-    rows = [dict(row) for row in reporting.connection.execute(f"SELECT * FROM {table}")]
+def _sorted_ledger(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(rows, key=lambda row: (timestamp_epoch(str(row["effective_at"])), timestamp_epoch(str(row["observed_at"])), str(row["ledger_ref"])))
+
+
+def _consent_rows(reporting: Any) -> list[dict[str, Any]]:
+    return _sorted_ledger([dict(row) for row in reporting.connection.execute("SELECT * FROM consent_ledger")])
+
+
+def _suppression_rows(reporting: Any) -> list[dict[str, Any]]:
+    return _sorted_ledger([dict(row) for row in reporting.connection.execute("SELECT * FROM suppression_ledger")])
 
 
 def _latest_consent(rows: list[dict[str, Any]], boundary: float) -> dict[tuple[str, str], dict[str, Any]]:
@@ -81,20 +101,30 @@ def _eligibility(cycle: bool, states: list[str], suppressions: dict[str, dict[st
     return False, "consent_unknown"
 
 
-def _group_record(reporting: Any, canonical: str, members: set[str], context: dict[str, Any]) -> dict[str, Any]:
-    consent_rows = [row for row in context["consent_rows"] if str(row["subject_id"]) in members]
-    suppression_rows = [row for row in context["suppression_rows"] if str(row["subject_id"]) in members]
-    latest_consent = _latest_consent(consent_rows, context["boundary"])
-    latest_suppression = _latest_suppression(suppression_rows, context["boundary"])
+def _group_governance(context: SubjectContext, canonical: str, members: set[str]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool, str]:
+    consent_rows = [row for row in context.consent_rows if str(row["subject_id"]) in members]
+    suppression_rows = [row for row in context.suppression_rows if str(row["subject_id"]) in members]
+    latest_consent = _latest_consent(consent_rows, context.boundary)
+    latest_suppression = _latest_suppression(suppression_rows, context.boundary)
     audience_states = [str(latest_consent[(member, "audience")]["state"]) if (member, "audience") in latest_consent else "unknown" for member in members]
-    cycle = canonical in context["cycles"]
+    cycle = canonical in context.cycles
     eligible, reason = _eligibility(cycle, audience_states, latest_suppression)
-    history = [row for row in context["identity_history"] if str(row["member_subject_id"]) in members]
-    states = context["states"]
-    identity_states = context["identity_states"]
-    state = "ambiguous" if cycle else "linked" if len(members) > 1 else states.get(canonical, identity_states.get(canonical, "isolated"))
-    kinds = context["kinds"]
+    return consent_rows, suppression_rows, eligible, reason
+
+
+def _group_identity(context: SubjectContext, canonical: str, members: set[str]) -> tuple[list[dict[str, Any]], str, str]:
+    history = [row for row in context.identity_history if str(row["member_subject_id"]) in members]
+    states = context.states
+    identity_states = context.identity_states
+    state = "ambiguous" if canonical in context.cycles else "linked" if len(members) > 1 else states.get(canonical, identity_states.get(canonical, "isolated"))
+    kinds = context.kinds
     kind = kinds.get(canonical) or next((kinds[item] for item in sorted(members) if item in kinds), "anonymous")
+    return history, state, kind
+
+
+def _group_record(reporting: Any, canonical: str, members: set[str], context: SubjectContext) -> dict[str, Any]:
+    consent_rows, suppression_rows, eligible, reason = _group_governance(context, canonical, members)
+    history, state, kind = _group_identity(context, canonical, members)
     return {
         "schema_version": 1, "subject_id": canonical, "kind": kind,
         "identity_state": state, "canonical_subject_id": canonical, "aliases": sorted(members),
@@ -111,11 +141,8 @@ def subject_records(reporting: Any, now_epoch: int | None = None) -> list[dict[s
     links, states, identity_history = reporting._current_links(now_timestamp)
     subjects, kinds, identity_states = _facts(reporting, identity_history)
     groups, cycles = _groups(reporting, subjects, links)
-    context = {
-        "states": states, "identity_history": identity_history, "kinds": kinds,
-        "identity_states": identity_states, "cycles": cycles,
-        "consent_rows": _ledger_rows(reporting, "consent_ledger"),
-        "suppression_rows": _ledger_rows(reporting, "suppression_ledger"),
-        "boundary": timestamp_epoch(now_timestamp),
-    }
+    context = SubjectContext(
+        states, identity_history, kinds, identity_states, cycles,
+        _consent_rows(reporting), _suppression_rows(reporting), timestamp_epoch(now_timestamp),
+    )
     return [_group_record(reporting, canonical, members, context) for canonical, members in sorted(groups.items())]

--- a/.agents/scripts/performance_reporting.py
+++ b/.agents/scripts/performance_reporting.py
@@ -1,39 +1,38 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Read-only projections, reconciliation, and bounded exports."""
+"""Compatibility facade for read-only marketing performance projections."""
 
 from __future__ import annotations
 
-import hashlib
-import json
 import os
-import re
 import secrets
-import sqlite3
-import time
-from collections import defaultdict
-from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
 from typing import Any, Iterable
 
+from _performance_reporting_events import EventQuery, event_records as _event_records
+from _performance_reporting_queries import (
+    assert_identity_graph_acyclic as _assert_identity_graph_acyclic,
+    current_links as _current_links,
+    effective_rows as _effective_rows,
+    source_rows as _source_rows,
+)
+from _performance_reporting_reconciliation import (
+    QUARANTINE_REF_RE,
+    SUBJECT_REF_RE,
+    reconcile as _reconcile,
+)
+from _performance_reporting_subjects import subject_records as _subject_records
 from performance_contract import (
     PerformanceContractError,
-    canonical_json,
     decimal_json,
-    decimal_wire,
     metric_definition,
-    parse_timestamp,
     require_alias,
-    timestamp_epoch,
-    utc_now,
     wire_json,
 )
 from performance_store import MarketingPerformanceStore
 
-SUBJECT_REF_RE = re.compile(r"^mkt-subj-v1:[a-f0-9]{64}$")
-QUARANTINE_REF_RE = re.compile(r"^mkt-quarantine-v1:[a-f0-9]{64}$")
 CONFIDENCE_RANK = {"low": 0, "medium": 1, "high": 2, "verified": 3}
 
 
@@ -62,72 +61,7 @@ class PerformanceReporting:
         self.connection = store.connection
 
     def _source_rows(self, now_epoch: int | None = None) -> list[dict[str, Any]]:
-        now = int(time.time()) if now_epoch is None else now_epoch
-        effective_resolutions = {
-            str(row["target_ref"])
-            for row in self.connection.execute(
-                "SELECT target_ref,effective_at FROM reconciliations "
-                "WHERE action='resolve_quarantine'"
-            )
-            if timestamp_epoch(str(row["effective_at"])) <= now
-        }
-        event_refs = {
-            str(row["event_ref"])
-            for row in self.connection.execute("SELECT DISTINCT event_ref FROM events")
-        }
-        unresolved: dict[tuple[str, str], int] = defaultdict(int)
-        for row in self.connection.execute("SELECT * FROM quarantine"):
-            if str(row["quarantine_ref"]) in effective_resolutions:
-                continue
-            if (
-                str(row["reason"]) == "correction_target_pending"
-                and str(row["source_event_ref"]) in event_refs
-            ):
-                continue
-            unresolved[(str(row["source"]), str(row["account_ref"]))] += 1
-        active_leases = {
-            (str(row["source"]), str(row["account_ref"]))
-            for row in self.connection.execute(
-                "SELECT source,account_ref FROM leases WHERE expires_at>?",
-                (now,),
-            )
-        }
-        output: list[dict[str, Any]] = []
-        for row in self.connection.execute(
-            "SELECT * FROM sources ORDER BY source,account_ref"
-        ):
-            key = (str(row["source"]), str(row["account_ref"]))
-            observed_at = row["last_observed_at"]
-            lag_seconds = None
-            stale = False
-            if observed_at is not None:
-                lag_seconds = int(max(0, now - timestamp_epoch(str(observed_at))))
-                stale = lag_seconds > int(row["stale_after_seconds"])
-            status = str(row["status"])
-            if unresolved.get(key, 0) > 0:
-                status = "partial"
-            elif key in active_leases:
-                status = "leased"
-            elif stale:
-                status = "stale"
-            output.append(
-                {
-                    "source": key[0],
-                    "account_ref": key[1],
-                    "adapter": str(row["adapter"]),
-                    "status": status,
-                    "coverage": str(row["coverage"]),
-                    "missing_scopes": json.loads(str(row["missing_scopes_json"])),
-                    "cursor_present": row["cursor_ref"] is not None,
-                    "last_observed_at": observed_at,
-                    "last_success_at": row["last_success_at"],
-                    "stale_after_seconds": int(row["stale_after_seconds"]),
-                    "lag_seconds": lag_seconds,
-                    "stale": stale,
-                    "unresolved_quarantine": unresolved.get(key, 0),
-                }
-            )
-        return output
+        return _source_rows(self, now_epoch)
 
     def _effective_rows(
         self,
@@ -136,81 +70,13 @@ class PerformanceReporting:
         source: str | None = None,
         account_ref: str | None = None,
         campaign_id: str | None = None,
-    ) -> list[sqlite3.Row]:
-        clauses: list[str] = []
-        parameters: list[str] = []
-        for field, value in (("source", source), ("account_ref", account_ref)):
-            if value is not None:
-                clauses.append(f"{field}=?")
-                parameters.append(value)
-        where = " WHERE " + " AND ".join(clauses) if clauses else ""
-        rows = list(
-            self.connection.execute(
-                "SELECT * FROM events" + where + " ORDER BY occurred_at,recorded_at,record_ref",
-                tuple(parameters),
-            )
-        )
-        if history:
-            return [row for row in rows if campaign_id is None or row["campaign_id"] == campaign_id]
-        latest: dict[tuple[str, str, str], sqlite3.Row] = {}
-        for row in rows:
-            key = (str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))
-            previous = latest.get(key)
-            if previous is None or int(row["revision"]) > int(previous["revision"]):
-                latest[key] = row
-        correction_refs = {
-            str(row["correction_ref"])
-            for row in latest.values()
-            if row["correction_ref"] is not None
-        }
-        effective = [
-            row
-            for row in rows
-            if latest.get((str(row["source"]), str(row["account_ref"]), str(row["event_ref"]))) is row
-            and str(row["event_ref"]) not in correction_refs
-        ]
-        return [
-            row for row in effective if campaign_id is None or row["campaign_id"] == campaign_id
-        ]
+    ) -> list[Any]:
+        return _effective_rows(self, history, source, account_ref, campaign_id)
 
     def _current_links(
         self, now_timestamp: str
     ) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:
-        latest: dict[str, sqlite3.Row] = {}
-        latest_keys: dict[str, tuple[float, float, str]] = {}
-        rows = list(self.connection.execute("SELECT * FROM identity_links"))
-        history = [
-            dict(row)
-            for row in sorted(
-                rows,
-                key=lambda item: (
-                    timestamp_epoch(str(item["effective_at"])),
-                    timestamp_epoch(str(item["recorded_at"])),
-                    str(item["link_ref"]),
-                ),
-            )
-        ]
-        for row in rows:
-            member = str(row["member_subject_id"])
-            ordering = (
-                timestamp_epoch(str(row["effective_at"])),
-                timestamp_epoch(str(row["recorded_at"])),
-                str(row["link_ref"]),
-            )
-            if (
-                ordering[0] <= timestamp_epoch(now_timestamp)
-                and ordering > latest_keys.get(member, (float("-inf"), float("-inf"), ""))
-            ):
-                latest[member] = row
-                latest_keys[member] = ordering
-        links: dict[str, str] = {}
-        states: dict[str, str] = {}
-        for member, row in latest.items():
-            action = str(row["action"])
-            states[member] = "linked" if action == "link" else "split"
-            if action == "link":
-                links[member] = str(row["canonical_subject_id"])
-        return links, states, history
+        return _current_links(self, now_timestamp)
 
     @staticmethod
     def _canonical(subject_id: str, links: dict[str, str]) -> tuple[str, bool]:
@@ -227,198 +93,46 @@ class PerformanceReporting:
         return subject_id, True
 
     def _assert_identity_graph_acyclic_from(self, effective_at: str) -> None:
-        effective_epoch = timestamp_epoch(effective_at)
-        boundaries = [
-            str(row["effective_at"])
-            for row in self.connection.execute(
-                "SELECT DISTINCT effective_at FROM identity_links"
-            )
-            if timestamp_epoch(str(row["effective_at"])) >= effective_epoch
-        ]
-        for boundary in sorted(boundaries, key=timestamp_epoch):
-            links, _states, _history = self._current_links(boundary)
-            if any(self._canonical(subject_id, links)[1] for subject_id in links):
-                raise PerformanceContractError(
-                    "identity reconciliation must not create a cyclic link graph"
-                )
+        _assert_identity_graph_acyclic(self, effective_at)
 
     @read_snapshot
     def subject_records(self, now_epoch: int | None = None) -> list[dict[str, Any]]:
         """Project subjects conservatively across explicit link/split history."""
-        now_timestamp = (
-            datetime.fromtimestamp(now_epoch, timezone.utc)
-            .replace(microsecond=0)
-            .isoformat()
-            .replace("+00:00", "Z")
-            if now_epoch is not None
-            else utc_now()
-        )
-        links, states, identity_history = self._current_links(now_timestamp)
-        kinds: dict[str, str] = {}
-        identity_states: dict[str, str] = {}
-        subjects: set[str] = set()
-        for row in self.connection.execute(
-            "SELECT subject_id,subject_kind,identity_state FROM events WHERE subject_id IS NOT NULL"
-        ):
-            subject_id = str(row["subject_id"])
-            subjects.add(subject_id)
-            kinds.setdefault(subject_id, str(row["subject_kind"]))
-            identity_states.setdefault(subject_id, str(row["identity_state"]))
-        for row in identity_history:
-            subjects.add(str(row["canonical_subject_id"]))
-            subjects.add(str(row["member_subject_id"]))
-        groups: dict[str, set[str]] = defaultdict(set)
-        cycles: set[str] = set()
-        for subject_id in subjects:
-            canonical, cycle = self._canonical(subject_id, links)
-            groups[canonical].add(subject_id)
-            if cycle:
-                cycles.add(canonical)
-        consent_rows = sorted(
-            [dict(row) for row in self.connection.execute("SELECT * FROM consent_ledger")],
-            key=lambda row: (
-                timestamp_epoch(str(row["effective_at"])),
-                timestamp_epoch(str(row["observed_at"])),
-                str(row["ledger_ref"]),
-            ),
-        )
-        suppression_rows = sorted(
-            [dict(row) for row in self.connection.execute("SELECT * FROM suppression_ledger")],
-            key=lambda row: (
-                timestamp_epoch(str(row["effective_at"])),
-                timestamp_epoch(str(row["observed_at"])),
-                str(row["ledger_ref"]),
-            ),
-        )
-        output: list[dict[str, Any]] = []
-        for canonical, members in sorted(groups.items()):
-            member_consent = [row for row in consent_rows if str(row["subject_id"]) in members]
-            member_suppression = [row for row in suppression_rows if str(row["subject_id"]) in members]
-            latest_consent: dict[tuple[str, str], dict[str, Any]] = {}
-            latest_consent_keys: dict[tuple[str, str], tuple[float, float, str]] = {}
-            for row in member_consent:
-                key = (str(row["subject_id"]), str(row["purpose"]))
-                ordering = (
-                    timestamp_epoch(str(row["effective_at"])),
-                    timestamp_epoch(str(row["observed_at"])),
-                    str(row["ledger_ref"]),
-                )
-                if (
-                    ordering[0] <= timestamp_epoch(now_timestamp)
-                    and ordering > latest_consent_keys.get(
-                        key,
-                        (float("-inf"), float("-inf"), ""),
-                    )
-                ):
-                    latest_consent[key] = row
-                    latest_consent_keys[key] = ordering
-            latest_suppression: dict[str, dict[str, Any]] = {}
-            latest_suppression_keys: dict[str, tuple[float, float, str]] = {}
-            for row in member_suppression:
-                key = str(row["subject_id"])
-                ordering = (
-                    timestamp_epoch(str(row["effective_at"])),
-                    timestamp_epoch(str(row["observed_at"])),
-                    str(row["ledger_ref"]),
-                )
-                if (
-                    ordering[0] <= timestamp_epoch(now_timestamp)
-                    and ordering > latest_suppression_keys.get(
-                        key,
-                        (float("-inf"), float("-inf"), ""),
-                    )
-                ):
-                    latest_suppression[key] = row
-                    latest_suppression_keys[key] = ordering
-            audience_states = [
-                str(latest_consent[(member, "audience")]["state"])
-                if (member, "audience") in latest_consent
-                else "unknown"
-                for member in members
-            ]
-            suppressed = any(
-                str(row["state"]) == "suppressed" for row in latest_suppression.values()
-            )
-            if canonical in cycles:
-                eligible, reason = False, "identity_ambiguous"
-            elif suppressed:
-                eligible, reason = False, "suppressed"
-            elif "denied" in audience_states:
-                eligible, reason = False, "consent_denied"
-            elif audience_states and all(state == "granted" for state in audience_states):
-                eligible, reason = True, "eligible"
-            else:
-                eligible, reason = False, "consent_unknown"
-            group_history = [
-                row for row in identity_history if str(row["member_subject_id"]) in members
-            ]
-            state = "ambiguous" if canonical in cycles else "linked" if len(members) > 1 else states.get(canonical, identity_states.get(canonical, "isolated"))
-            kind = kinds.get(canonical) or next((kinds[item] for item in sorted(members) if item in kinds), "anonymous")
-            output.append(
-                {
-                    "schema_version": 1,
-                    "subject_id": canonical,
-                    "kind": kind,
-                    "identity_state": state,
-                    "canonical_subject_id": canonical,
-                    "aliases": sorted(members),
-                    "consent": [self._consent_record(row) for row in member_consent],
-                    "suppression": [self._suppression_record(row) for row in member_suppression],
-                    "identity_history": [self._identity_record(row) for row in group_history],
-                    "audience_eligible": eligible,
-                    "eligibility_reason": reason,
-                }
-            )
-        return output
+        return _subject_records(self, now_epoch)
 
     @staticmethod
     def _provenance(row: dict[str, Any]) -> dict[str, Any]:
         return {
-            "source": str(row["source"]),
-            "account_ref": str(row["account_ref"]),
-            "observed_at": str(row["observed_at"]),
-            "evidence_ref": str(row["evidence_ref"]),
+            "source": str(row["source"]), "account_ref": str(row["account_ref"]),
+            "observed_at": str(row["observed_at"]), "evidence_ref": str(row["evidence_ref"]),
         }
 
     def _consent_record(self, row: dict[str, Any]) -> dict[str, Any]:
         return {
-            "purpose": str(row["purpose"]),
-            "state": str(row["state"]),
-            "lawful_basis": row["lawful_basis"],
-            "effective_at": str(row["effective_at"]),
+            "purpose": str(row["purpose"]), "state": str(row["state"]),
+            "lawful_basis": row["lawful_basis"], "effective_at": str(row["effective_at"]),
             "provenance": self._provenance(row),
         }
 
     def _suppression_record(self, row: dict[str, Any]) -> dict[str, Any]:
         return {
-            "state": str(row["state"]),
-            "reason": row["reason"],
-            "effective_at": str(row["effective_at"]),
-            "provenance": self._provenance(row),
+            "state": str(row["state"]), "reason": row["reason"],
+            "effective_at": str(row["effective_at"]), "provenance": self._provenance(row),
         }
 
     @staticmethod
     def _identity_record(row: dict[str, Any]) -> dict[str, Any]:
         return {
-            "action": str(row["action"]),
-            "canonical_subject_id": str(row["canonical_subject_id"]),
-            "member_subject_id": str(row["member_subject_id"]),
-            "effective_at": str(row["effective_at"]),
+            "action": str(row["action"]), "canonical_subject_id": str(row["canonical_subject_id"]),
+            "member_subject_id": str(row["member_subject_id"]), "effective_at": str(row["effective_at"]),
             "provenance": {
-                "source": "owner",
-                "account_ref": "owner-reconciliation",
-                "observed_at": str(row["recorded_at"]),
-                "evidence_ref": str(row["evidence_ref"]),
+                "source": "owner", "account_ref": "owner-reconciliation",
+                "observed_at": str(row["recorded_at"]), "evidence_ref": str(row["evidence_ref"]),
             },
         }
 
     @staticmethod
-    def _effective_confidence(
-        confidence: str,
-        source_status: str,
-        completeness: str,
-        identity_state: str,
-    ) -> str:
+    def _effective_confidence(confidence: str, source_status: str, completeness: str, identity_state: str) -> str:
         cap = "verified"
         if completeness == "partial" or source_status == "partial":
             cap = "medium"
@@ -431,120 +145,9 @@ class PerformanceReporting:
         return confidence if CONFIDENCE_RANK[confidence] <= CONFIDENCE_RANK[cap] else cap
 
     @read_snapshot
-    def event_records(
-        self,
-        *,
-        history: bool = False,
-        source: str | None = None,
-        account_ref: str | None = None,
-        campaign_id: str | None = None,
-        now_epoch: int | None = None,
-    ) -> list[dict[str, Any]]:
+    def event_records(self, **options: Any) -> list[dict[str, Any]]:
         """Return schema-valid pseudonymous event records."""
-        source_state = {
-            (row["source"], row["account_ref"]): row
-            for row in self._source_rows(now_epoch)
-        }
-        subjects = {row["subject_id"]: row for row in self.subject_records(now_epoch)}
-        records: list[dict[str, Any]] = []
-        for row in self._effective_rows(
-            history=history,
-            source=source,
-            account_ref=account_ref,
-            campaign_id=campaign_id,
-        ):
-            state = source_state[(str(row["source"]), str(row["account_ref"]))]
-            subject_id = row["subject_id"]
-            if subject_id is None:
-                governance = {"audience_eligible": False, "eligibility_reason": "aggregate"}
-                canonical_subject = None
-                identity_state = str(row["identity_state"])
-            else:
-                subject = next(
-                    (item for item in subjects.values() if str(subject_id) in item["aliases"]),
-                    None,
-                )
-                canonical_subject = subject["subject_id"] if subject else str(subject_id)
-                identity_state = subject["identity_state"] if subject else str(row["identity_state"])
-                governance = {
-                    "audience_eligible": bool(subject and subject["audience_eligible"]),
-                    "eligibility_reason": subject["eligibility_reason"] if subject else "consent_unknown",
-                }
-            effective_confidence = self._effective_confidence(
-                str(row["confidence"]),
-                state["status"],
-                str(row["completeness"]),
-                identity_state,
-            )
-            records.append(
-                {
-                    "schema_version": 1,
-                    "record_ref": str(row["record_ref"]),
-                    "event_ref": str(row["event_ref"]),
-                    "source": {
-                        "kind": str(row["source"]),
-                        "account_ref": str(row["account_ref"]),
-                        "revision": int(row["revision"]),
-                        "observed_at": str(row["observed_at"]),
-                        "recorded_at": str(row["recorded_at"]),
-                        "source_observed_at": (
-                            str(row["source_observed_at"])
-                            if row["source_observed_at"] is not None
-                            else None
-                        ),
-                        "source_recorded_at": (
-                            str(row["source_recorded_at"])
-                            if row["source_recorded_at"] is not None
-                            else None
-                        ),
-                        "evidence_ref": str(row["evidence_ref"]),
-                        "coverage": state["coverage"],
-                        "missing_scopes": state["missing_scopes"],
-                    },
-                    "event": {
-                        "type": str(row["event_type"]),
-                        "occurred_at": str(row["occurred_at"]),
-                        "correction_of": row["correction_ref"],
-                    },
-                    "subject": {
-                        "subject_id": canonical_subject,
-                        "kind": str(row["subject_kind"]),
-                        "identity_state": identity_state,
-                    },
-                    "scope": {
-                        **{
-                            field: row[field]
-                            for field in (
-                                "campaign_id",
-                                "channel",
-                                "creative_id",
-                                "touchpoint_id",
-                                "outcome_id",
-                            )
-                        },
-                        "dimensions": json.loads(str(row["dimensions_json"])),
-                    },
-                    "measurement": {
-                        "metric_id": str(row["metric_id"]),
-                        "value": decimal_wire(str(row["value_text"])),
-                        "unit": str(row["unit"]),
-                        "aggregation": str(row["aggregation"]),
-                        "currency": row["currency"],
-                        "period_start": row["period_start"],
-                        "period_end": row["period_end"],
-                    },
-                    "quality": {
-                        "confidence": str(row["confidence"]),
-                        "effective_confidence": effective_confidence,
-                        "completeness": str(row["completeness"]),
-                        "source_type": str(row["source_type"]),
-                        "collected_by": str(row["collected_by"]),
-                        "evidence_ref": str(row["evidence_ref"]),
-                    },
-                    "governance": governance,
-                }
-            )
-        return records
+        return _event_records(self, EventQuery.from_options(options))
 
     @staticmethod
     def phase1_result(event: dict[str, Any]) -> dict[str, Any]:
@@ -558,51 +161,27 @@ class PerformanceReporting:
         else:
             result_subject = {"type": "marketing", "id": "aggregate"}
         dimensions = dict(scope["dimensions"])
-        dimensions.update(
-            {
-                key: value
-                for key, value in {
-                    "channel": scope["channel"],
-                    "creative_id": scope["creative_id"],
-                    "touchpoint_id": scope["touchpoint_id"],
-                    "outcome_id": scope["outcome_id"],
-                    "currency": event["measurement"]["currency"],
-                }.items()
-                if value is not None
-            }
-        )
+        dimensions.update({key: value for key, value in {
+            "channel": scope["channel"], "creative_id": scope["creative_id"],
+            "touchpoint_id": scope["touchpoint_id"], "outcome_id": scope["outcome_id"],
+            "currency": event["measurement"]["currency"],
+        }.items() if value is not None})
         return {
             "schema_version": 1,
             "metric": metric_definition(event["measurement"]["metric_id"], event["measurement"]["unit"]),
-            "subject": result_subject,
-            "dimensions": dimensions,
+            "subject": result_subject, "dimensions": dimensions,
             "measurement": {
-                "value": (
-                    decimal_json(event["measurement"]["value"])
-                    if isinstance(event["measurement"]["value"], str)
-                    else event["measurement"]["value"]
-                ),
-                "unit": event["measurement"]["unit"],
-                "aggregation": event["measurement"]["aggregation"],
-                "period_start": event["measurement"]["period_start"],
-                "period_end": event["measurement"]["period_end"],
-                "observed_at": (
-                    event["source"]["source_observed_at"]
-                    or event["source"]["observed_at"]
-                ),
-                "recorded_at": (
-                    event["source"]["source_recorded_at"]
-                    or event["source"]["recorded_at"]
-                ),
+                "value": decimal_json(event["measurement"]["value"]) if isinstance(event["measurement"]["value"], str) else event["measurement"]["value"],
+                "unit": event["measurement"]["unit"], "aggregation": event["measurement"]["aggregation"],
+                "period_start": event["measurement"]["period_start"], "period_end": event["measurement"]["period_end"],
+                "observed_at": event["source"]["source_observed_at"] or event["source"]["observed_at"],
+                "recorded_at": event["source"]["source_recorded_at"] or event["source"]["recorded_at"],
                 "source_event_at": event["event"]["occurred_at"],
             },
             "quality": {
-                "confidence": event["quality"]["effective_confidence"],
-                "source_type": event["quality"]["source_type"],
-                "source_ref": event["quality"]["evidence_ref"],
-                "collected_by": event["quality"]["collected_by"],
-                "evidence": [event["record_ref"]],
-                "notes": None,
+                "confidence": event["quality"]["effective_confidence"], "source_type": event["quality"]["source_type"],
+                "source_ref": event["quality"]["evidence_ref"], "collected_by": event["quality"]["collected_by"],
+                "evidence": [event["record_ref"]], "notes": None,
             },
         }
 
@@ -620,155 +199,22 @@ class PerformanceReporting:
         elif any(source["status"] in {"partial", "stale", "leased"} for source in sources):
             status = "partial"
         return {
-            "schema": "aidevops.marketing-performance-status/v1",
-            "status": status,
-            "sources": sources,
+            "schema": "aidevops.marketing-performance-status/v1", "status": status, "sources": sources,
             "summary": {
-                "source_accounts": len(sources),
-                "event_history": event_history,
-                "effective_events": effective,
-                "subjects": len(self.subject_records(now_epoch)),
-                "quarantine_total": quarantine_total,
+                "source_accounts": len(sources), "event_history": event_history, "effective_events": effective,
+                "subjects": len(self.subject_records(now_epoch)), "quarantine_total": quarantine_total,
                 "unresolved_quarantine": unresolved,
             },
         }
 
     def reconcile(self, document: Any) -> dict[str, Any]:
         """Append explicit owner identity or quarantine decisions."""
-        if not isinstance(document, dict) or document.get("schema") != "aidevops.marketing-performance-reconciliation/v1":
-            raise PerformanceContractError("unsupported reconciliation schema")
-        actions = document.get("actions")
-        if not isinstance(actions, list) or not actions:
-            raise PerformanceContractError("reconciliation actions must be a non-empty array")
-        recorded_at = utc_now()
-        applied = 0
-        self.connection.execute("BEGIN IMMEDIATE")
-        try:
-            for action in actions:
-                if not isinstance(action, dict):
-                    raise PerformanceContractError("reconciliation action must be an object")
-                action_type = action.get("action")
-                required_fields = {
-                    "link": {
-                        "action",
-                        "canonical_subject_id",
-                        "member_subject_id",
-                        "effective_at",
-                        "evidence_ref",
-                    },
-                    "split": {
-                        "action",
-                        "canonical_subject_id",
-                        "member_subject_id",
-                        "effective_at",
-                        "evidence_ref",
-                    },
-                    "resolve_quarantine": {
-                        "action",
-                        "quarantine_ref",
-                        "resolution",
-                        "effective_at",
-                        "evidence_ref",
-                    },
-                }
-                expected = required_fields.get(str(action_type))
-                if expected is None:
-                    raise PerformanceContractError("reconciliation action is unsupported")
-                if set(action) != expected:
-                    raise PerformanceContractError(
-                        "reconciliation action fields do not match the action contract"
-                    )
-                effective_at = parse_timestamp(action.get("effective_at"), "reconciliation.effective_at")
-                evidence = require_alias(
-                    action.get("evidence_ref"),
-                    "reconciliation.evidence_ref",
-                )
-                evidence_ref = "mkt-evidence-v1:sha256:" + hashlib.sha256(evidence.encode("utf-8")).hexdigest()
-                if action_type in {"link", "split"}:
-                    canonical = action.get("canonical_subject_id")
-                    member = action.get("member_subject_id")
-                    if not isinstance(canonical, str) or not SUBJECT_REF_RE.fullmatch(canonical):
-                        raise PerformanceContractError("canonical_subject_id is invalid")
-                    if not isinstance(member, str) or not SUBJECT_REF_RE.fullmatch(member):
-                        raise PerformanceContractError("member_subject_id is invalid")
-                    if canonical == member:
-                        raise PerformanceContractError("identity reconciliation requires distinct subjects")
-                    known = int(self.connection.execute(
-                        "SELECT COUNT(DISTINCT subject_id) FROM events WHERE subject_id IN (?,?)",
-                        (canonical, member),
-                    ).fetchone()[0])
-                    if known < 2:
-                        raise PerformanceContractError("identity reconciliation subjects must already exist")
-                    competing = list(
-                        self.connection.execute(
-                            "SELECT action,canonical_subject_id FROM identity_links "
-                            "WHERE member_subject_id=? AND effective_at=?",
-                            (member, effective_at),
-                        )
-                    )
-                    if any(
-                        str(row["action"]) != action_type
-                        or str(row["canonical_subject_id"]) != canonical
-                        for row in competing
-                    ):
-                        raise PerformanceContractError(
-                            "identity reconciliation conflicts at the same effective time"
-                        )
-                    link_ref = self.store.pseudonym("mkt-link-v1", action_type, canonical, member, effective_at, evidence_ref)
-                    self.connection.execute(
-                        "INSERT OR IGNORE INTO identity_links(link_ref,action,canonical_subject_id,member_subject_id,evidence_ref,effective_at,recorded_at) VALUES(?,?,?,?,?,?,?)",
-                        (link_ref, action_type, canonical, member, evidence_ref, effective_at, recorded_at),
-                    )
-                    if action_type == "link":
-                        self._assert_identity_graph_acyclic_from(effective_at)
-                    target_ref = member
-                    resolution = action_type
-                    reconciliation_parts = [
-                        str(action_type),
-                        str(canonical),
-                        str(member),
-                    ]
-                elif action_type == "resolve_quarantine":
-                    target_ref = action.get("quarantine_ref")
-                    resolution = action.get("resolution")
-                    if not isinstance(target_ref, str) or not QUARANTINE_REF_RE.fullmatch(target_ref):
-                        raise PerformanceContractError("quarantine_ref is invalid")
-                    if resolution not in {"discarded", "superseded"}:
-                        raise PerformanceContractError("quarantine resolution is unsupported")
-                    if self.connection.execute("SELECT 1 FROM quarantine WHERE quarantine_ref=?", (target_ref,)).fetchone() is None:
-                        raise PerformanceContractError("quarantine target does not exist")
-                    reconciliation_parts = [
-                        str(action_type),
-                        str(target_ref),
-                        str(resolution),
-                    ]
-                reconciliation_ref = self.store.pseudonym(
-                    "mkt-reconciliation-v1",
-                    *reconciliation_parts,
-                    effective_at,
-                    evidence_ref,
-                )
-                payload = {
-                    key: value
-                    for key, value in action.items()
-                    if key not in {"evidence_ref"}
-                }
-                cursor = self.connection.execute(
-                    "INSERT OR IGNORE INTO reconciliations(reconciliation_ref,action,target_ref,resolution,evidence_ref,effective_at,recorded_at,payload_json) VALUES(?,?,?,?,?,?,?,?)",
-                    (reconciliation_ref, action_type, target_ref, resolution, evidence_ref, effective_at, recorded_at, canonical_json(payload)),
-                )
-                applied += int(cursor.rowcount > 0)
-            self.connection.commit()
-        except Exception:
-            self.connection.rollback()
-            raise
-        return {"schema": "aidevops.marketing-performance-reconciliation-result/v1", "applied": applied}
+        return _reconcile(self, document)
 
     @staticmethod
     def _atomic_jsonl(path: Path, records: Iterable[dict[str, Any]]) -> int:
-        if path.is_symlink() or path.parent.is_symlink() or (
-            path.exists() and not path.is_file()
-        ):
+        unsafe_existing = path.exists() and not path.is_file()
+        if path.is_symlink() or path.parent.is_symlink() or unsafe_existing:
             raise PerformanceContractError("export destination must be a regular file")
         path.parent.mkdir(parents=True, exist_ok=True)
         temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
@@ -788,7 +234,7 @@ class PerformanceReporting:
         return count
 
     def export(self, purpose: str, output: Path, *, result_format: bool = False) -> dict[str, Any]:
-        """Write an explicit pseudonymous measurement or eligible-audience export."""
+        """Write an explicit pseudonymous measurement or audience export."""
         if purpose == "audience":
             records = [record for record in self.subject_records() if record["audience_eligible"]]
         elif purpose == "measurement":
@@ -797,36 +243,20 @@ class PerformanceReporting:
         else:
             raise PerformanceContractError("export purpose is unsupported")
         count = self._atomic_jsonl(output, records)
-        return {
-            "schema": "aidevops.marketing-performance-export/v1",
-            "purpose": purpose,
-            "records": count,
-            "output": str(output),
-            "identifier_policy": "pseudonymous-subjects-validated-dimensions",
-        }
+        return {"schema": "aidevops.marketing-performance-export/v1", "purpose": purpose, "records": count, "output": str(output), "identifier_policy": "pseudonymous-subjects-validated-dimensions"}
 
     def write_campaign_summary(self, campaign_id: str, account_ref: str) -> Path:
-        """Write only aggregate campaign result projections to a versionable summary."""
+        """Write aggregate campaign results to a versionable summary."""
         campaign_id = require_alias(campaign_id, "campaign id")
         account_ref = require_alias(account_ref, "account ref")
         if self.store.paths.summaries.is_symlink() or not self.store.paths.summaries.is_dir():
             raise PerformanceContractError("campaign summary directory is unsafe")
         account_directory = self.store.paths.summaries / account_ref
-        if account_directory.is_symlink() or (
-            account_directory.exists() and not account_directory.is_dir()
-        ):
+        if account_directory.is_symlink() or (account_directory.exists() and not account_directory.is_dir()):
             raise PerformanceContractError("campaign account summary directory is unsafe")
         account_directory.mkdir(mode=0o755, exist_ok=True)
-        events = self.event_records(
-            source="campaign",
-            account_ref=account_ref,
-            campaign_id=campaign_id,
-        )
-        records = [
-            self.phase1_result(event)
-            for event in events
-            if event["subject"]["subject_id"] is None
-        ]
+        events = self.event_records(source="campaign", account_ref=account_ref, campaign_id=campaign_id)
+        records = [self.phase1_result(event) for event in events if event["subject"]["subject_id"] is None]
         destination = account_directory / f"{campaign_id}.jsonl"
         self._atomic_jsonl(destination, records)
         os.chmod(destination, 0o644)
@@ -835,21 +265,8 @@ class PerformanceReporting:
     @read_snapshot
     def rebuild_summaries(self) -> dict[str, Any]:
         """Rebuild aggregate campaign summaries from immutable event history."""
-        campaign_accounts = [
-            (str(row["campaign_id"]), str(row["account_ref"]))
-            for row in self.connection.execute(
-                "SELECT DISTINCT campaign_id,account_ref FROM events "
-                "WHERE source='campaign' AND campaign_id IS NOT NULL "
-                "ORDER BY campaign_id,account_ref"
-            )
-        ]
-        paths = [
-            str(self.write_campaign_summary(campaign_id, account_ref))
-            for campaign_id, account_ref in campaign_accounts
-        ]
-        return {
-            "schema": "aidevops.marketing-performance-rebuild/v1",
-            "campaigns": len(campaign_accounts),
-            "summaries": paths,
-            "history_rewritten": False,
-        }
+        campaign_accounts = [(str(row["campaign_id"]), str(row["account_ref"])) for row in self.connection.execute(
+            "SELECT DISTINCT campaign_id,account_ref FROM events WHERE source='campaign' AND campaign_id IS NOT NULL ORDER BY campaign_id,account_ref"
+        )]
+        paths = [str(self.write_campaign_summary(campaign_id, account_ref)) for campaign_id, account_ref in campaign_accounts]
+        return {"schema": "aidevops.marketing-performance-rebuild/v1", "campaigns": len(campaign_accounts), "summaries": paths, "history_rewritten": False}

--- a/.agents/scripts/performance_reporting.py
+++ b/.agents/scripts/performance_reporting.py
@@ -19,8 +19,8 @@ from _performance_reporting_queries import (
     source_rows as _source_rows,
 )
 from _performance_reporting_reconciliation import (
-    QUARANTINE_REF_RE,
-    SUBJECT_REF_RE,
+    QUARANTINE_REF_RE as _QUARANTINE_REF_RE,
+    SUBJECT_REF_RE as _SUBJECT_REF_RE,
     reconcile as _reconcile,
 )
 from _performance_reporting_subjects import subject_records as _subject_records
@@ -34,6 +34,18 @@ from performance_contract import (
 from performance_store import MarketingPerformanceStore
 
 CONFIDENCE_RANK = {"low": 0, "medium": 1, "high": 2, "verified": 3}
+QUARANTINE_REF_RE = _QUARANTINE_REF_RE
+SUBJECT_REF_RE = _SUBJECT_REF_RE
+
+
+def _source_confidence_cap(source_status: str, completeness: str) -> str:
+    if completeness == "partial" or source_status == "partial":
+        return "medium"
+    if completeness == "unknown" or source_status in {"unavailable", "unknown"}:
+        return "low"
+    if source_status == "stale":
+        return "high"
+    return "verified"
 
 
 def read_snapshot(method: Any) -> Any:
@@ -133,16 +145,9 @@ class PerformanceReporting:
 
     @staticmethod
     def _effective_confidence(confidence: str, source_status: str, completeness: str, identity_state: str) -> str:
-        cap = "verified"
-        if completeness == "partial" or source_status == "partial":
-            cap = "medium"
-        elif completeness == "unknown" or source_status in {"unavailable", "unknown"}:
-            cap = "low"
-        elif source_status == "stale":
-            cap = "high"
-        if identity_state == "ambiguous" and CONFIDENCE_RANK[cap] > CONFIDENCE_RANK["high"]:
-            cap = "high"
-        return confidence if CONFIDENCE_RANK[confidence] <= CONFIDENCE_RANK[cap] else cap
+        cap = _source_confidence_cap(source_status, completeness)
+        identity_cap = "high" if identity_state == "ambiguous" else "verified"
+        return min((confidence, cap, identity_cap), key=CONFIDENCE_RANK.__getitem__)
 
     @read_snapshot
     def event_records(self, **options: Any) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Refactors `PerformanceReporting` behind focused source/query, subject, event, and reconciliation modules while preserving:

- public facade calls and read-snapshot semantics
- exact decimal and timestamp wire projections
- privacy eligibility and identity-cycle rejection
- atomic reconciliation transactions and bounded exports

## Quality result

- Qlty new-file gate: 4 eligible modules, 0 smells
- Qlty regression gate: 101 scoped findings on `origin/main` to 96 on this head, net -5
- initial Codacy findings were addressed by removing dynamic SQL, bounding projection complexity, and preserving public constant exports explicitly
- no Qlty override labels

## Runtime Testing

- **Risk level:** Medium
- `python3 .agents/scripts/tests/test-marketing-performance-ingest.py` — 19 passed
- `.agents/scripts/linters-local.sh --changed` — passed
- Python compilation and `git diff --check` — passed
- review evidence digest: `55e636ba2e48bfc2b68f85e16a48fa4e0b264ac99ba6c7a0a3196663b96b004f`

Resolves #30252

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.263 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 6m and 107,270 tokens on this as a headless worker.
