### PR TITLE
t18239: feat: add campaign growth orchestration

### DIFF
--- a/.agents/aidevops/campaigns-plane.md
+++ b/.agents/aidevops/campaigns-plane.md
@@ -231,6 +231,30 @@ Channel specs: `.agents/configs/campaign-channel-specs.json`.
 **Phase 6 CLI (t2969 — shipped):** `campaign launch`, `campaign promote`,
 `campaign feedback` — cross-plane promotion of results and learnings.
 
+### Campaign growth orchestration
+
+`aidevops campaign grow` is the progressive entry point for a complete growth
+campaign. It coordinates evidence from research, creative production/review,
+approved distribution receipts, performance, and reporting without becoming a
+publisher, provider client, or analytics engine.
+
+```bash
+aidevops campaign grow plan --intake intake.json
+aidevops campaign grow start <campaign-id> --repo <repo> --evidence owner-evidence.json
+aidevops campaign grow status <campaign-id> --repo <repo>
+aidevops campaign grow resume <campaign-id> --repo <repo> --evidence owner-evidence.json
+```
+
+`plan` is non-mutating and reports channels, capabilities, artifacts, approvals,
+and degraded fallbacks. `start` and `resume` write only
+`active/<id>/orchestration/campaign-growth-state.json`; each owner remains
+authoritative for its own research, assets, queue receipts, performance records,
+and recommendations. A distribution stage must carry explicit, current owner
+approval. Unknown provider outcomes, partial metrics, missing evidence, expired
+approval, suppression, or insufficient experiment evidence remain truthful stage
+states and never become success. See `workflows/campaign-growth.md` for evidence
+shape, recovery, and specialist routing.
+
 ### Campaign research dossier contract (schema v1)
 
 `campaign research <id> --source <evidence.json>` produces

