### PR TITLE
GH#30261: reuse Hostinger SSH credentials across account sites

### DIFF
--- a/.agents/configs/wordpress-sites.json.txt
+++ b/.agents/configs/wordpress-sites.json.txt
@@ -12,7 +12,7 @@
   },
 
   "servers": {
-    "_note": "DRY server definitions — reference from sites using 'server_ref'. Site-level fields override server defaults.",
+    "_note": "DRY hosting-account/server definitions — reference from sites using 'server_ref'. Store one credential per account, not per domain. Site-level fields override server defaults.",
     "hetzner-vps-1": {
       "type": "hetzner",
       "ssh_host": "123.45.67.89",
@@ -23,7 +23,9 @@
       "type": "hostinger",
       "ssh_host": "ssh.example.com",
       "ssh_port": 65002,
-      "ssh_user": "u123456789"
+      "ssh_user": "u123456789",
+      "ssh_password_env": "HOSTINGER_SSH_PASSWORD_ACCOUNT_1",
+      "_credential_note": "The env-var name is safe config. Store its value once with: aidevops secret set HOSTINGER_SSH_PASSWORD_ACCOUNT_1"
     },
     "cloudways-master": {
       "type": "cloudways",
@@ -46,7 +48,7 @@
       "type": "hostinger",
       "url": "https://example.com",
       "server_ref": "hostinger-shared-1",
-      "_note": "server_ref inherits ssh_host, ssh_port, ssh_user from servers.hostinger-shared-1",
+      "_note": "server_ref inherits the shared account connection and credential reference; all sites on this Hostinger account reuse it",
       "wp_path": "/domains/example.com/public_html",
       "mainwp_connected": true,
       "mainwp_site_id": 123,

--- a/.agents/scripts/tests/test-wp-helper-shared-auth-env.sh
+++ b/.agents/scripts/tests/test-wp-helper-shared-auth-env.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+WP_HELPER="${SCRIPT_DIR}/../wp-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+cleanup_tmp_dir() {
+	local tmp_dir="${TMP_DIR:-}"
+	local tmp_base="${tmp_dir##*/}"
+
+	if [[ -z "$tmp_dir" || ! -d "$tmp_dir" ]]; then
+		return 0
+	fi
+	if [[ "$tmp_base" != aidevops-wp-shared-password.* ]]; then
+		printf 'Refusing to remove unexpected temp directory: %s\n' "$tmp_dir" >&2
+		return 1
+	fi
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+assert_result() {
+	local name="$1"
+	local rc="$2"
+	local detail="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+		printf 'PASS %s\n' "$name"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf 'FAIL %s — %s\n' "$name" "$detail"
+	fi
+	return 0
+}
+
+run_site() {
+	local site="$1"
+	local password="${2:-}"
+	local output_file="$3"
+
+	HOME="${TMP_DIR}/home" \
+		PATH="${TMP_DIR}/bin:${PATH}" \
+		MOCK_SSHPASS_LOG="${TMP_DIR}/sshpass.log" \
+		HOSTINGER_SSH_PASSWORD_ACCOUNT_1="$password" \
+		"$WP_HELPER" "$site" core version >"$output_file" 2>&1
+	return $?
+}
+
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-wp-shared-password.XXXXXX") || exit 1
+trap cleanup_tmp_dir EXIT
+mkdir -p "${TMP_DIR}/home/.config/aidevops" "${TMP_DIR}/bin" || exit 1
+
+cat >"${TMP_DIR}/home/.config/aidevops/wordpress-sites.json" <<'JSON'
+{
+  "servers": {
+    "hostinger-account-1": {
+      "type": "hostinger",
+      "ssh_host": "ssh.example.com",
+      "ssh_port": 65002,
+      "ssh_user": "u123456789",
+      "ssh_password_env": "HOSTINGER_SSH_PASSWORD_ACCOUNT_1"
+    }
+  },
+  "sites": {
+    "site-a": {
+      "name": "Site A",
+      "type": "hostinger",
+      "server_ref": "hostinger-account-1",
+      "wp_path": "/domains/site-a.example/public_html"
+    },
+    "site-b": {
+      "name": "Site B",
+      "type": "hostinger",
+      "server_ref": "hostinger-account-1",
+      "wp_path": "/domains/site-b.example/public_html"
+    }
+  }
+}
+JSON
+
+cat >"${TMP_DIR}/bin/sshpass" <<'MOCK'
+#!/usr/bin/env bash
+printf 'password=%s\nargs=%s\n' "${SSHPASS:-}" "$*" >>"$MOCK_SSHPASS_LOG"
+exit 0
+MOCK
+chmod 700 "${TMP_DIR}/bin/sshpass"
+
+cat >"${TMP_DIR}/bin/ssh" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-G" ]]; then
+	printf 'hostname ssh.example.com\nuser u123456789\nport 65002\nidentityfile ~/.ssh/id_rsa\n'
+	exit 0
+fi
+printf 'Unexpected direct ssh invocation: %s\n' "$*" >&2
+exit 1
+MOCK
+chmod 700 "${TMP_DIR}/bin/ssh"
+
+output_file="${TMP_DIR}/site-a.out"
+run_site site-a fixture-password "$output_file"
+rc=$?
+log=$(<"${TMP_DIR}/sshpass.log")
+if [[ "$rc" -eq 0 && "$log" == *'password=fixture-password'* && "$log" == *'/domains/site-a.example/public_html'* ]]; then
+	assert_result "uses account-level password environment reference" 0
+else
+	assert_result "uses account-level password environment reference" 1 "rc=${rc} log=${log}"
+fi
+
+: >"${TMP_DIR}/sshpass.log"
+output_file="${TMP_DIR}/site-b.out"
+run_site site-b fixture-password "$output_file"
+rc=$?
+log=$(<"${TMP_DIR}/sshpass.log")
+if [[ "$rc" -eq 0 && "$log" == *'password=fixture-password'* && "$log" == *'/domains/site-b.example/public_html'* ]]; then
+	assert_result "reuses one account credential for another site" 0
+else
+	assert_result "reuses one account credential for another site" 1 "rc=${rc} log=${log}"
+fi
+
+output_file="${TMP_DIR}/missing.out"
+run_site site-a '' "$output_file"
+rc=$?
+output=$(<"$output_file")
+if [[ "$rc" -ne 0 && "$output" == *'SSH password environment variable is not set'* ]]; then
+	assert_result "fails safely when shared password is not injected" 0
+else
+	assert_result "fails safely when shared password is not injected" 1 "rc=${rc} output=${output}"
+fi
+
+printf '\nTests: %d run, %d passed, %d failed\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -163,7 +163,9 @@ resolve_server_ref() {
 		if [[ -z "$current_identity" ]]; then
 			local cfg_identity
 			cfg_identity=$(echo "$ssh_defaults" | jq -r '.ssh_identity_file // empty')
-			[[ -n "$cfg_identity" ]] && merged=$(echo "$merged" | jq --arg v "$cfg_identity" '.ssh_identity_file = $v')
+			local expanded_cfg_identity="${cfg_identity/#\~/$HOME}"
+			[[ -n "$cfg_identity" && -f "$expanded_cfg_identity" ]] &&
+				merged=$(echo "$merged" | jq --arg v "$cfg_identity" '.ssh_identity_file = $v')
 		fi
 	fi
 
@@ -292,6 +294,8 @@ execute_wp_via_ssh() {
 	local_path=$(echo "$site_config" | jq -r '.path // empty')
 	local password_file
 	password_file=$(echo "$site_config" | jq -r '.password_file // empty')
+	local ssh_password_env
+	ssh_password_env=$(echo "$site_config" | jq -r '.ssh_password_env // empty')
 	local ssh_identity_file
 	ssh_identity_file=$(echo "$site_config" | jq -r '.ssh_identity_file // empty')
 
@@ -325,7 +329,10 @@ execute_wp_via_ssh() {
 			ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 			return $?
 		fi
-		# Fallback: sshpass with password file (backward compatible for password-auth users)
+		if [[ -n "$ssh_password_env" ]]; then
+			execute_ssh_with_password_env "$ssh_password_env" "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
+			return $?
+		fi
 		check_sshpass
 		local expanded_password_file
 		if [[ -n "$password_file" ]]; then
@@ -365,6 +372,28 @@ execute_wp_via_ssh() {
 		return 1
 		;;
 	esac
+}
+
+# Execute SSH with a password injected through a named environment variable.
+execute_ssh_with_password_env() {
+	local password_env="$1"
+	local ssh_port="$2"
+	local ssh_target="$3"
+	local remote_cmd="$4"
+
+	if [[ ! "$password_env" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+		print_error "Invalid ssh_password_env name: $password_env"
+		return 1
+	fi
+	if [[ -z "${!password_env:-}" ]]; then
+		print_error "SSH password environment variable is not set: $password_env"
+		print_info "Run with: aidevops secret $password_env -- wp-helper.sh ..."
+		return 1
+	fi
+
+	check_sshpass
+	SSHPASS="${!password_env}" sshpass -e ssh -n -p "$ssh_port" "$ssh_target" "$remote_cmd"
+	return $?
 }
 
 # Run WP-CLI command on a site
@@ -638,21 +667,28 @@ Setup (per-tenant, e.g. "acme"):
 
 Server References (DRY server config):
   Define shared server infrastructure in the "servers" section and reference
-  it from sites using "server_ref". Site-level fields override server defaults.
+	  it from sites using "server_ref". One server/account credential can therefore
+	  serve every site under that account. Site-level fields override server defaults.
 
   "servers": {
-    "hetzner-vps-1": {
-      "ssh_host": "123.45.67.89",
-      "ssh_user": "root",
-      "ssh_port": 22
+    "hostinger-account-1": {
+      "type": "hostinger",
+      "ssh_host": "ssh.example.com",
+      "ssh_user": "u123456789",
+      "ssh_port": 65002,
+      "ssh_password_env": "HOSTINGER_SSH_PASSWORD_ACCOUNT_1"
     }
   },
   "sites": {
     "my-site": {
-      "server_ref": "hetzner-vps-1",
-      "wp_path": "/var/www/my-site/public"
+      "server_ref": "hostinger-account-1",
+      "wp_path": "/domains/example.com/public_html"
     }
   }
+
+  Store only the shared password as a secret, then inject it when running:
+    aidevops secret set HOSTINGER_SSH_PASSWORD_ACCOUNT_1
+    aidevops secret HOSTINGER_SSH_PASSWORD_ACCOUNT_1 -- wp-helper.sh my-site core version
 
 SSH Config Integration:
   If ssh_host matches a Host alias in ~/.ssh/config, connection parameters

--- a/.agents/services/hosting/hostinger.md
+++ b/.agents/services/hosting/hostinger.md
@@ -23,12 +23,31 @@ tools:
 - **API**: REST at `https://developers.hostinger.com`
 - **Auth**: Bearer token in `~/.config/aidevops/credentials.sh` as `HOSTINGER_API_TOKEN`
 - **SSH**: Port 65002, key auth (recommended) or password auth; framework prefers key when `ssh_identity_file` is configured
+- **Credential scope**: Hostinger SSH access is hosting-account scoped, not domain scoped; inventory and group sites before requesting credentials
 - **Panel**: Custom hPanel
 - **No MCP required** — uses curl for API, ssh for key auth or sshpass for password auth
 
 <!-- AI-CONTEXT-END -->
 
 ## Configuration
+
+### Discover account boundaries first
+
+Before asking for SSH credentials, use the Hostinger API token to inventory websites and group them by account `username`. Domains with the same username share one SSH login and must reuse one server/account configuration. Do not request or store duplicate credentials per domain.
+
+Connection metadata (`ssh_host`, `ssh_port`, `ssh_user`, and domain paths) belongs in configuration and is not a password. Store only the shared password or private key securely. For WordPress fleets, prefer `wordpress-sites.json` `servers` plus per-site `server_ref`; `wp-helper.sh` supports an account-level `ssh_password_env` reference.
+
+Name secrets by account alias rather than site, for example `HOSTINGER_SSH_PASSWORD_ACCOUNT_1`. Run commands with the referenced secret injected:
+
+```bash
+aidevops secret set HOSTINGER_SSH_PASSWORD_ACCOUNT_1
+aidevops secret HOSTINGER_SSH_PASSWORD_ACCOUNT_1 -- \
+  wp-helper.sh example-site plugin list
+```
+
+Only request another SSH credential when API inventory, the hosting panel, or a failed authenticated probe shows a genuinely different account/server.
+
+### Legacy Hostinger helper
 
 Copy template and edit with server details:
 
@@ -92,6 +111,8 @@ sudo apt-get install sshpass  # Linux
 ## Security
 
 - SSH key auth is recommended; set `ssh_identity_file` in site config (e.g. `~/.ssh/hostinger_ed25519`)
+- Keep one credential per hosting account/server and reference it from every site on that account
+- Do not put non-secret host, port, username, or domain-path metadata in the secret store
 - Store passwords in files with 600 permissions; never commit them
 - Port 65002 (non-standard); be aware of concurrent connection limits
 

--- a/.agents/tools/wordpress/wp-admin.md
+++ b/.agents/tools/wordpress/wp-admin.md
@@ -37,6 +37,8 @@ tools:
 | MainWP | Fleet operations, connected sites |
 | WordPress MCP | AI-powered admin actions |
 
+**Shared-host credential rule:** Before requesting SSH access for several sites, identify hosting account/server boundaries. Configure one entry under `servers`, reference it from each site with `server_ref`, and store/inject one password or key per account—not one credential set per domain. Hostinger websites with the same account username share SSH access.
+
 **wp-helper.sh Commands**:
 
 ```bash


### PR DESCRIPTION
## Summary

Scope Hostinger SSH authentication to a shared hosting account and let WordPress sites reuse one injected secret via server_ref.

## Files Changed

.agents/configs/wordpress-sites.json.txt, .agents/scripts/tests/test-wp-helper-shared-auth-env.sh, .agents/scripts/wp-helper.sh, .agents/services/hosting/hostinger.md, .agents/tools/wordpress/wp-admin.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Privacy grep found no customer identifiers or local paths; Secretlint passed; shared-auth regression tests passed 3/3; full local linter suite passed.

Resolves #30261


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.263 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 52m and 300,315 tokens on this with the user in an interactive session.