### PR TITLE
t18240: feat: add privacy-safe marketing optimization

### DIFF
--- a/.agents/aidevops/feedback/mining-promotion.md
+++ b/.agents/aidevops/feedback/mining-promotion.md
@@ -130,6 +130,22 @@ Approved mined themes route to the smallest durable surface that can use them.
 | `_performance/` annotations | Feedback explains, qualifies, or challenges a metric movement, experiment result, incident trend, campaign result, or business KPI. | Metric or result ID, observation window, feedback theme, evidence count, segment/channel, source capture IDs, confidence, and sensitivity tier. | Qualitative annotations contextualize numbers; they do not replace measurements. Link to the metric artifact rather than duplicating dashboards. |
 | TODO / GitHub task | Mined feedback reveals actionable work: a bug, missing doc, product gap, process gap, follow-up investigation, or automation opportunity with enough context for a worker. | Public-safe title, worker-ready problem statement, sanitized evidence summary, affected files or discovery path when known, verification expectation, source theme ID, and privacy review result. | Public repos must never contain private/client names, local paths, raw quotes, emails, or sensitive evidence. Use placeholders and keep detailed evidence in `_feedback/` or a private plane. |
 
+### Validated growth learning
+
+An attribution projection or recommendation is not automatically durable
+learning. Promote a growth insight only after a reviewed experiment decision or
+repeated evidence has met the applicable sample, privacy, freshness, and
+contradiction gates. Carry forward the experiment/analysis or recommendation ID,
+aggregate evidence count, source snapshot, metric, model/window assumptions,
+confidence, caveat, owner decision, and retest date.
+
+Promoted knowledge contains the smallest reusable conclusion and a pointer to
+the governed evidence bundle. It never contains raw journeys, subject IDs,
+small-cohort breakdowns, private excerpts, contact destinations, or provider
+payloads. Observational attribution is labelled as a hypothesis-generating
+signal, not a causal result. Superseding evidence appends a new insight or marks
+the old recommendation superseded; it does not erase the prior audit record.
+
 ### Durable insights: `_knowledge/insights/`
 
 Promote to knowledge when the feedback is useful outside the immediate workflow.

--- a/.agents/aidevops/performance.md
+++ b/.agents/aidevops/performance.md
@@ -386,12 +386,63 @@ history.
 
 `/performance <URL>` remains the separate web-performance audit command.
 
-## Deferred Beyond Marketing Ingest
+## Attribution and Experiment Projections
+
+`marketing-optimization-helper.py` reads normalized, immutable marketing events
+and writes rebuildable analytical projections. It never updates source events,
+consent, suppression, identity links, campaigns, provider accounts, or prior
+experiment decisions.
+
+Three versioned schemas define this layer:
+
+- `schemas/marketing-attribution.schema.json` records the source snapshot,
+  direct or last-touch model, lookback-window version, aggregate credit,
+  source coverage, uncertainty, and a mandatory non-causal caveat.
+- `schemas/marketing-experiment.schema.json` preregisters hypothesis, assignment
+  unit, control and treatment variants, primary and guardrail metrics, minimum
+  sample/privacy thresholds, window, exclusions, stopping policy, owner,
+  analysis, and decision audit.
+- `schemas/growth-recommendation.schema.json` records evidence, impact range,
+  confidence, owner, required approval, rollback, retest date, status, and any
+  recommendation it supersedes.
+
+Attribution is a projection, not source truth. The same source snapshot, model,
+window, and versions produce the same `projection_id`; changing a model or
+window version produces a new projection without erasing old decisions. Refunds
+and costs remain compensating outcomes. Missing touchpoints stay unattributed,
+and ambiguous identity increases uncertainty rather than being guessed.
+
+Experiment analysis accepts aggregate observations only. A result is
+`insufficient_evidence` until every variant meets both the preregistered sample
+minimum and inherited privacy threshold and the minimum test duration has
+elapsed. Guardrail regressions block winner adoption. Randomized assignment may
+support a bounded experimental claim; all other comparisons remain
+observational.
+
+```bash
+marketing-optimization-helper.py attribute --input events.json --model last_touch --window-days 30 --model-version 1 --window-version 1 --run-id RUN --generated-at TIME
+marketing-optimization-helper.py experiment --input experiment.json --run-id RUN --observed-at TIME
+marketing-optimization-helper.py report --input evidence.json --minimum-cohort 10 --generated-at TIME
+marketing-optimization-helper.py recommend --input evidence.json --owner content --approval ROLE --rollback PLAN --retest-at TIME --created-at TIME
+marketing-optimization-helper.py status --input report.json --now TIME
+```
+
+Projection and report publication uses an atomic temporary-file replacement.
+Concurrent runs use distinct run IDs; callers must compare source snapshot and
+version before replacing a newer published projection. A failed run leaves the
+previous published artifact intact. Reports move through
+`_reports/drafts` review before a published bundle; raw evidence remains in its
+private source plane.
+
+Existing Phase 1 records without attribution remain valid and report as
+unattributed. Rebuilds derive new projections from effective immutable event and
+reconciliation history rather than editing historical records.
+
+## Deferred Beyond Marketing Optimization
 
 - Provider-authenticated live marketing adapters and scheduled collectors.
 - Promotion paths from `_cases/` and `_projects/`.
 - Dashboard generation and recurring review cadence.
-- Attribution, experiment assignment, and optimization decisions.
 - Cross-plane lesson promotion back to `_knowledge/insights/`.
 
 Later phases may extend these schemas, but they must keep Phase 1 result fields

--- a/.agents/content/optimization.md
+++ b/.agents/content/optimization.md
@@ -24,9 +24,9 @@ tools:
 
 - **Purpose**: Optimize content via A/B testing, variant generation, and analytics-driven iteration
 - **Input**: Published content, performance metrics, test hypotheses
-- **Output**: Winning variants, optimization recommendations, analytics insights
+- **Output**: Evidence-qualified candidate variants, approval-bound optimization recommendations, analytics insights
 - **Related**: `content/production-*.md` (variants), `content/distribution-*.md` (platform metrics), `content/research.md` (next cycle)
-- **Core rules**: 10+ variants before committing | 250+ samples before judging | <2% = kill | 2-3% = scale | >3% = go aggressive | Proven first, original second
+- **Core rules**: Preregister hypothesis/control/metrics | Meet sample and privacy thresholds | Check guardrails and freshness | Human approval before consequential changes
 
 <!-- AI-CONTEXT-END -->
 
@@ -44,7 +44,12 @@ tools:
 
 **Platform minimums**: YouTube: 250 impressions, 2% CTR, 50% retention | TikTok: 500 views, 70% completion | Blog: 100 visitors, 2min+ avg | Email: 250 sends, 20% open | Thumbnail: 1000 impressions, 5% CTR
 
-**Statistical significance**: 95% confidence minimum; 7+ days for day-of-week variance; 14+ days for audiences <1000.
+**Statistical validity**: Preregister the primary metric, control, guardrails,
+minimum sample, duration, exclusions, and stopping policy. The default decision
+threshold is 95% confidence, 7+ days for day-of-week variance, and 14+ days for
+audiences under 1000, but power analysis and inherited privacy minimums may
+require more evidence. Do not peek, extend, or swap metrics to manufacture a
+winner.
 
 ### What to Test (priority order)
 
@@ -72,8 +77,8 @@ thumbnail-helper.sh analyze VIDEO_ID
 1. **Generate**: 10+ variants via `content/production-*.md` agents
 2. **Deploy**: YouTube A/B, TikTok separate videos, Google Optimize for blog, email list split
 3. **Collect**: 250+ samples per variant (CTR, retention, completion, time on page)
-4. **Analyze**: Lift = `(variant - baseline) / baseline * 100`; require 95% significance
-5. **Scale winners**: Extract pattern, store (`/remember "Hook pattern: ..."`), apply to next 10 pieces
+4. **Analyze**: Use `marketing-optimization-helper.py experiment`; require preregistered sample, duration, confidence, privacy, and guardrail checks
+5. **Review candidates**: Route creative changes to Content, channel/campaign changes to Marketing, and product changes to Product; preserve owner approval
 6. **Batch cycle**: Week 1 produce → Week 2 collect → Week 3 analyze + kill bottom 7 → Week 4 produce from top 3
 
 ## Variant Generation
@@ -116,7 +121,23 @@ content-calendar-helper.sh stats                # overall health
 
 **Seasonality**: Q4 (Oct-Dec) highest buying intent → reviews, comparisons, affiliate. Q1 educational/how-to. Q2-Q3 experiment + build backlog.
 