--- a/.agents/configs/capability-registry.json
+++ b/.agents/configs/capability-registry.json
@@ -117,6 +117,17 @@
       "probes": {"deployed": {"path": "scripts/_knowledge_social_meta_outbound_provider.py"}, "configured": {"live": "requires selected official provider transport"}, "authenticated": {"live": "requires selected product token"}, "authorized": {"live": "requires exact identity and publish permission check"}, "reachable": {"live": "requires official provider health request"}, "usable": {"live": "requires provider-health action status usable"}}
     },
     {
+      "name": "campaign-growth-orchestration",
+      "aliases": ["campaign-grow", "growth-campaign"],
+      "owner": "Campaigns Plane",
+      "description": "Evidence-backed cross-owner campaign growth planning, state, and recovery without provider mutation",
+      "runtimes": ["opencode", "claude-code"],
+      "entry_points": ["workflows/campaign-growth.md", "scripts/campaign-growth-helper.py"],
+      "fallback": "evidence-only-manual-handoff",
+      "required": ["deployed", "runtime_compatible", "tool_visible"],
+      "probes": {"deployed": {"path": "scripts/campaign-growth-helper.py"}, "tool_visible": {"tool": "python3"}}
+    },
+    {
       "name": "vault-operations",
       "aliases": ["vault", "protected-data", "encrypted-memory"],
       "owner": "Vault",

--- a/.agents/content.md
+++ b/.agents/content.md
@@ -139,6 +139,11 @@ job first: `campaign-helper.sh production create <id> --channel <channel>`. The
 manifest remains `brief_ready` until a production owner records verified output;
 fan-out prompt preparation remains `prompts_ready`, never generated or published.
 
+For an end-to-end cross-owner campaign lifecycle, use
+`aidevops campaign grow plan --intake <file>` first, then attach the content
+owner's reviewed evidence to the growth checkpoint. The campaign growth workflow
+coordinates state and recovery; it does not bypass creative or publishing approval.
+
 ```bash
 content-fanout-helper.sh template default   # Brief template
 content-fanout-helper.sh plan ~/brief.md    # Generate fan-out plan

--- a/.agents/scripts/campaign-growth-helper.py
+++ b/.agents/scripts/campaign-growth-helper.py
@@ -11,150 +11,20 @@ queueing, performance ingestion, and reporting stay with their existing owners.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from campaign_growth_contract import STAGES, GrowthError, build_state, campaign_dir, evidence, intake, read_json
 
 
-VERSION = 1
-STAGES = ("intake", "research", "production", "review", "distribution", "performance", "report")
-TERMINAL = {"succeeded", "partial", "failed", "unknown", "blocked", "review_required"}
 STATE_FILE = "campaign-growth-state.json"
 
 
-class GrowthError(ValueError):
-    """Raised when orchestration inputs or checkpoints are unsafe."""
-
-
-def _read_json(path: Path, label: str) -> dict[str, Any]:
-    if path.is_symlink() or not path.is_file():
-        raise GrowthError(f"{label} is unavailable")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise GrowthError(f"{label} must be valid UTF-8 JSON") from exc
-    if not isinstance(value, dict):
-        raise GrowthError(f"{label} must be a JSON object")
-    return value
-
-
-def _digest(value: Any) -> str:
-    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
-
-
-def _campaign_dir(repo: str, campaign_id: str) -> Path:
-    if not campaign_id or "/" in campaign_id or ".." in campaign_id:
-        raise GrowthError("campaign_id must be a bounded campaign alias")
-    root = Path(repo).expanduser().absolute()
-    campaign = root / "_campaigns" / "active" / campaign_id
-    if any(path.is_symlink() for path in (root, root / "_campaigns", root / "_campaigns" / "active", campaign)):
-        raise GrowthError("campaign path must not contain symlinks")
-    if not campaign.is_dir():
-        raise GrowthError("active campaign is unavailable")
-    return campaign.resolve()
-
-
-def _intake(path: Path) -> dict[str, Any]:
-    value = _read_json(path, "campaign intake")
-    required = ("brand", "product", "offer", "objectives", "channels", "approvals")
-    if value.get("schema_version") != 1 or any(key not in value for key in required):
-        raise GrowthError("campaign intake does not satisfy the schema-v1 orchestration minimum")
-    return value
-
-
-def _evidence(path: Path | None, campaign: Path | None) -> dict[str, Any]:
-    default = campaign / "orchestration" / "evidence.json" if campaign else None
-    source = path or default
-    if source is None or not source.exists():
-        return {"version": VERSION, "stages": {}}
-    value = _read_json(source, "campaign growth evidence")
-    if value.get("version") != VERSION or not isinstance(value.get("stages", {}), dict):
-        raise GrowthError("campaign growth evidence must use version 1 and contain stages")
-    return value
-
-
-def _stage(status: str, evidence: list[str], operation_ids: list[str] | None = None, reason: str | None = None) -> dict[str, Any]:
-    value: dict[str, Any] = {"status": status, "evidence": evidence}
-    if operation_ids:
-        value["operation_ids"] = operation_ids
-    if reason:
-        value["reason"] = reason
-    return value
-
-
-def _owner_stage(source: dict[str, Any], stage: str) -> dict[str, Any] | None:
-    candidate = source.get("stages", {}).get(stage)
-    if not isinstance(candidate, dict):
-        return None
-    status = candidate.get("status")
-    evidence = candidate.get("evidence")
-    if status not in TERMINAL or not isinstance(evidence, list) or not all(isinstance(item, str) and item for item in evidence):
-        raise GrowthError(f"{stage} evidence must have a truthful status and non-empty evidence references")
-    operation_ids = candidate.get("operation_ids", [])
-    if not isinstance(operation_ids, list) or not all(isinstance(item, str) and item for item in operation_ids):
-        raise GrowthError(f"{stage} operation_ids must be strings")
-    return _stage(status, evidence, operation_ids, candidate.get("reason"))
-
-
-def _build_state(campaign_id: str, intake: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
-    stages: dict[str, dict[str, Any]] = {
-        "intake": _stage("succeeded", ["intake.json"]),
-    }
-    prior_ok = True
-    approvals = intake.get("approvals", {})
-    for name in STAGES[1:]:
-        if not prior_ok:
-            stages[name] = _stage("not_started", [], reason="an earlier owner stage is incomplete")
-            continue
-        supplied = _owner_stage(source, name)
-        if supplied is None:
-            if name in {"review", "distribution"}:
-                stages[name] = _stage("review_required", [], reason="explicit approval and owner evidence are required")
-            else:
-                stages[name] = _stage("blocked", [], reason=f"{name} owner evidence is unavailable")
-            prior_ok = False
-            continue
-        if name == "review" and (approvals.get("claims") != "approved" or approvals.get("creative") != "approved"):
-            stages[name] = _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "claims or creative approval is absent or expired")
-            prior_ok = False
-            continue
-        if name == "distribution" and source.get("stages", {}).get(name, {}).get("approval") != "approved":
-            stages[name] = _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "distribution approval is absent or expired")
-            prior_ok = False
-            continue
-        stages[name] = supplied
-        prior_ok = supplied["status"] == "succeeded"
-    statuses = [entry["status"] for entry in stages.values()]
-    if all(status == "succeeded" for status in statuses):
-        overall = "succeeded"
-    elif "unknown" in statuses:
-        overall = "unknown"
-    elif "review_required" in statuses:
-        overall = "review_required"
-    elif "failed" in statuses:
-        overall = "failed"
-    elif "partial" in statuses:
-        overall = "partial"
-    else:
-        overall = "blocked"
-    operations = sorted({operation for stage in stages.values() for operation in stage.get("operation_ids", [])})
-    return {
-        "schema_version": VERSION,
-        "campaign_id": campaign_id,
-        "status": overall,
-        "stages": stages,
-        "operation_ids": operations,
-        "evidence_hash": _digest(source),
-    }
-
-
 def _capabilities(script_dir: Path) -> list[dict[str, str]]:
-    registry = _read_json(script_dir.parent / "configs" / "capability-registry.json", "capability registry")
+    registry = read_json(script_dir.parent / "configs" / "capability-registry.json", "capability registry")
     names = {entry.get("name"): entry for entry in registry.get("capabilities", []) if isinstance(entry, dict)}
     required = ("campaign-research-dossiers", "social-provider-readiness", "approval-bound-social-publishing")
     result: list[dict[str, str]] = []
@@ -165,16 +35,16 @@ def _capabilities(script_dir: Path) -> list[dict[str, str]]:
 
 
 def _plan(arguments: argparse.Namespace) -> int:
-    intake = _intake(Path(arguments.intake).expanduser().absolute())
+    campaign_intake = intake(Path(arguments.intake).expanduser().absolute())
     plan = {
         "schema": "aidevops.campaign-growth-plan/v1",
         "dry_run": True,
         "campaign": {
-            "brand": intake["brand"].get("name"),
-            "product": intake["product"].get("name"),
-            "offer": intake["offer"].get("summary"),
-            "channels": intake["channels"],
-            "objectives": intake["objectives"],
+            "brand": campaign_intake["brand"].get("name"),
+            "product": campaign_intake["product"].get("name"),
+            "offer": campaign_intake["offer"].get("summary"),
+            "channels": campaign_intake["channels"],
+            "objectives": campaign_intake["objectives"],
         },
         "stages": list(STAGES),
         "capabilities": _capabilities(Path(__file__).resolve().parent),
@@ -215,14 +85,14 @@ def _write_state(path: Path, state: dict[str, Any], prior: dict[str, Any] | None
 
 
 def _load_state(path: Path) -> dict[str, Any] | None:
-    return _read_json(path, "campaign checkpoint") if path.exists() else None
+    return read_json(path, "campaign checkpoint") if path.exists() else None
 
 
 def _status(arguments: argparse.Namespace, write: bool) -> int:
-    campaign = _campaign_dir(arguments.repo, arguments.campaign_id)
-    intake = _intake(campaign / "intake.json")
-    source = _evidence(Path(arguments.evidence).expanduser().absolute() if arguments.evidence else None, campaign)
-    state = _build_state(arguments.campaign_id, intake, source)
+    campaign = campaign_dir(arguments.repo, arguments.campaign_id)
+    campaign_intake = intake(campaign / "intake.json")
+    source = evidence(Path(arguments.evidence).expanduser().absolute() if arguments.evidence else None, campaign)
+    state = build_state(arguments.campaign_id, campaign_intake, source)
     path = _state_path(campaign)
     if write:
         state = _write_state(path, state, _load_state(path))

--- a/.agents/scripts/campaign-growth-helper.py
+++ b/.agents/scripts/campaign-growth-helper.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Coordinate evidence-backed campaign growth stages without provider writes.
+
+This helper is deliberately an orchestration boundary.  It reads owner evidence
+and writes only an atomic campaign checkpoint; research, production, outbound
+queueing, performance ingestion, and reporting stay with their existing owners.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+VERSION = 1
+STAGES = ("intake", "research", "production", "review", "distribution", "performance", "report")
+TERMINAL = {"succeeded", "partial", "failed", "unknown", "blocked", "review_required"}
+STATE_FILE = "campaign-growth-state.json"
+
+
+class GrowthError(ValueError):
+    """Raised when orchestration inputs or checkpoints are unsafe."""
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise GrowthError(f"{label} is unavailable")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GrowthError(f"{label} must be valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise GrowthError(f"{label} must be a JSON object")
+    return value
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _campaign_dir(repo: str, campaign_id: str) -> Path:
+    if not campaign_id or "/" in campaign_id or ".." in campaign_id:
+        raise GrowthError("campaign_id must be a bounded campaign alias")
+    root = Path(repo).expanduser().absolute()
+    campaign = root / "_campaigns" / "active" / campaign_id
+    if any(path.is_symlink() for path in (root, root / "_campaigns", root / "_campaigns" / "active", campaign)):
+        raise GrowthError("campaign path must not contain symlinks")
+    if not campaign.is_dir():
+        raise GrowthError("active campaign is unavailable")
+    return campaign.resolve()
+
+
+def _intake(path: Path) -> dict[str, Any]:
+    value = _read_json(path, "campaign intake")
+    required = ("brand", "product", "offer", "objectives", "channels", "approvals")
+    if value.get("schema_version") != 1 or any(key not in value for key in required):
+        raise GrowthError("campaign intake does not satisfy the schema-v1 orchestration minimum")
+    return value
+
+
+def _evidence(path: Path | None, campaign: Path | None) -> dict[str, Any]:
+    default = campaign / "orchestration" / "evidence.json" if campaign else None
+    source = path or default
+    if source is None or not source.exists():
+        return {"version": VERSION, "stages": {}}
+    value = _read_json(source, "campaign growth evidence")
+    if value.get("version") != VERSION or not isinstance(value.get("stages", {}), dict):
+        raise GrowthError("campaign growth evidence must use version 1 and contain stages")
+    return value
+
+
+def _stage(status: str, evidence: list[str], operation_ids: list[str] | None = None, reason: str | None = None) -> dict[str, Any]:
+    value: dict[str, Any] = {"status": status, "evidence": evidence}
+    if operation_ids:
+        value["operation_ids"] = operation_ids
+    if reason:
+        value["reason"] = reason
+    return value
+
+
+def _owner_stage(source: dict[str, Any], stage: str) -> dict[str, Any] | None:
+    candidate = source.get("stages", {}).get(stage)
+    if not isinstance(candidate, dict):
+        return None
+    status = candidate.get("status")
+    evidence = candidate.get("evidence")
+    if status not in TERMINAL or not isinstance(evidence, list) or not all(isinstance(item, str) and item for item in evidence):
+        raise GrowthError(f"{stage} evidence must have a truthful status and non-empty evidence references")
+    operation_ids = candidate.get("operation_ids", [])
+    if not isinstance(operation_ids, list) or not all(isinstance(item, str) and item for item in operation_ids):
+        raise GrowthError(f"{stage} operation_ids must be strings")
+    return _stage(status, evidence, operation_ids, candidate.get("reason"))
+
+
+def _build_state(campaign_id: str, intake: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    stages: dict[str, dict[str, Any]] = {
+        "intake": _stage("succeeded", ["intake.json"]),
+    }
+    prior_ok = True
+    approvals = intake.get("approvals", {})
+    for name in STAGES[1:]:
+        if not prior_ok:
+            stages[name] = _stage("not_started", [], reason="an earlier owner stage is incomplete")
+            continue
+        supplied = _owner_stage(source, name)
+        if supplied is None:
+            if name in {"review", "distribution"}:
+                stages[name] = _stage("review_required", [], reason="explicit approval and owner evidence are required")
+            else:
+                stages[name] = _stage("blocked", [], reason=f"{name} owner evidence is unavailable")
+            prior_ok = False
+            continue
+        if name == "review" and (approvals.get("claims") != "approved" or approvals.get("creative") != "approved"):
+            stages[name] = _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "claims or creative approval is absent or expired")
+            prior_ok = False
+            continue
+        if name == "distribution" and source.get("stages", {}).get(name, {}).get("approval") != "approved":
+            stages[name] = _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "distribution approval is absent or expired")
+            prior_ok = False
+            continue
+        stages[name] = supplied
+        prior_ok = supplied["status"] == "succeeded"
+    statuses = [entry["status"] for entry in stages.values()]
+    if all(status == "succeeded" for status in statuses):
+        overall = "succeeded"
+    elif "unknown" in statuses:
+        overall = "unknown"
+    elif "review_required" in statuses:
+        overall = "review_required"
+    elif "failed" in statuses:
+        overall = "failed"
+    elif "partial" in statuses:
+        overall = "partial"
+    else:
+        overall = "blocked"
+    operations = sorted({operation for stage in stages.values() for operation in stage.get("operation_ids", [])})
+    return {
+        "schema_version": VERSION,
+        "campaign_id": campaign_id,
+        "status": overall,
+        "stages": stages,
+        "operation_ids": operations,
+        "evidence_hash": _digest(source),
+    }
+
+
+def _capabilities(script_dir: Path) -> list[dict[str, str]]:
+    registry = _read_json(script_dir.parent / "configs" / "capability-registry.json", "capability registry")
+    names = {entry.get("name"): entry for entry in registry.get("capabilities", []) if isinstance(entry, dict)}
+    required = ("campaign-research-dossiers", "social-provider-readiness", "approval-bound-social-publishing")
+    result: list[dict[str, str]] = []
+    for name in required:
+        entry = names.get(name)
+        result.append({"name": name, "status": "available" if entry else "degraded", "fallback": str(entry.get("fallback", "manual-handoff")) if entry else "manual-handoff"})
+    return result
+
+
+def _plan(arguments: argparse.Namespace) -> int:
+    intake = _intake(Path(arguments.intake).expanduser().absolute())
+    plan = {
+        "schema": "aidevops.campaign-growth-plan/v1",
+        "dry_run": True,
+        "campaign": {
+            "brand": intake["brand"].get("name"),
+            "product": intake["product"].get("name"),
+            "offer": intake["offer"].get("summary"),
+            "channels": intake["channels"],
+            "objectives": intake["objectives"],
+        },
+        "stages": list(STAGES),
+        "capabilities": _capabilities(Path(__file__).resolve().parent),
+        "approvals_required": ["claims", "creative", "distribution", "budget/audience/offer changes"],
+        "artifacts": ["research dossier", "production manifests", "distribution receipts", "performance summary", "report recommendation"],
+        "fallbacks": ["research-unavailable", "gated-no-mutation", "approval-required-manual-handoff"],
+        "mutation": False,
+    }
+    print(json.dumps(plan, sort_keys=True))
+    return 0
+
+
+def _state_path(campaign: Path) -> Path:
+    destination = campaign / "orchestration" / STATE_FILE
+    if destination.parent.is_symlink() or destination.is_symlink():
+        raise GrowthError("campaign checkpoint path is unsafe")
+    return destination
+
+
+def _write_state(path: Path, state: dict[str, Any], prior: dict[str, Any] | None) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if prior and prior.get("evidence_hash") == state["evidence_hash"]:
+        state["generation"] = prior.get("generation", 1)
+    else:
+        state["generation"] = int(prior.get("generation", 0)) + 1 if prior else 1
+    state["updated_at"] = int(time.time())
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(state, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        Path(temporary_name).unlink(missing_ok=True)
+        raise
+    return state
+
+
+def _load_state(path: Path) -> dict[str, Any] | None:
+    return _read_json(path, "campaign checkpoint") if path.exists() else None
+
+
+def _status(arguments: argparse.Namespace, write: bool) -> int:
+    campaign = _campaign_dir(arguments.repo, arguments.campaign_id)
+    intake = _intake(campaign / "intake.json")
+    source = _evidence(Path(arguments.evidence).expanduser().absolute() if arguments.evidence else None, campaign)
+    state = _build_state(arguments.campaign_id, intake, source)
+    path = _state_path(campaign)
+    if write:
+        state = _write_state(path, state, _load_state(path))
+    elif path.exists():
+        state["checkpoint"] = _load_state(path)
+    print(json.dumps(state, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan", help="Print a non-mutating campaign growth plan")
+    plan.add_argument("--intake", required=True)
+    plan.set_defaults(handler=_plan)
+    for name, help_text, write in (
+        ("status", "Show the evidence-derived orchestration state", False),
+        ("start", "Create or update an orchestration checkpoint", True),
+        ("resume", "Reconcile evidence and update an orchestration checkpoint", True),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument("campaign_id")
+        command.add_argument("--repo", default=".")
+        command.add_argument("--evidence", help="owner-produced stage evidence JSON")
+        command.set_defaults(handler=lambda arguments, write=write: _status(arguments, write))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    try:
+        return int(arguments.handler(arguments))
+    except GrowthError as error:
+        print(f"campaign growth: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/campaign-helper.sh
+++ b/.agents/scripts/campaign-helper.sh
@@ -1675,6 +1675,10 @@ main() {
 	launch) cmd_launch "$@" ;;
 	promote) cmd_promote "$@" ;;
 	feedback) cmd_feedback "$@" ;;
+	grow | growth)
+		[[ -f "${SCRIPT_DIR}/campaign-growth-helper.py" ]] || { print_error "Campaign growth helper not found: ${SCRIPT_DIR}/campaign-growth-helper.py"; return 1; }
+		python3 "${SCRIPT_DIR}/campaign-growth-helper.py" "$@"
+		;;
 	production)
 		[[ -f "$CAMPAIGN_PRODUCTION_HELPER" ]] || { print_error "Campaign production helper not found: ${CAMPAIGN_PRODUCTION_HELPER}"; return 1; }
 		python3 "$CAMPAIGN_PRODUCTION_HELPER" "$@"

--- a/.agents/scripts/campaign_growth_contract.py
+++ b/.agents/scripts/campaign_growth_contract.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Campaign growth evidence contract and truthful state projection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+VERSION = 1
+STAGES = ("intake", "research", "production", "review", "distribution", "performance", "report")
+TERMINAL = {"succeeded", "partial", "failed", "unknown", "blocked", "review_required"}
+
+
+class GrowthError(ValueError):
+    """Raised when orchestration inputs or checkpoints are unsafe."""
+
+
+def read_json(path: Path, label: str) -> dict[str, Any]:
+    """Read one regular JSON object without following a symlink."""
+    if path.is_symlink() or not path.is_file():
+        raise GrowthError(f"{label} is unavailable")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GrowthError(f"{label} must be valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise GrowthError(f"{label} must be a JSON object")
+    return value
+
+
+def digest(value: Any) -> str:
+    """Return a stable source-evidence hash for idempotent recovery."""
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def campaign_dir(repo: str, campaign_id: str) -> Path:
+    """Resolve an active campaign only when every ancestor is a real directory."""
+    if not campaign_id or "/" in campaign_id or ".." in campaign_id:
+        raise GrowthError("campaign_id must be a bounded campaign alias")
+    root = Path(repo).expanduser().absolute()
+    campaign = root / "_campaigns" / "active" / campaign_id
+    if any(path.is_symlink() for path in (root, root / "_campaigns", root / "_campaigns" / "active", campaign)):
+        raise GrowthError("campaign path must not contain symlinks")
+    if not campaign.is_dir():
+        raise GrowthError("active campaign is unavailable")
+    return campaign.resolve()
+
+
+def intake(path: Path) -> dict[str, Any]:
+    """Require the fields needed to plan safely from schema-v1 intake."""
+    value = read_json(path, "campaign intake")
+    required = ("brand", "product", "offer", "objectives", "channels", "approvals")
+    if value.get("schema_version") != VERSION or any(key not in value for key in required):
+        raise GrowthError("campaign intake does not satisfy the schema-v1 orchestration minimum")
+    return value
+
+
+def evidence(path: Path | None, campaign: Path | None) -> dict[str, Any]:
+    """Load supplied owner evidence or use the campaign-local default."""
+    source = path or (campaign / "orchestration" / "evidence.json" if campaign else None)
+    if source is None or not source.exists():
+        return {"version": VERSION, "stages": {}}
+    value = read_json(source, "campaign growth evidence")
+    if value.get("version") != VERSION or not isinstance(value.get("stages", {}), dict):
+        raise GrowthError("campaign growth evidence must use version 1 and contain stages")
+    return value
+
+
+def _stage(status: str, evidence_refs: list[str], operation_ids: list[str] | None = None, reason: str | None = None) -> dict[str, Any]:
+    value: dict[str, Any] = {"status": status, "evidence": evidence_refs}
+    if operation_ids:
+        value["operation_ids"] = operation_ids
+    if reason:
+        value["reason"] = reason
+    return value
+
+
+def _owner_stage(source: dict[str, Any], stage: str) -> dict[str, Any] | None:
+    candidate = source.get("stages", {}).get(stage)
+    if not isinstance(candidate, dict):
+        return None
+    status, evidence_refs = candidate.get("status"), candidate.get("evidence")
+    if status not in TERMINAL or not isinstance(evidence_refs, list) or not all(isinstance(item, str) and item for item in evidence_refs):
+        raise GrowthError(f"{stage} evidence must have a truthful status and non-empty evidence references")
+    operation_ids = candidate.get("operation_ids", [])
+    if not isinstance(operation_ids, list) or not all(isinstance(item, str) and item for item in operation_ids):
+        raise GrowthError(f"{stage} operation_ids must be strings")
+    return _stage(status, evidence_refs, operation_ids, candidate.get("reason"))
+
+
+def _resolve_stage(name: str, source: dict[str, Any], approvals: dict[str, Any], prior_ok: bool) -> tuple[dict[str, Any], bool]:
+    if not prior_ok:
+        return _stage("not_started", [], reason="an earlier owner stage is incomplete"), False
+    supplied = _owner_stage(source, name)
+    if supplied is None:
+        status = "review_required" if name in {"review", "distribution"} else "blocked"
+        return _stage(status, [], reason=f"{name} owner evidence is unavailable"), False
+    if name == "review" and (approvals.get("claims") != "approved" or approvals.get("creative") != "approved"):
+        return _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "claims or creative approval is absent or expired"), False
+    if name == "distribution" and source.get("stages", {}).get(name, {}).get("approval") != "approved":
+        return _stage("review_required", supplied["evidence"], supplied.get("operation_ids"), "distribution approval is absent or expired"), False
+    return supplied, supplied["status"] == "succeeded"
+
+
+def _overall_status(stages: dict[str, dict[str, Any]]) -> str:
+    statuses = {entry["status"] for entry in stages.values()}
+    if statuses == {"succeeded"}:
+        return "succeeded"
+    return next((status for status in ("unknown", "review_required", "failed", "partial") if status in statuses), "blocked")
+
+
+def build_state(campaign_id: str, campaign_intake: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    """Project owner evidence into a single checkpoint without mutating owners."""
+    stages: dict[str, dict[str, Any]] = {"intake": _stage("succeeded", ["intake.json"])}
+    prior_ok = True
+    approvals = campaign_intake.get("approvals", {})
+    for name in STAGES[1:]:
+        stages[name], prior_ok = _resolve_stage(name, source, approvals, prior_ok)
+    operations = sorted({operation for stage in stages.values() for operation in stage.get("operation_ids", [])})
+    return {
+        "schema_version": VERSION,
+        "campaign_id": campaign_id,
+        "status": _overall_status(stages),
+        "stages": stages,
+        "operation_ids": operations,
+        "evidence_hash": digest(source),
+    }

--- a/.agents/scripts/tests/fixtures/campaign-growth/brand-offer.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/brand-offer.json
@@ -1,0 +1,1 @@
+{"brand":"Northstar","offer":"A 14-day evaluation","evidence":"synthetic fixture only"}

--- a/.agents/scripts/tests/fixtures/campaign-growth/evidence-happy.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/evidence-happy.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "stages": {
+    "research": {"status": "succeeded", "evidence": ["research/dossier.json"]},
+    "production": {"status": "succeeded", "evidence": ["creative/x-v1.md", "creative/reddit-v1.md", "media/metadata.json"]},
+    "review": {"status": "succeeded", "evidence": ["review/approved.json"]},
+    "distribution": {"status": "succeeded", "approval": "approved", "evidence": ["distribution/x-receipt.json", "distribution/reddit-receipt.json"], "operation_ids": ["op-x-001", "op-reddit-001"]},
+    "performance": {"status": "succeeded", "evidence": ["metrics/funnel.json"]},
+    "report": {"status": "succeeded", "evidence": ["reports/recommendation.json"]}
+  }
+}

--- a/.agents/scripts/tests/fixtures/campaign-growth/intake.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/intake.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "brand": {"name": "Northstar", "reference": "DESIGN.md"},
+  "product": {"name": "Northstar Analytics", "description": "Privacy-safe growth analytics"},
+  "offer": {"summary": "A 14-day evaluation", "terms": "New customers only"},
+  "objectives": [{"metric": "Qualified leads", "target": "25"}],
+  "audiences": [{"segment": "Operations leaders", "buying_roles": ["Champion"], "pains": ["Unknown attribution"], "jobs": ["Measure campaigns"], "outcomes": ["Reliable decisions"]}],
+  "positioning": {"statement": "Evidence before automation", "differentiators": ["Privacy safe"]},
+  "proof": [{"claim": "Evidence-backed reports", "evidence_reference": "research/northstar-study.json", "approval_status": "approved"}],
+  "objections": ["Migration effort"],
+  "exclusions": ["Unsupported regions"],
+  "channels": ["twitter", "reddit"],
+  "dates": {"start": "2026-08-01", "end": "2026-08-31"},
+  "kpis": [{"metric": "Reach", "target": "1000"}],
+  "disclosures": ["Synthetic fixture"],
+  "sensitivity": "internal",
+  "approvals": {"owner": "Marketing", "claims": "approved", "creative": "approved"}
+}

--- a/.agents/scripts/tests/fixtures/campaign-growth/media-metadata.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/media-metadata.json
@@ -1,0 +1,1 @@
+{"asset_id":"asset-northstar-x-v1","license":"approved","synthetic":true,"review":"approved"}

--- a/.agents/scripts/tests/fixtures/campaign-growth/metrics.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/metrics.json
@@ -1,0 +1,1 @@
+{"reach":1200,"conversions":42,"leads":25,"sales":8,"revenue":2400,"refunds":0,"cost":600}

--- a/.agents/scripts/tests/fixtures/campaign-growth/provider-receipts.json
+++ b/.agents/scripts/tests/fixtures/campaign-growth/provider-receipts.json
@@ -1,0 +1,1 @@
+{"providers":["x","reddit"],"operation_ids":["op-x-001","op-reddit-001"],"status":"succeeded"}

--- a/.agents/scripts/tests/test-campaign-growth-e2e.py
+++ b/.agents/scripts/tests/test-campaign-growth-e2e.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic coverage for campaign growth planning, approval, and recovery."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HELPER = ROOT / ".agents" / "scripts" / "campaign-growth-helper.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "campaign-growth"
+
+
+class CampaignGrowthE2E(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name) / "repo"
+        self.campaign = self.repo / "_campaigns" / "active" / "northstar"
+        self.campaign.mkdir(parents=True)
+        shutil.copy(FIXTURES / "intake.json", self.campaign / "intake.json")
+        self.evidence = self.repo / "evidence.json"
+        shutil.copy(FIXTURES / "evidence-happy.json", self.evidence)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_helper(self, *arguments: str, expected: int = 0) -> dict[str, object]:
+        result = subprocess.run(["python3", str(HELPER), *arguments], capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, expected, result.stderr)
+        return json.loads(result.stdout) if result.stdout else {}
+
+    def test_plan_is_non_mutating_and_describes_fallbacks(self) -> None:
+        plan = self.run_helper("plan", "--intake", str(self.campaign / "intake.json"))
+        self.assertTrue(plan["dry_run"])
+        self.assertFalse(plan["mutation"])
+        self.assertIn("distribution receipts", plan["artifacts"])
+        self.assertFalse((self.campaign / "orchestration").exists())
+
+    def test_happy_path_persists_idempotent_evidence_checkpoint(self) -> None:
+        first = self.run_helper("start", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+        resumed = self.run_helper("resume", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+        self.assertEqual(first["status"], "succeeded")
+        self.assertEqual(first["operation_ids"], ["op-reddit-001", "op-x-001"])
+        self.assertEqual(first["generation"], resumed["generation"])
+
+    def test_missing_approval_stops_distribution_without_false_success(self) -> None:
+        evidence = json.loads(self.evidence.read_text(encoding="utf-8"))
+        del evidence["stages"]["distribution"]["approval"]
+        self.evidence.write_text(json.dumps(evidence), encoding="utf-8")
+        state = self.run_helper("start", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+        self.assertEqual(state["status"], "review_required")
+        self.assertEqual(state["stages"]["distribution"]["status"], "review_required")
+        self.assertEqual(state["stages"]["performance"]["status"], "not_started")
+
+    def test_unknown_provider_and_partial_metrics_remain_visible(self) -> None:
+        evidence = json.loads(self.evidence.read_text(encoding="utf-8"))
+        evidence["stages"]["distribution"]["status"] = "unknown"
+        evidence["stages"]["performance"]["status"] = "partial"
+        self.evidence.write_text(json.dumps(evidence), encoding="utf-8")
+        state = self.run_helper("status", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+        self.assertEqual(state["status"], "unknown")
+        self.assertEqual(state["stages"]["performance"]["status"], "not_started")
+
+    def test_failure_and_recovery_inputs_stop_only_the_affected_route(self) -> None:
+        cases = (
+            ("missing evidence", "research", "blocked", "blocked"),
+            ("unlicensed asset", "production", "blocked", "blocked"),
+            ("unsupported provider", "distribution", "blocked", "blocked"),
+            ("rate limit", "distribution", "partial", "partial"),
+            ("suppression", "performance", "partial", "partial"),
+            ("insufficient experiment evidence", "report", "blocked", "blocked"),
+        )
+        for reason, stage, status, overall in cases:
+            with self.subTest(reason=reason):
+                evidence = json.loads((FIXTURES / "evidence-happy.json").read_text(encoding="utf-8"))
+                evidence["stages"][stage]["status"] = status
+                evidence["stages"][stage]["reason"] = reason
+                self.evidence.write_text(json.dumps(evidence), encoding="utf-8")
+                state = self.run_helper("status", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+                self.assertEqual(state["status"], overall)
+                self.assertEqual(state["stages"][stage]["status"], status)
+
+    def test_claim_or_creative_approval_requires_review(self) -> None:
+        intake = json.loads((self.campaign / "intake.json").read_text(encoding="utf-8"))
+        intake["approvals"]["creative"] = "pending"
+        (self.campaign / "intake.json").write_text(json.dumps(intake), encoding="utf-8")
+        state = self.run_helper("status", "northstar", "--repo", str(self.repo), "--evidence", str(self.evidence))
+        self.assertEqual(state["status"], "review_required")
+        self.assertEqual(state["stages"]["review"]["status"], "review_required")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-campaign-growth-e2e.py
+++ b/.agents/scripts/tests/test-campaign-growth-e2e.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -32,7 +33,7 @@ class CampaignGrowthE2E(unittest.TestCase):
         self.temporary.cleanup()
 
     def run_helper(self, *arguments: str, expected: int = 0) -> dict[str, object]:
-        result = subprocess.run(["python3", str(HELPER), *arguments], capture_output=True, text=True, check=False)
+        result = subprocess.run([sys.executable, str(HELPER), *arguments], capture_output=True, text=True, check=False)  # nosec B603
         self.assertEqual(result.returncode, expected, result.stderr)
         return json.loads(result.stdout) if result.stdout else {}
 

--- a/.agents/workflows/campaign-growth.md
+++ b/.agents/workflows/campaign-growth.md
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Campaign Growth Workflow
+
+Use this workflow when a user needs one evidence-backed campaign lifecycle across
+research, content, approved distribution, performance, and recommendations.
+
+## Start with a safe plan
+
+```bash
+aidevops campaign grow plan --intake intake.json
+```
+
+The plan accepts the existing schema-v1 intake and is dry-run only. It names the
+channels, required approvals, expected owner artifacts, capability fallbacks, and
+metrics path. It does not create a campaign, draft content, contact a provider, or
+change a budget, audience, offer, or account.
+
+## Owner evidence and checkpoint
+
+After `campaign new` has created an active campaign, owners may supply bounded
+evidence to the orchestrator:
+
+```json
+{
+  "version": 1,
+  "stages": {
+    "research": {"status": "succeeded", "evidence": ["research/dossier.json"]},
+    "production": {"status": "succeeded", "evidence": ["creative/x-v1.md"]},
+    "review": {"status": "succeeded", "evidence": ["review/approved.json"]},
+    "distribution": {"status": "succeeded", "approval": "approved", "evidence": ["distribution/x-receipt.json"], "operation_ids": ["op_example"]},
+    "performance": {"status": "partial", "evidence": ["metrics/funnel.json"]}
+  }
+}
+```
+
+Run `aidevops campaign grow start <id> --repo <repo> --evidence <file>` to write
+only the atomic orchestration checkpoint. `status` derives state without writing;
+`resume` recomputes from the supplied owner evidence and preserves the generation
+when its evidence hash and operation IDs are unchanged.
+
+## Approval and recovery boundaries
+
+- Claims, creative, publishing/outreach, budgets, audiences, offers, and provider
+  accounts remain separately approved by their owners.
+- Missing or expired distribution approval produces `review_required`; no queue or
+  provider action is attempted.
+- `unknown` provider outcomes retain their stable operation IDs for owner
+  reconciliation. Never retry an unknown remote action as a new action.
+- `partial`, suppressed, stale, or insufficient performance evidence remains
+  partial and cannot create a recommendation success.
+- Unsupported capability and unhealthy provider states use the reported fallback:
+  evidence-only/manual handoff or gated-no-mutation.
+
+## Specialist ownership
+
+- Research: `campaign research` and the research dossier contract.
+- Creative: `campaign production` and Content review evidence.
+- Distribution: `campaign distribution` and social provider health/queue receipts.
+- Metrics: `aidevops performance ingest-campaign`.
+- Reports and recommendations: `marketing-optimization-helper.py` and
+  `reports/marketing.md`.

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1068,7 +1068,7 @@ _help_commands() {
 	echo "  vault <cmd>        Local encrypted Vault broker (init/unlock/lock/status/read/update)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
 	echo "  knowledge <cmd>    Knowledge plane management (init/status/provision)"
-	echo "  campaign <cmd>     Campaign plane: init/provision/ls (P1) + asset (P4) + new/list/status/archive (P2) + draft (P5) + launch/promote (P6)"
+	echo "  campaign <cmd>     Campaign plane: init/provision/ls (P1) + asset (P4) + new/list/status/archive (P2) + draft (P5) + launch/promote (P6) + grow (orchestration)"
 	echo "  stats <cmd>        LLM usage analytics (summary/models/projects/costs/trend)"
 	echo "  tabby <cmd>        Manage Tabby terminal profiles (sync/status/zshrc/help)"
 	echo "  buzz <cmd>         Manage Buzz Desktop OpenCode ACP compatibility"
@@ -1204,6 +1204,8 @@ _help_detailed_sections() {
 	echo "  aidevops campaign launch <id>                  # Move active/<id> → launched/, create templates (P6)"
 	echo "  aidevops campaign promote <id> [--results|--learnings] # Cross-plane promotion (P6)"
 	echo "  aidevops campaign feedback [<id>]              # Surface _feedback/ insights for research (P6)"
+	echo "  aidevops campaign grow plan --intake <file>    # Non-mutating growth orchestration plan"
+	echo "  aidevops campaign grow <start|status|resume> <id> # Evidence-backed growth checkpoint"
 	echo ""
 	echo "Performance Plane:"
 	echo "  aidevops performance init                     # Provision _performance/marketing/"
@@ -1967,6 +1969,17 @@ main() {
 		asset | assets)
 			shift
 			_dispatch_helper "campaign-asset-helper.sh" "campaign-asset-helper.sh" "$@"
+			;;
+		grow | growth)
+			shift
+			local _growth_helper="${AIDEVOPS_CLI_MODULES_DIR%/aidevops-cli}/campaign-growth-helper.py"
+			[[ ! -f "$_growth_helper" ]] && _growth_helper="$AGENTS_DIR/scripts/campaign-growth-helper.py"
+			if [[ -f "$_growth_helper" ]]; then
+				python3 "$_growth_helper" "$@"
+			else
+				print_error "campaign-growth-helper.py not found. Run: aidevops update"
+				return 1
+			fi
 			;;
 		*)
 			_dispatch_helper "$_camp_helper" "$_camp_helper" "$@"


### PR DESCRIPTION
## Summary

- Add evidence-backed campaign growth planning, checkpointing, and recovery.
- Preserve owner approvals and explicit non-success states without provider mutation.
- Document the workflow, capability, and hermetic fixtures.

## Verification

- Campaign growth E2E tests.
- Campaign status-routing tests.
- Changed-file local linters.

Resolves #30146

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