-**Feedback loop**: Publish → collect analytics → analyze → extract patterns → store (`/remember "Pattern: ..."`) → feed research cycle → repeat.
+**Feedback loop**: Publish with approval → collect normalized evidence → build a
+freshness-aware aggregate report → analyze the preregistered test → review the
+candidate recommendation → retest. Observational attribution can suggest a test,
+but cannot justify a causal winner.
+
+## Performance Evidence Handoff
+
+Consume only privacy-safe projections from the Performance Plane. A usable
+handoff includes source snapshot and coverage, attribution model/window/version,
+experiment analysis ID, primary and guardrail metrics, aggregate sample sizes,
+confidence, freshness, caveats, and any contradicting evidence. Sparse cohorts
+remain suppressed and raw journeys or subject IDs do not enter content briefs.
+
+Recommendations must name the observed problem, target metric, expected impact
+range, confidence, owner, required approval, rollback, and retest date. They are
+decision inputs only: this agent does not autonomously publish, message, change
+spend, retarget, change audiences/offers, or mutate provider accounts.
 
 ## Proven First, Original Second
 
@@ -135,4 +156,6 @@ content-calendar-helper.sh stats                # overall health
 
 **Feeds into**: `content/research.md` (next research), `content/production-*.md` (next batch). **Uses from**: `content/distribution-*.md` (analytics), `content/production-*.md` (variants). **Related**: `tools/task-management/beads.md`, `reference/memory.md`.
 
-**After optimization**: Store winners (`/remember "Pattern: ..."`), update calendar to prioritize what works, feed winning topics into research cycle, scale with 10 more pieces using winning patterns.
+**After optimization**: Promote only reviewed, privacy-safe validated learning.
+Keep the experiment and decision references, note novelty/seasonality limits,
+and supersede prior recommendations instead of erasing their audit trail.

--- a/.agents/reports/marketing.md
+++ b/.agents/reports/marketing.md
@@ -30,10 +30,15 @@ agents; this doc owns report structure and handoff.
 
 1. Scope: campaign, channel, audience, offer, date range, spend, and goals.
 2. Executive summary: performance, constraint, opportunity, and decision.
-3. Funnel view: impressions, clicks, leads, sales, retention, and attribution.
+3. Funnel view: reach/impressions, engagement, account growth, traffic,
+   conversion, leads/stages, sales, revenue/refunds, costs, and ROI/payback only
+   where units and coverage make them valid.
 4. Creative/content findings: message, hook, offer, channel fit, and evidence.
-5. Experiment log: variants, sample size, winner, confidence, and next test.
-6. Recommendations: budget, creative, landing page, email, sales, or SEO tasks.
+5. Experiment log: preregistered hypothesis/control, variants, assignment,
+   sample/privacy thresholds, window, exclusions, primary/guardrail outcomes,
+   confidence, decision, and next test.
+6. Recommendations: evidence refs, expected impact range, confidence, owner,
+   required approval, rollback, retest date, and supersession status.
 7. Handoff: campaign routine, client report agent, or worker-ready backlog.
 
 ## Evidence Rules
@@ -43,6 +48,32 @@ agents; this doc owns report structure and handoff.
 - Cite dashboards, exports, screenshots, source tables, or tool outputs.
 - Record currency, time zone, date range, and data freshness.
 - Make recommendations measurable with owner, target metric, and re-test date.
+- Name the attribution model, lookback window, model/window versions, coverage,
+  unknown identity, and unattributed outcomes. Observational credit is not
+  incremental lift.
+- Suppress cohorts below the inherited privacy/minimum-sample threshold. Never
+  include subject-level journeys, direct identifiers, or raw private evidence.
+- Mark missing, partial, stale, contradictory, novelty-sensitive, or seasonal
+  evidence explicitly. Do not infer values for a missing funnel stage.
+- Keep platform reach/engagement/account-growth metrics distinct from CRM leads,
+  commerce sales/revenue/refunds, and costs.
+
+## Freshness and Publication
+
+`marketing-optimization-helper.py report` creates a deterministic aggregate
+draft. Every source records observed time, age, coverage, and `fresh` or `stale`
+status. Stale evidence can preserve historical context but cannot silently drive
+a current recommendation. No-data is a valid report state.
+
+Drafts follow `_reports/drafts` → review → published bundle. Atomic publication
+must leave the previous report available on partial failure. A report records its
+source snapshot, projection/analysis IDs, caveats, suppression count, and
+decision outputs so model-version recomputes remain auditable.
+
+Report generation and recommendation generation do not grant authority to
+publish content, send messages, change budgets/audiences/offers, retarget, or
+mutate provider accounts. Route those proposals to the domain owner and preserve
+the required approval in the recommendation record.
 
 ## Export Notes
 

--- a/.agents/schemas/growth-recommendation.schema.json
+++ b/.agents/schemas/growth-recommendation.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aidevops.local/schemas/growth-recommendation.schema.json",
+  "title": "Growth Recommendation v1",
+  "description": "Approval-bound aggregate recommendation derived from privacy-safe evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "recommendation_id", "status", "observed_problem", "target_metric", "evidence", "expected_impact", "confidence", "owner", "required_approval", "prohibited_mutations", "rollback", "retest_at", "created_at", "supersedes"],
+  "properties": {
+    "schema": {"const": "aidevops.growth-recommendation/v1"},
+    "recommendation_id": {"type": "string", "pattern": "^growth-rec-v1:[a-f0-9]{64}$"},
+    "status": {"enum": ["draft", "awaiting_approval", "approved", "testing", "validated", "rejected", "superseded", "insufficient_evidence"]},
+    "observed_problem": {"type": "string", "minLength": 1, "maxLength": 1000},
+    "target_metric": {"type": "string", "pattern": "^marketing\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)+$"},
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["refs", "source_snapshot", "sample_size", "privacy_safe", "causality"],
+      "properties": {
+        "refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 256}},
+        "source_snapshot": {"type": "string", "minLength": 1, "maxLength": 256},
+        "sample_size": {"type": "integer", "minimum": 0},
+        "privacy_safe": {"const": true},
+        "causality": {"enum": ["observational", "experimental"]}
+      }
+    },
+    "expected_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum", "unit"],
+      "properties": {
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "unit": {"enum": ["absolute", "relative_fraction", "percentage_points", "currency"]}
+      }
+    },
+    "confidence": {"enum": ["low", "medium", "high", "verified"]},
+    "owner": {"enum": ["content", "marketing", "product", "sales", "seo", "campaign-owner", "report-owner"]},
+    "required_approval": {"type": "string", "minLength": 1, "maxLength": 256},
+    "prohibited_mutations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"enum": ["publish", "message", "spend", "retarget", "change_audience", "change_offer", "mutate_provider_account"]}
+    },
+    "rollback": {"type": "string", "minLength": 1, "maxLength": 1000},
+    "retest_at": {"type": "string", "format": "date-time"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "supersedes": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^growth-rec-v1:[a-f0-9]{64}$"}}
+  }
+}

--- a/.agents/schemas/marketing-attribution.schema.json
+++ b/.agents/schemas/marketing-attribution.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aidevops.local/schemas/marketing-attribution.schema.json",
+  "title": "Marketing Attribution Projection v1",
+  "description": "Rebuildable privacy-safe attribution projection over immutable normalized marketing events.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "projection_id", "run_id", "source_snapshot", "model", "window", "generated_at", "coverage", "causality", "aggregates"],
+  "properties": {
+    "schema": {"const": "aidevops.marketing-attribution/v1"},
+    "projection_id": {"type": "string", "pattern": "^mkt-attribution-v1:[a-f0-9]{64}$"},
+    "run_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "source_snapshot": {"type": "string", "minLength": 1, "maxLength": 256},
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"enum": ["direct", "last_touch"]},
+        "version": {"type": "integer", "minimum": 1}
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["days", "version"],
+      "properties": {
+        "days": {"type": "integer", "minimum": 1, "maximum": 365},
+        "version": {"type": "integer", "minimum": 1}
+      }
+    },
+    "generated_at": {"type": "string", "format": "date-time"},
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "matched_outcomes", "unattributed_outcomes", "identity_uncertain_outcomes"],
+      "properties": {
+        "source": {"enum": ["complete", "partial", "unknown"]},
+        "matched_outcomes": {"type": "integer", "minimum": 0},
+        "unattributed_outcomes": {"type": "integer", "minimum": 0},
+        "identity_uncertain_outcomes": {"type": "integer", "minimum": 0}
+      }
+    },
+    "causality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claim", "caveat"],
+      "properties": {
+        "claim": {"enum": ["observational", "experimental"]},
+        "caveat": {"type": "string", "minLength": 1, "maxLength": 512}
+      }
+    },
+    "aggregates": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/aggregate"}
+    }
+  },
+  "$defs": {
+    "amount": {"type": "string", "pattern": "^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?$"},
+    "aggregate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["campaign_id", "channel", "credited_outcomes", "credit", "revenue", "refunds", "costs", "net_revenue", "currency", "uncertainty"],
+      "properties": {
+        "campaign_id": {"type": ["string", "null"], "maxLength": 128},
+        "channel": {"type": ["string", "null"], "maxLength": 128},
+        "credited_outcomes": {"type": "integer", "minimum": 0},
+        "credit": {"$ref": "#/$defs/amount"},
+        "revenue": {"$ref": "#/$defs/amount"},
+        "refunds": {"$ref": "#/$defs/amount"},
+        "costs": {"$ref": "#/$defs/amount"},
+        "net_revenue": {"$ref": "#/$defs/amount"},
+        "currency": {"type": ["string", "null"], "pattern": "^[A-Z]{3}$"},
+        "uncertainty": {"enum": ["low", "medium", "high"]}
+      }
+    }
+  }
+}

--- a/.agents/schemas/marketing-experiment.schema.json
+++ b/.agents/schemas/marketing-experiment.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aidevops.local/schemas/marketing-experiment.schema.json",
+  "title": "Marketing Experiment v1",
+  "description": "Preregistered aggregate marketing experiment and immutable decision audit.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "experiment_id", "version", "state", "hypothesis", "owner", "assignment", "variants", "metrics", "sample_policy", "window", "stopping_policy", "exclusions", "analysis", "decision"],
+  "properties": {
+    "schema": {"const": "aidevops.marketing-experiment/v1"},
+    "experiment_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$"},
+    "version": {"type": "integer", "minimum": 1},
+    "state": {"enum": ["draft", "approved", "running", "analysis_ready", "decided", "archived"]},
+    "hypothesis": {"type": "string", "minLength": 1, "maxLength": 1000},
+    "owner": {"type": "string", "minLength": 1, "maxLength": 128},
+    "assignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unit", "method", "control_variant"],
+      "properties": {
+        "unit": {"enum": ["anonymous_subject", "account", "session", "aggregate_cohort"]},
+        "method": {"enum": ["deterministic_hash", "provider_randomized", "preassigned_cohort"]},
+        "control_variant": {"type": "string", "minLength": 1, "maxLength": 128}
+      }
+    },
+    "variants": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 128}
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary", "guardrails"],
+      "properties": {
+        "primary": {"type": "string", "pattern": "^marketing\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)+$"},
+        "guardrails": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^marketing\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)+$"}}
+      }
+    },
+    "sample_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum_per_variant", "privacy_minimum", "confidence_threshold"],
+      "properties": {
+        "minimum_per_variant": {"type": "integer", "minimum": 2},
+        "privacy_minimum": {"type": "integer", "minimum": 2},
+        "confidence_threshold": {"type": "number", "minimum": 0.5, "maximum": 0.9999}
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["starts_at", "ends_at", "minimum_days"],
+      "properties": {
+        "starts_at": {"type": "string", "format": "date-time"},
+        "ends_at": {"type": "string", "format": "date-time"},
+        "minimum_days": {"type": "integer", "minimum": 1}
+      }
+    },
+    "stopping_policy": {"type": "string", "minLength": 1, "maxLength": 512},
+    "exclusions": {"type": "array", "items": {"type": "string", "maxLength": 256}},
+    "analysis": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/analysis"}]},
+    "decision": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/decision"}]}
+  },
+  "$defs": {
+    "analysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["analysis_id", "run_id", "source_snapshot", "status", "reason", "observed_at", "variants", "peeking_detected"],
+      "properties": {
+        "analysis_id": {"type": "string", "pattern": "^mkt-experiment-analysis-v1:[a-f0-9]{64}$"},
+        "run_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "source_snapshot": {"type": "string", "minLength": 1, "maxLength": 256},
+        "status": {"enum": ["insufficient_evidence", "no_material_difference", "candidate_winner", "guardrail_regression", "contradictory"]},
+        "reason": {"type": "string", "minLength": 1, "maxLength": 512},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "variants": {"type": "array", "items": {"type": "object"}},
+        "peeking_detected": {"type": "boolean"}
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "selected_variant", "decided_at", "decided_by", "rationale"],
+      "properties": {
+        "status": {"enum": ["adopt", "retain_control", "continue", "stop", "inconclusive"]},
+        "selected_variant": {"type": ["string", "null"]},
+        "decided_at": {"type": "string", "format": "date-time"},
+        "decided_by": {"type": "string", "minLength": 1, "maxLength": 128},
+        "rationale": {"type": "string", "minLength": 1, "maxLength": 1000}
+      }
+    }
+  }
+}

--- a/.agents/scripts/marketing-optimization-helper.py
+++ b/.agents/scripts/marketing-optimization-helper.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic privacy-safe marketing attribution and experiment analysis."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+SCHEMA_ATTRIBUTION = "aidevops.marketing-attribution/v1"
+SCHEMA_EXPERIMENT_ANALYSIS = "aidevops.marketing-experiment-analysis/v1"
+SCHEMA_REPORT = "aidevops.marketing-optimization-report/v1"
+SCHEMA_RECOMMENDATION = "aidevops.growth-recommendation/v1"
+TOUCHPOINT_TYPES = {"impression", "engagement", "social_receipt", "visit", "outreach_sent"}
+OUTCOME_TYPES = {"conversion", "lead_created", "lead_stage", "sale", "revenue"}
+PROHIBITED_MUTATIONS = [
+    "publish",
+    "message",
+    "spend",
+    "retarget",
+    "change_audience",
+    "change_offer",
+    "mutate_provider_account",
+]
+
+
+class OptimizationError(ValueError):
+    """Raised when an optimization input violates the public contract."""
+
+
+def _load(path: str) -> dict[str, Any]:
+    document = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise OptimizationError("input must be a JSON object")
+    return document
+
+
+def _canonical(document: Any) -> str:
+    return json.dumps(document, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _digest(prefix: str, document: Any) -> str:
+    value = hashlib.sha256(_canonical(document).encode("utf-8")).hexdigest()
+    return f"{prefix}:{value}"
+
+
+def _timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise OptimizationError(f"{field} must be an RFC 3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise OptimizationError(f"{field} must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise OptimizationError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _decimal(value: Any, field: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise OptimizationError(f"{field} must be an integer or canonical decimal string")
+    try:
+        return Decimal(str(value))
+    except InvalidOperation as exc:
+        raise OptimizationError(f"{field} is not numeric") from exc
+
+
+def _decimal_text(value: Decimal) -> str:
+    normalized = format(value, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return normalized or "0"
+
+
+def _artifact_identity(document: dict[str, Any]) -> Any:
+    fields = ("projection_id", "analysis_id", "report_id", "recommendation_id")
+    return next((document.get(field) for field in fields if document.get(field)), None)
+
+
+def _artifact_time(document: dict[str, Any]) -> Any:
+    return document.get("generated_at") or document.get("observed_at") or document.get("created_at")
+
+
+def _guard_publish(target: Path, document: dict[str, Any]) -> None:
+    if not target.exists():
+        return
+    existing = json.loads(target.read_text(encoding="utf-8"))
+    existing_time = _artifact_time(existing)
+    incoming_time = _artifact_time(document)
+    same_identity = _artifact_identity(existing) == _artifact_identity(document)
+    if same_identity or not existing_time or not incoming_time:
+        return
+    if _timestamp(incoming_time, "incoming publish time") <= _timestamp(existing_time, "existing publish time"):
+        raise OptimizationError("atomic publish refused to overwrite an equal or newer analytical artifact")
+
+
+def _atomic_replace(target: Path, rendered: str) -> None:
+    file_descriptor, temporary = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _write(document: dict[str, Any], output: str | None) -> None:
+    rendered = json.dumps(document, sort_keys=True, indent=2) + "\n"
+    if output is None:
+        print(rendered, end="")
+        return
+    target = Path(output).expanduser().absolute()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _guard_publish(target, document)
+    _atomic_replace(target, rendered)
+
+
+def _event_parts(event: dict[str, Any]) -> tuple[str, datetime, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    try:
+        event_type = str(event["event"]["type"])
+        occurred_at = _timestamp(event["event"]["occurred_at"], "event.occurred_at")
+        subject = event["subject"]
+        scope = event["scope"]
+        measurement = event["measurement"]
+    except (KeyError, TypeError) as exc:
+        raise OptimizationError("events must follow marketing-performance-event v1") from exc
+    if not all(isinstance(value, dict) for value in (subject, scope, measurement)):
+        raise OptimizationError("event subject, scope, and measurement must be objects")
+    return event_type, occurred_at, subject, scope, measurement
+
+
+def _parse_attribution_events(events: list[dict[str, Any]]) -> list[tuple[Any, ...]]:
+    parsed: list[tuple[datetime, str, dict[str, Any], dict[str, Any], dict[str, Any], str]] = []
+    for index, raw_event in enumerate(events):
+        if not isinstance(raw_event, dict):
+            raise OptimizationError("each event must be an object")
+        event_type, occurred_at, subject, scope, measurement = _event_parts(raw_event)
+        stable_ref = str(raw_event.get("event_ref") or f"event-{index:08d}")
+        parsed.append((occurred_at, event_type, subject, scope, measurement, stable_ref))
+    parsed.sort(key=lambda item: (item[0], item[5]))
+    return parsed
+
+
+def _attribution_input(document: dict[str, Any], model: str) -> tuple[list[dict[str, Any]], str, str, list[tuple[Any, ...]]]:
+    if model not in {"direct", "last_touch"}:
+        raise OptimizationError("model must be direct or last_touch")
+    events = document.get("events")
+    if not isinstance(events, list):
+        raise OptimizationError("events must be an array")
+    snapshot = str(document.get("source_snapshot") or "")
+    if not snapshot:
+        raise OptimizationError("source_snapshot is required")
+    source_coverage = document.get("coverage", "unknown")
+    if source_coverage not in {"complete", "partial", "unknown"}:
+        raise OptimizationError("coverage must be complete, partial, or unknown")
+    parsed = _parse_attribution_events(events)
+    return events, snapshot, source_coverage, parsed
+
+
+def _touchpoint_index(parsed: list[tuple[Any, ...]]) -> dict[str, list[tuple[datetime, dict[str, Any]]]]:
+    touchpoints: dict[str, list[tuple[datetime, dict[str, Any]]]] = defaultdict(list)
+    for occurred_at, event_type, subject, scope, _measurement, _event_ref in parsed:
+        subject_id = subject.get("subject_id")
+        if event_type in TOUCHPOINT_TYPES and isinstance(subject_id, str):
+            touchpoints[subject_id].append((occurred_at, scope))
+    return touchpoints
+
+
+def _attribution_bucket(totals: dict[tuple[Any, ...], dict[str, Any]], scope: dict[str, Any], currency: str | None) -> dict[str, Any]:
+    key = (scope.get("campaign_id"), scope.get("channel"), currency)
+    return totals.setdefault(
+        key,
+        {"credited_outcomes": 0, "credit": Decimal(0), "revenue": Decimal(0), "refunds": Decimal(0), "costs": Decimal(0), "uncertain": False},
+    )
+
+
+def _attributed_scope(occurred_at: datetime, subject: dict[str, Any], scope: dict[str, Any], model: str, window_seconds: int, touchpoints: dict[str, list[tuple[datetime, dict[str, Any]]]]) -> dict[str, Any] | None:
+    if subject.get("identity_state") == "ambiguous":
+        return None
+    if model == "direct":
+        return scope
+    subject_id = subject.get("subject_id")
+    if isinstance(subject_id, str):
+        candidates = [
+            candidate_scope
+            for touched_at, candidate_scope in touchpoints.get(subject_id, [])
+            if 0 <= (occurred_at - touched_at).total_seconds() <= window_seconds
+        ]
+        if candidates:
+            return candidates[-1]
+    return scope if scope.get("channel") == "direct" else None
+
+
+def _measurement_currency(measurement: dict[str, Any]) -> str | None:
+    currency = measurement.get("currency")
+    if currency is not None and not isinstance(currency, str):
+        raise OptimizationError("measurement.currency must be a string or null")
+    return currency
+
+
+def _apply_attribution_event(event: tuple[Any, ...], totals: dict[tuple[Any, ...], dict[str, Any]], model: str, window_days: int, touchpoints: dict[str, list[tuple[datetime, dict[str, Any]]]]) -> tuple[int, int, int]:
+    occurred_at, event_type, subject, scope, measurement, _event_ref = event
+    value = _decimal(measurement.get("value"), "measurement.value")
+    currency = _measurement_currency(measurement)
+    if event_type in {"refund", "cost"}:
+        target = _attribution_bucket(totals, scope, currency)
+        target["refunds" if event_type == "refund" else "costs"] += abs(value)
+        return 0, 0, 0
+    if event_type not in OUTCOME_TYPES:
+        return 0, 0, 0
+    identity_state = subject.get("identity_state")
+    uncertain = int(identity_state == "ambiguous")
+    selected_scope = _attributed_scope(occurred_at, subject, scope, model, window_days * 86400, touchpoints)
+    if selected_scope is None:
+        return 0, 1, uncertain
+    target = _attribution_bucket(totals, selected_scope, currency)
+    target["credited_outcomes"] += 1
+    target["credit"] += Decimal(1)
+    target["revenue"] += value if event_type == "revenue" else Decimal(0)
+    target["uncertain"] = target["uncertain"] or identity_state == "split"
+    return 1, 0, uncertain
+
+
+def _attribute_events(parsed: list[tuple[Any, ...]], model: str, window_days: int) -> tuple[dict[tuple[Any, ...], dict[str, Any]], int, int, int]:
+    touchpoints = _touchpoint_index(parsed)
+    totals: dict[tuple[Any, ...], dict[str, Any]] = {}
+    matched = unattributed = uncertain = 0
+    for event in parsed:
+        event_matched, event_unattributed, event_uncertain = _apply_attribution_event(event, totals, model, window_days, touchpoints)
+        matched += event_matched
+        unattributed += event_unattributed
+        uncertain += event_uncertain
+    return totals, matched, unattributed, uncertain
+
+
+def _attribution_aggregates(totals: dict[tuple[Any, ...], dict[str, Any]], source_coverage: str) -> list[dict[str, Any]]:
+    aggregates = []
+    for (campaign_id, channel, currency), values in sorted(
+        totals.items(), key=lambda item: tuple("" if value is None else value for value in item[0])
+    ):
+        uncertainty = "high" if values["uncertain"] or source_coverage == "unknown" else "medium" if source_coverage == "partial" else "low"
+        aggregates.append({
+            "campaign_id": campaign_id,
+            "channel": channel,
+            "credited_outcomes": values["credited_outcomes"],
+            "credit": _decimal_text(values["credit"]),
+            "revenue": _decimal_text(values["revenue"]),
+            "refunds": _decimal_text(values["refunds"]),
+            "costs": _decimal_text(values["costs"]),
+            "net_revenue": _decimal_text(values["revenue"] - values["refunds"]),
+            "currency": currency,
+            "uncertainty": uncertainty,
+        })
+    return aggregates
+
+
+def attribute(document: dict[str, Any], model: str, window_days: int, model_version: int, window_version: int, run_id: str, generated_at: str) -> dict[str, Any]:
+    """Build a deterministic aggregate attribution projection."""
+    events, snapshot, source_coverage, parsed = _attribution_input(document, model)
+    totals, matched, unattributed, uncertain = _attribute_events(parsed, model, window_days)
+    aggregates = _attribution_aggregates(totals, source_coverage)
+
+    identity_events = sorted(events, key=lambda event: (str(event.get("event_ref", "")), _canonical(event)))
+    identity = {"source_snapshot": snapshot, "model": model, "model_version": model_version, "window_days": window_days, "window_version": window_version, "events": identity_events}
+    return {
+        "schema": SCHEMA_ATTRIBUTION,
+        "projection_id": _digest("mkt-attribution-v1", identity),
+        "run_id": run_id,
+        "source_snapshot": snapshot,
+        "model": {"name": model, "version": model_version},
+        "window": {"days": window_days, "version": window_version},
+        "generated_at": generated_at,
+        "coverage": {"source": source_coverage, "matched_outcomes": matched, "unattributed_outcomes": unattributed, "identity_uncertain_outcomes": uncertain},
+        "causality": {"claim": "observational", "caveat": "Attribution assigns observational credit; it does not establish incremental or causal growth."},
+        "aggregates": aggregates,
+    }
+
+
+def _require_experiment_fields(document: dict[str, Any]) -> None:
+    required = ["experiment_id", "source_snapshot", "state", "hypothesis", "owner", "variants", "assignment", "metrics", "sample_policy", "window", "stopping_policy", "exclusions", "observations"]
+    missing = [field for field in required if field not in document]
+    if missing:
+        raise OptimizationError(f"experiment input missing: {', '.join(missing)}")
+
+
+def _validate_experiment_collections(document: dict[str, Any]) -> None:
+    variants = document["variants"]
+    observations = document["observations"]
+    if not isinstance(variants, list):
+        raise OptimizationError("experiment variants must be an array")
+    if len(variants) < 2:
+        raise OptimizationError("experiment requires at least two variants")
+    if not isinstance(observations, list):
+        raise OptimizationError("experiment requires at least two variants and aggregate observations")
+
+
+def _validate_experiment_registry(document: dict[str, Any]) -> None:
+    _validate_experiment_collections(document)
+    if document["state"] not in {"running", "analysis_ready", "decided"}:
+        raise OptimizationError("only running, analysis_ready, or decided experiments can be analyzed")
+    if not str(document["hypothesis"]).strip():
+        raise OptimizationError("experiment hypothesis and owner must be preregistered")
+    if not str(document["owner"]).strip():
+        raise OptimizationError("experiment hypothesis and owner must be preregistered")
+    if not str(document["stopping_policy"]).strip():
+        raise OptimizationError("experiment stopping_policy and exclusions must be preregistered")
+    if not isinstance(document["exclusions"], list):
+        raise OptimizationError("experiment stopping_policy and exclusions must be preregistered")
+
+
+def _experiment_contract(document: dict[str, Any]) -> tuple[list[str], dict[str, dict[str, Any]], str, dict[str, Any], dict[str, Any]]:
+    _require_experiment_fields(document)
+    _validate_experiment_registry(document)
+    variants = document["variants"]
+    observations = document["observations"]
+    control = document["assignment"].get("control_variant")
+    if control not in variants:
+        raise OptimizationError("control_variant must name a preregistered variant")
+    by_variant = {str(item.get("variant")): item for item in observations if isinstance(item, dict)}
+    if set(by_variant) != set(variants):
+        raise OptimizationError("observations must contain each preregistered variant exactly once")
+    return variants, by_variant, control, document["sample_policy"], document["window"]
+
+
+def _experiment_window(window: dict[str, Any], observed_at: str) -> bool:
+    starts_at = _timestamp(window["starts_at"], "window.starts_at")
+    ends_at = _timestamp(window["ends_at"], "window.ends_at")
+    analysis_time = _timestamp(observed_at, "observed_at")
+    elapsed_days = (min(analysis_time, ends_at) - starts_at).total_seconds() / 86400
+    return analysis_time < ends_at or elapsed_days < int(window["minimum_days"])
+
+
+def _experiment_row(variant: str, observation: dict[str, Any], minimum: int, registered_guardrails: set[str]) -> tuple[dict[str, Any], bool]:
+    sample = int(observation.get("sample", 0))
+    successes = int(observation.get("successes", 0))
+    if sample < 0 or successes < 0 or successes > sample:
+        raise OptimizationError("experiment sample and successes are invalid")
+    observed_guardrails = observation.get("guardrails", {})
+    if not isinstance(observed_guardrails, dict) or set(observed_guardrails) != registered_guardrails:
+        raise OptimizationError("observed guardrails must exactly match preregistered guardrail metrics")
+    row = {"variant": variant, "sample": sample, "successes": successes, "rate": successes / sample if sample else 0.0, "guardrails": observed_guardrails}
+    return row, sample < minimum
+
+
+def _experiment_rows(document: dict[str, Any], variants: list[str], by_variant: dict[str, dict[str, Any]], minimum: int) -> tuple[list[dict[str, Any]], bool, list[Any]]:
+    validity_flags = document.get("validity_flags", [])
+    if not isinstance(validity_flags, list):
+        raise OptimizationError("validity_flags must be an array")
+    registered_guardrails = set(document["metrics"].get("guardrails", []))
+    rows = []
+    insufficient = bool(validity_flags)
+    for variant in variants:
+        row, below_minimum = _experiment_row(variant, by_variant[variant], minimum, registered_guardrails)
+        rows.append(row)
+        insufficient = insufficient or below_minimum
+    return rows, insufficient, validity_flags
+
+
+def _score_experiment_row(row: dict[str, Any], control_row: dict[str, Any], threshold: float) -> tuple[bool, bool]:
+    pooled = (row["successes"] + control_row["successes"]) / (row["sample"] + control_row["sample"])
+    error = math.sqrt(pooled * (1 - pooled) * (1 / row["sample"] + 1 / control_row["sample"]))
+    z_score = (row["rate"] - control_row["rate"]) / error if error else 0.0
+    confidence = math.erf(abs(z_score) / math.sqrt(2))
+    row["lift"] = row["rate"] - control_row["rate"]
+    row["confidence"] = confidence
+    regressions = [name for name, value in row["guardrails"].items() if isinstance(value, dict) and value.get("regressed") is True]
+    row["guardrail_regressions"] = sorted(regressions)
+    return bool(regressions), row["lift"] > 0 and confidence >= threshold
+
+
+def _score_experiment(rows: list[dict[str, Any]], control: str, threshold: float, insufficient: bool) -> tuple[list[dict[str, Any]], bool]:
+    control_row = next(row for row in rows if row["variant"] == control)
+    candidates: list[dict[str, Any]] = []
+    guardrail_regression = False
+    if not insufficient:
+        for row in rows:
+            if row["variant"] == control:
+                continue
+            row_regression, candidate = _score_experiment_row(row, control_row, threshold)
+            guardrail_regression = guardrail_regression or row_regression
+            if candidate:
+                candidates.append(row)
+    return candidates, guardrail_regression
+
+
+def _experiment_decision(validity_flags: list[Any], insufficient: bool, contradictory: bool, guardrail_regression: bool, candidates: list[dict[str, Any]]) -> tuple[str, str, str | None]:
+    if validity_flags:
+        return "insufficient_evidence", "Novelty, seasonality, or another preregistered validity concern requires more evidence.", None
+    if insufficient:
+        return "insufficient_evidence", "Minimum sample, privacy threshold, or preregistered duration has not been met.", None
+    if contradictory:
+        return "contradictory", "Primary or supporting metrics conflict; owner review is required.", None
+    if guardrail_regression:
+        return "guardrail_regression", "A preregistered guardrail regressed; no winner may be adopted.", None
+    if candidates:
+        winner = max(candidates, key=lambda row: (row["lift"], row["variant"]))["variant"]
+        return "candidate_winner", "A treatment exceeded control at the preregistered confidence threshold.", winner
+    return "no_material_difference", "No treatment exceeded control at the preregistered confidence threshold.", None
+
+
+def analyze_experiment(document: dict[str, Any], run_id: str, observed_at: str) -> dict[str, Any]:
+    """Analyze preregistered aggregate binary outcomes without optional stopping."""
+    variants, by_variant, control, policy, window = _experiment_contract(document)
+    minimum = max(int(policy["minimum_per_variant"]), int(policy["privacy_minimum"]))
+    rows, insufficient, validity_flags = _experiment_rows(document, variants, by_variant, minimum)
+    peeking = _experiment_window(window, observed_at)
+    insufficient = insufficient or peeking
+    candidates, guardrail_regression = _score_experiment(rows, control, float(policy["confidence_threshold"]), insufficient)
+    status, reason, winner = _experiment_decision(validity_flags, insufficient, document.get("contradictory_metrics") is True, guardrail_regression, candidates)
+    identity = {"experiment_id": document["experiment_id"], "source_snapshot": document["source_snapshot"], "run_id": run_id, "rows": rows, "policy": policy, "window": window}
+    return {
+        "schema": SCHEMA_EXPERIMENT_ANALYSIS,
+        "analysis_id": _digest("mkt-experiment-analysis-v1", identity),
+        "experiment_id": document["experiment_id"],
+        "run_id": run_id,
+        "source_snapshot": document["source_snapshot"],
+        "primary_metric": document["metrics"]["primary"],
+        "status": status,
+        "reason": reason,
+        "winner": winner,
+        "observed_at": observed_at,
+        "variants": rows,
+        "peeking_detected": peeking,
+        "validity_flags": sorted(str(flag) for flag in validity_flags),
+        "causality": "experimental" if document["assignment"].get("method") in {"deterministic_hash", "provider_randomized"} else "observational",
+    }
+
+
+def _report_freshness(sources: Any, generated_at: str, stale_after_hours: int) -> tuple[list[dict[str, Any]], bool]:
+    if not isinstance(sources, list):
+        raise OptimizationError("report sources must be an array")
+    generated = _timestamp(generated_at, "generated_at")
+    freshness = []
+    stale = False
+    for source in sources:
+        observed = _timestamp(source.get("observed_at"), "sources.observed_at")
+        age_hours = max(0.0, (generated - observed).total_seconds() / 3600)
+        source_stale = age_hours > stale_after_hours
+        stale = stale or source_stale
+        freshness.append({"source": source.get("source"), "coverage": source.get("coverage", "unknown"), "observed_at": source.get("observed_at"), "age_hours": round(age_hours, 3), "status": "stale" if source_stale else "fresh"})
+    return freshness, stale
+
+
+def _report_funnel_row(aggregate: dict[str, Any], minimum_cohort: int) -> dict[str, Any] | None:
+    if int(aggregate["credited_outcomes"]) < minimum_cohort:
+        return None
+    revenue = Decimal(aggregate["revenue"])
+    refunds = Decimal(aggregate["refunds"])
+    costs = Decimal(aggregate["costs"])
+    net = revenue - refunds
+    roi = (net - costs) / costs if costs else None
+    return {**aggregate, "roi": _decimal_text(roi) if roi is not None else None, "payback": "not_computable" if costs == 0 else "covered" if net >= costs else "not_covered"}
+
+
+def _report_funnel(attribution: Any, minimum_cohort: int) -> tuple[list[dict[str, Any]], int]:
+    if attribution is not None and attribution.get("schema") != SCHEMA_ATTRIBUTION:
+        raise OptimizationError("report attribution input has an unsupported schema")
+    aggregates = []
+    suppressed = 0
+    if attribution:
+        for aggregate in attribution["aggregates"]:
+            row = _report_funnel_row(aggregate, minimum_cohort)
+            if row is None:
+                suppressed += 1
+                continue
+            aggregates.append(row)
+    return aggregates, suppressed
+
+
+def _empty_metric_groups() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "reach": [],
+        "engagement": [],
+        "account_growth": [],
+        "traffic": [],
+        "conversion": [],
+        "leads_and_stages": [],
+        "sales": [],
+        "revenue_refunds_costs": [],
+        "other": [],
+    }
+
+
+def _metric_category(metric_id: str) -> str:
+    category_markers = (
+        ("reach", ("impression", "reach")),
+        ("engagement", ("engagement", "click", "reply")),
+        ("account_growth", ("follower", "subscriber", "account_growth")),
+        ("traffic", ("visit", "traffic", "session")),
+        ("conversion", ("conversion",)),
+        ("leads_and_stages", ("lead", "stage")),
+        ("sales", ("sale",)),
+        ("revenue_refunds_costs", ("revenue", "refund", "cost", "roi", "payback")),
+    )
+    return next((name for name, markers in category_markers if any(marker in metric_id for marker in markers)), "other")
+
+
+def _report_metrics(metrics: Any, minimum_cohort: int) -> tuple[dict[str, list[dict[str, Any]]], int]:
+    metric_groups = _empty_metric_groups()
+    if not isinstance(metrics, list):
+        raise OptimizationError("report metrics must be an array")
+    suppressed = 0
+    for metric in metrics:
+        if not isinstance(metric, dict) or "metric_id" not in metric:
+            raise OptimizationError("each report metric must be an object with metric_id")
+        if {"subject_id", "event_ref", "contact", "email"}.intersection(metric):
+            raise OptimizationError("individual-level fields are forbidden in reports")
+        if int(metric.get("cohort_size", 0)) < minimum_cohort:
+            suppressed += 1
+            continue
+        metric_groups[_metric_category(str(metric["metric_id"]))].append(metric)
+    for group in metric_groups.values():
+        group.sort(key=lambda metric: (str(metric.get("metric_id")), str(metric.get("source_ref", ""))))
+    return metric_groups, suppressed
+
+
+def build_report(document: dict[str, Any], minimum_cohort: int, stale_after_hours: int, generated_at: str) -> dict[str, Any]:
+    """Render only aggregate, threshold-safe decision evidence."""
+    attribution = document.get("attribution")
+    experiments = document.get("experiments", [])
+    if not isinstance(experiments, list):
+        raise OptimizationError("experiments must be an array")
+    freshness, stale = _report_freshness(document.get("sources", []), generated_at, stale_after_hours)
+    aggregates, suppressed = _report_funnel(attribution, minimum_cohort)
+    metric_groups, metric_suppressed = _report_metrics(document.get("metrics", []), minimum_cohort)
+    suppressed += metric_suppressed
+    contradictions = document.get("contradictions", [])
+    if not isinstance(contradictions, list):
+        raise OptimizationError("contradictions must be an array")
+    caveats = ["Observational attribution does not establish causality.", "Suppressed cohorts are omitted rather than inferred.", "Missing or partial source coverage limits comparisons."]
+    if contradictions:
+        caveats.append("Contradictory metrics require owner review before a recommendation or decision.")
+
+    return {
+        "schema": SCHEMA_REPORT,
+        "report_id": _digest("mkt-optimization-report-v1", {"attribution": attribution, "experiments": experiments, "metrics": metric_groups, "freshness": freshness, "minimum_cohort": minimum_cohort, "contradictions": contradictions}),
+        "generated_at": generated_at,
+        "status": "stale" if stale else "current",
+        "privacy": {"minimum_cohort": minimum_cohort, "suppressed_aggregates": suppressed, "individual_records": False},
+        "freshness": freshness,
+        "funnel": aggregates,
+        "metrics": metric_groups,
+        "experiments": experiments,
+        "contradictions": contradictions,
+        "caveats": caveats,
+        "decision_outputs": [experiment for experiment in experiments if experiment.get("status") in {"candidate_winner", "guardrail_regression", "insufficient_evidence"}],
+    }
+
+
+def _recommendation_evidence(document: dict[str, Any]) -> dict[str, Any]:
+    evidence = document.get("evidence")
+    if not isinstance(evidence, dict):
+        raise OptimizationError("evidence is required")
+    required = ["refs", "source_snapshot", "sample_size", "causality", "target_metric", "observed_problem", "expected_impact"]
+    missing = [field for field in required if field not in evidence]
+    if missing:
+        raise OptimizationError(f"recommendation evidence missing: {', '.join(missing)}")
+    return evidence
+
+
+def _recommendation_status(document: dict[str, Any], evidence: dict[str, Any]) -> str:
+    evidence_blocked = document.get("evidence_status") in {"insufficient_evidence", "stale", "contradictory"}
+    evidence_blocked = evidence_blocked or evidence.get("freshness") == "stale" or evidence.get("contradictory") is True
+    if int(evidence["sample_size"]) < int(document.get("minimum_sample", 2)) or evidence_blocked:
+        return "insufficient_evidence"
+    return "awaiting_approval"
+
+
+def _recommendation_impact(evidence: dict[str, Any], retest_at: str, created_at: str) -> dict[str, Any]:
+    expected_impact = evidence["expected_impact"]
+    if not isinstance(expected_impact, dict) or float(expected_impact["minimum"]) > float(expected_impact["maximum"]):
+        raise OptimizationError("expected impact minimum cannot exceed maximum")
+    if _timestamp(retest_at, "retest_at") <= _timestamp(created_at, "created_at"):
+        raise OptimizationError("retest_at must be after created_at")
+    return expected_impact
+
+
+def recommend(document: dict[str, Any], owner: str, approval: str, rollback: str, retest_at: str, created_at: str) -> dict[str, Any]:
+    """Create an approval-bound recommendation, never a provider mutation."""
+    evidence = _recommendation_evidence(document)
+    status = _recommendation_status(document, evidence)
+    supersedes = sorted(set(document.get("supersedes", [])))
+    expected_impact = _recommendation_impact(evidence, retest_at, created_at)
+    identity = {"evidence": evidence, "owner": owner, "approval": approval, "rollback": rollback, "retest_at": retest_at, "supersedes": supersedes}
+    return {
+        "schema": SCHEMA_RECOMMENDATION,
+        "recommendation_id": _digest("growth-rec-v1", identity),
+        "status": status,
+        "observed_problem": evidence["observed_problem"],
+        "target_metric": evidence["target_metric"],
+        "evidence": {"refs": sorted(set(evidence["refs"])), "source_snapshot": evidence["source_snapshot"], "sample_size": int(evidence["sample_size"]), "privacy_safe": True, "causality": evidence["causality"]},
+        "expected_impact": expected_impact,
+        "confidence": evidence.get("confidence", "medium"),
+        "owner": owner,
+        "required_approval": approval,
+        "prohibited_mutations": PROHIBITED_MUTATIONS,
+        "rollback": rollback,
+        "retest_at": retest_at,
+        "created_at": created_at,
+        "supersedes": supersedes,
+    }
+
+
+def status(document: dict[str, Any], now: str, stale_after_hours: int) -> dict[str, Any]:
+    """Return freshness without mutating reports or decisions."""
+    observed_value = document.get("generated_at") or document.get("observed_at")
+    observed = _timestamp(observed_value, "generated_at/observed_at")
+    age_hours = max(0.0, (_timestamp(now, "now") - observed).total_seconds() / 3600)
+    return {"schema": "aidevops.marketing-optimization-status/v1", "status": "stale" if age_hours > stale_after_hours else "current", "age_hours": round(age_hours, 3), "stale_after_hours": stale_after_hours, "source_schema": document.get("schema")}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    attribute_parser = subparsers.add_parser("attribute", help="Build a versioned attribution projection")
+    attribute_parser.add_argument("--input", required=True)
+    attribute_parser.add_argument("--output")
+    attribute_parser.add_argument("--model", choices=("direct", "last_touch"), default="last_touch")
+    attribute_parser.add_argument("--window-days", type=int, default=30)
+    attribute_parser.add_argument("--model-version", type=int, default=1)
+    attribute_parser.add_argument("--window-version", type=int, default=1)
+    attribute_parser.add_argument("--run-id", required=True)
+    attribute_parser.add_argument("--generated-at", required=True)
+
+    experiment_parser = subparsers.add_parser("experiment", help="Analyze a preregistered aggregate experiment")
+    experiment_parser.add_argument("--input", required=True)
+    experiment_parser.add_argument("--output")
+    experiment_parser.add_argument("--run-id", required=True)
+    experiment_parser.add_argument("--observed-at", required=True)
+
+    report_parser = subparsers.add_parser("report", help="Build a freshness-aware aggregate report")
+    report_parser.add_argument("--input", required=True)
+    report_parser.add_argument("--output")
+    report_parser.add_argument("--minimum-cohort", type=int, default=10)
+    report_parser.add_argument("--stale-after-hours", type=int, default=48)
+    report_parser.add_argument("--generated-at", required=True)
+
+    recommend_parser = subparsers.add_parser("recommend", help="Create an approval-bound recommendation")
+    recommend_parser.add_argument("--input", required=True)
+    recommend_parser.add_argument("--output")
+    recommend_parser.add_argument("--owner", choices=("content", "marketing", "product", "sales", "seo", "campaign-owner", "report-owner"), required=True)
+    recommend_parser.add_argument("--approval", required=True)
+    recommend_parser.add_argument("--rollback", required=True)
+    recommend_parser.add_argument("--retest-at", required=True)
+    recommend_parser.add_argument("--created-at", required=True)
+
+    status_parser = subparsers.add_parser("status", help="Check projection or report freshness")
+    status_parser.add_argument("--input", required=True)
+    status_parser.add_argument("--output")
+    status_parser.add_argument("--now", required=True)
+    status_parser.add_argument("--stale-after-hours", type=int, default=48)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        document = _load(args.input)
+        if args.command == "attribute":
+            result = attribute(document, args.model, args.window_days, args.model_version, args.window_version, args.run_id, args.generated_at)
+        elif args.command == "experiment":
+            result = analyze_experiment(document, args.run_id, args.observed_at)
+        elif args.command == "report":
+            result = build_report(document, args.minimum_cohort, args.stale_after_hours, args.generated_at)
+        elif args.command == "recommend":
+            result = recommend(document, args.owner, args.approval, args.rollback, args.retest_at, args.created_at)
+        else:
+            result = status(document, args.now, args.stale_after_hours)
+        _write(result, args.output)
+    except (OSError, json.JSONDecodeError, OptimizationError, KeyError, TypeError, ValueError) as exc:
+        print(json.dumps({"schema": "aidevops.marketing-optimization-error/v1", "error": str(exc)}))
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/tests/fixtures/marketing-optimization/experiment.json
+++ b/.agents/scripts/tests/fixtures/marketing-optimization/experiment.json
@@ -1,0 +1,18 @@
+{
+  "experiment_id": "creative-headline-1",
+  "source_snapshot": "fixture:experiment-2026-08-01",
+  "state": "analysis_ready",
+  "hypothesis": "The treatment headline improves conversion without increasing unsubscribes.",
+  "owner": "content",
+  "variants": ["control", "treatment"],
+  "assignment": {"unit": "anonymous_subject", "method": "deterministic_hash", "control_variant": "control"},
+  "metrics": {"primary": "marketing.conversions.total", "guardrails": ["marketing.unsubscribe.total"]},
+  "sample_policy": {"minimum_per_variant": 250, "privacy_minimum": 10, "confidence_threshold": 0.95},
+  "window": {"starts_at": "2026-07-01T00:00:00Z", "ends_at": "2026-07-15T00:00:00Z", "minimum_days": 7},
+  "stopping_policy": "Analyze after the fixed window and minimum sample are complete.",
+  "exclusions": ["invalid automated traffic"],
+  "observations": [
+    {"variant": "control", "sample": 1000, "successes": 100, "guardrails": {"marketing.unsubscribe.total": {"value": 5, "regressed": false}}},
+    {"variant": "treatment", "sample": 1000, "successes": 160, "guardrails": {"marketing.unsubscribe.total": {"value": 6, "regressed": false}}}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/marketing-optimization/journeys.json
+++ b/.agents/scripts/tests/fixtures/marketing-optimization/journeys.json
@@ -1,0 +1,48 @@
+{
+  "source_snapshot": "fixture:snapshot-2026-08-01",
+  "coverage": "complete",
+  "events": [
+    {
+      "event_ref": "touch-a",
+      "event": {"type": "visit", "occurred_at": "2026-07-01T09:00:00Z"},
+      "subject": {"subject_id": "mkt-subj-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "identity_state": "isolated"},
+      "scope": {"campaign_id": "awareness", "channel": "social"},
+      "measurement": {"value": 1, "currency": null}
+    },
+    {
+      "event_ref": "touch-b",
+      "event": {"type": "visit", "occurred_at": "2026-07-10T09:00:00Z"},
+      "subject": {"subject_id": "mkt-subj-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "identity_state": "isolated"},
+      "scope": {"campaign_id": "conversion", "channel": "search"},
+      "measurement": {"value": 1, "currency": null}
+    },
+    {
+      "event_ref": "revenue-a",
+      "event": {"type": "revenue", "occurred_at": "2026-07-20T09:00:00Z"},
+      "subject": {"subject_id": "mkt-subj-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "identity_state": "isolated"},
+      "scope": {"campaign_id": "checkout", "channel": "direct"},
+      "measurement": {"value": "120.00", "currency": "GBP"}
+    },
+    {
+      "event_ref": "refund-a",
+      "event": {"type": "refund", "occurred_at": "2026-07-22T09:00:00Z"},
+      "subject": {"subject_id": "mkt-subj-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "identity_state": "isolated"},
+      "scope": {"campaign_id": "conversion", "channel": "search"},
+      "measurement": {"value": "20.00", "currency": "GBP"}
+    },
+    {
+      "event_ref": "cost-a",
+      "event": {"type": "cost", "occurred_at": "2026-07-22T09:00:00Z"},
+      "subject": {"subject_id": null, "identity_state": "not_applicable"},
+      "scope": {"campaign_id": "conversion", "channel": "search"},
+      "measurement": {"value": "30.00", "currency": "GBP"}
+    },
+    {
+      "event_ref": "unknown-conversion",
+      "event": {"type": "conversion", "occurred_at": "2026-07-23T09:00:00Z"},
+      "subject": {"subject_id": null, "identity_state": "ambiguous"},
+      "scope": {"campaign_id": null, "channel": null},
+      "measurement": {"value": 1, "currency": null}
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/marketing-optimization/sparse-experiment.json
+++ b/.agents/scripts/tests/fixtures/marketing-optimization/sparse-experiment.json
@@ -1,0 +1,18 @@
+{
+  "experiment_id": "sparse-cohort-1",
+  "source_snapshot": "fixture:sparse-2026-08-01",
+  "state": "analysis_ready",
+  "hypothesis": "The treatment increases qualified leads.",
+  "owner": "marketing",
+  "variants": ["control", "treatment"],
+  "assignment": {"unit": "aggregate_cohort", "method": "preassigned_cohort", "control_variant": "control"},
+  "metrics": {"primary": "marketing.leads.qualified", "guardrails": []},
+  "sample_policy": {"minimum_per_variant": 250, "privacy_minimum": 10, "confidence_threshold": 0.95},
+  "window": {"starts_at": "2026-07-01T00:00:00Z", "ends_at": "2026-07-15T00:00:00Z", "minimum_days": 7},
+  "stopping_policy": "Analyze after the fixed window and minimum sample are complete.",
+  "exclusions": [],
+  "observations": [
+    {"variant": "control", "sample": 4, "successes": 1, "guardrails": {}},
+    {"variant": "treatment", "sample": 4, "successes": 3, "guardrails": {}}
+  ]
+}

--- a/.agents/scripts/tests/test-marketing-optimization.py
+++ b/.agents/scripts/tests/test-marketing-optimization.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic attribution, experiment, privacy, and recommendation contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+AGENTS = SCRIPTS.parent
+HELPER = SCRIPTS / "marketing-optimization-helper.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "marketing-optimization"
+
+SPEC = importlib.util.spec_from_file_location("marketing_optimization_helper", HELPER)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load marketing optimization helper")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MarketingOptimizationTests(unittest.TestCase):
+    """Use only synthetic aggregate and pseudonymous evidence."""
+
+    @staticmethod
+    def fixture(name: str) -> dict[str, object]:
+        return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+    def attribution(self, **overrides: object) -> dict[str, object]:
+        arguments = {
+            "document": self.fixture("journeys.json"),
+            "model": "last_touch",
+            "window_days": 30,
+            "model_version": 1,
+            "window_version": 1,
+            "run_id": "fixture-run",
+            "generated_at": "2026-08-01T00:00:00Z",
+        }
+        arguments.update(overrides)
+        return MODULE.attribute(**arguments)
+
+    def test_last_touch_is_deterministic_and_adjusts_refunds_and_costs(self) -> None:
+        first = self.attribution()
+        second = self.attribution(run_id="different-run")
+        self.assertEqual(first["projection_id"], second["projection_id"])
+        reversed_events = self.fixture("journeys.json")
+        reversed_events["events"].reverse()
+        replay = self.attribution(document=reversed_events)
+        self.assertEqual(first["projection_id"], replay["projection_id"])
+        self.assertEqual(1, first["coverage"]["matched_outcomes"])
+        self.assertEqual(1, first["coverage"]["identity_uncertain_outcomes"])
+        search = next(row for row in first["aggregates"] if row["campaign_id"] == "conversion")
+        self.assertEqual("120", search["revenue"])
+        self.assertEqual("20", search["refunds"])
+        self.assertEqual("30", search["costs"])
+        self.assertEqual("100", search["net_revenue"])
+        self.assertEqual("observational", first["causality"]["claim"])
+
+    def test_window_and_model_version_produce_auditable_new_projection(self) -> None:
+        original = self.attribution()
+        changed = self.attribution(model_version=2)
+        expired = self.attribution(window_days=5)
+        self.assertNotEqual(original["projection_id"], changed["projection_id"])
+        self.assertEqual(1, expired["coverage"]["matched_outcomes"])
+        self.assertGreater(expired["coverage"]["unattributed_outcomes"], 0)
+        checkout = next(row for row in expired["aggregates"] if row["campaign_id"] == "checkout")
+        self.assertEqual("120", checkout["revenue"])
+
+    def test_no_data_and_direct_model_are_explicit(self) -> None:
+        empty = {"source_snapshot": "fixture:empty", "coverage": "unknown", "events": []}
+        projection = self.attribution(document=empty, model="direct")
+        self.assertEqual([], projection["aggregates"])
+        self.assertEqual("unknown", projection["coverage"]["source"])
+        direct = self.attribution(model="direct")
+        self.assertEqual(1, direct["coverage"]["matched_outcomes"])
+        self.assertEqual(1, direct["coverage"]["identity_uncertain_outcomes"])
+
+    def test_experiment_candidate_winner_requires_preregistered_thresholds(self) -> None:
+        result = MODULE.analyze_experiment(
+            self.fixture("experiment.json"),
+            "analysis-run",
+            "2026-07-16T00:00:00Z",
+        )
+        self.assertEqual("candidate_winner", result["status"])
+        self.assertEqual("treatment", result["winner"])
+        self.assertFalse(result["peeking_detected"])
+        self.assertEqual("experimental", result["causality"])
+
+    def test_sparse_and_peeked_experiments_are_insufficient(self) -> None:
+        sparse = MODULE.analyze_experiment(
+            self.fixture("sparse-experiment.json"),
+            "analysis-run",
+            "2026-07-16T00:00:00Z",
+        )
+        self.assertEqual("insufficient_evidence", sparse["status"])
+        peeked_input = self.fixture("experiment.json")
+        peeked = MODULE.analyze_experiment(peeked_input, "peek-run", "2026-07-02T00:00:00Z")
+        self.assertEqual("insufficient_evidence", peeked["status"])
+        self.assertTrue(peeked["peeking_detected"])
+
+    def test_guardrail_regression_blocks_winner(self) -> None:
+        experiment = self.fixture("experiment.json")
+        experiment["observations"][1]["guardrails"]["marketing.unsubscribe.total"]["regressed"] = True
+        result = MODULE.analyze_experiment(experiment, "guardrail-run", "2026-07-16T00:00:00Z")
+        self.assertEqual("guardrail_regression", result["status"])
+        self.assertIsNone(result["winner"])
+
+    def test_novelty_seasonality_and_contradictions_prevent_a_winner(self) -> None:
+        validity_input = self.fixture("experiment.json")
+        validity_input["validity_flags"] = ["novelty", "seasonality"]
+        validity = MODULE.analyze_experiment(validity_input, "validity-run", "2026-07-16T00:00:00Z")
+        self.assertEqual("insufficient_evidence", validity["status"])
+        contradictory_input = self.fixture("experiment.json")
+        contradictory_input["contradictory_metrics"] = True
+        contradictory = MODULE.analyze_experiment(contradictory_input, "contradictory-run", "2026-07-16T00:00:00Z")
+        self.assertEqual("contradictory", contradictory["status"])
+
+    def test_report_suppresses_sparse_cohorts_and_marks_stale_sources(self) -> None:
+        projection = self.attribution()
+        report = MODULE.build_report(
+            {
+                "attribution": projection,
+                "experiments": [],
+                "sources": [{"source": "crm", "coverage": "partial", "observed_at": "2026-07-01T00:00:00Z"}],
+                "metrics": [
+                    {"metric_id": "marketing.impressions.total", "value": 10000, "unit": "impression", "cohort_size": 10000, "source_ref": "fixture:analytics"},
+                    {"metric_id": "marketing.leads.qualified", "value": 3, "unit": "lead", "cohort_size": 3, "source_ref": "fixture:crm"},
+                ],
+                "contradictions": ["Platform conversions exceed verified CRM conversions."],
+            },
+            minimum_cohort=10,
+            stale_after_hours=48,
+            generated_at="2026-08-01T00:00:00Z",
+        )
+        self.assertEqual("stale", report["status"])
+        self.assertEqual([], report["funnel"])
+        self.assertGreater(report["privacy"]["suppressed_aggregates"], 0)
+        self.assertFalse(report["privacy"]["individual_records"])
+        self.assertEqual("marketing.impressions.total", report["metrics"]["reach"][0]["metric_id"])
+        self.assertEqual([], report["metrics"]["leads_and_stages"])
+        self.assertTrue(report["contradictions"])
+
+    def test_recommendation_is_idempotent_approval_bound_and_superseding(self) -> None:
+        evidence = {
+            "refs": ["mkt-experiment-analysis-v1:fixture"],
+            "source_snapshot": "fixture:experiment-2026-08-01",
+            "sample_size": 2000,
+            "causality": "experimental",
+            "target_metric": "marketing.conversions.total",
+            "observed_problem": "Control conversion is lower than the tested treatment.",
+            "expected_impact": {"minimum": 0.03, "maximum": 0.08, "unit": "relative_fraction"},
+            "confidence": "high",
+        }
+        document = {"evidence": evidence, "minimum_sample": 250, "supersedes": []}
+        first = MODULE.recommend(document, "content", "campaign owner approval", "Restore the control creative.", "2026-09-01T00:00:00Z", "2026-08-01T00:00:00Z")
+        replay = MODULE.recommend(document, "content", "campaign owner approval", "Restore the control creative.", "2026-09-01T00:00:00Z", "2026-08-02T00:00:00Z")
+        self.assertEqual(first["recommendation_id"], replay["recommendation_id"])
+        self.assertEqual("awaiting_approval", first["status"])
+        self.assertIn("spend", first["prohibited_mutations"])
+        successor = MODULE.recommend({**document, "supersedes": [first["recommendation_id"]]}, "content", "campaign owner approval", "Restore the control creative.", "2026-09-01T00:00:00Z", "2026-08-03T00:00:00Z")
+        self.assertEqual([first["recommendation_id"]], successor["supersedes"])
+        self.assertNotEqual(first["recommendation_id"], successor["recommendation_id"])
+
+    def test_atomic_output_preserves_complete_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "published" / "report.json"
+            MODULE._write(self.attribution(), str(output))
+            self.assertEqual("aidevops.marketing-attribution/v1", json.loads(output.read_text(encoding="utf-8"))["schema"])
+            older_different = self.attribution(model_version=2, generated_at="2026-07-31T00:00:00Z")
+            with self.assertRaises(MODULE.OptimizationError):
+                MODULE._write(older_different, str(output))
+
+    def test_contract_schemas_are_valid_json(self) -> None:
+        for name in (
+            "marketing-attribution.schema.json",
+            "marketing-experiment.schema.json",
+            "growth-recommendation.schema.json",
+        ):
+            schema = json.loads((AGENTS / "schemas" / name).read_text(encoding="utf-8"))
+            self.assertEqual("https://json-schema.org/draft/2020-12/schema", schema["$schema"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add versioned privacy-safe attribution, preregistered experiment analysis, aggregate freshness-aware funnel reporting, and approval-bound growth recommendations. Enforce cohort suppression, immutable source history, model/window replay, guardrails, sample duration, stale/contradictory evidence stops, atomic publication, and recommendation supersession.

## Files Changed

.agents/aidevops/feedback/mining-promotion.md, .agents/aidevops/performance.md, .agents/content/optimization.md, .agents/reports/marketing.md, .agents/schemas/growth-recommendation.schema.json, .agents/schemas/marketing-attribution.schema.json, .agents/schemas/marketing-experiment.schema.json, .agents/scripts/marketing-optimization-helper.py, .agents/scripts/tests/fixtures/marketing-optimization/experiment.json, .agents/scripts/tests/fixtures/marketing-optimization/journeys.json, .agents/scripts/tests/fixtures/marketing-optimization/sparse-experiment.json, .agents/scripts/tests/test-marketing-optimization.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-marketing-optimization.py (11 passed); python3 .agents/scripts/tests/test-marketing-performance-ingest.py (19 passed); JSON schema parse and Python compile passed; .agents/scripts/linters-local.sh --changed passed

Resolves #30147


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.263 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 42m and 167,132 tokens on this as a headless worker.