### PR TITLE
GH#30285: preserve approval across trusted tier backfill

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1069,16 +1069,24 @@ _approval_verify_locked_issue_continuity() {
 	# canonical workload tier; timeline authorization below still binds its actor.
 	if ! jq -e --argjson signed "$signed_lifecycle" '
 		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:in-review" or . == "status:in-progress" or . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
+		def tier_label: . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		.lifecycle as $current |
 		($current.labels | map(.name)) as $current_labels |
 		($signed.labels | map(.name)) as $signed_labels |
+		($current_labels - $signed_labels) as $added_labels |
+		($signed_labels - $current_labels) as $removed_labels |
+		([$added_labels[] | select(tier_label)] | length) as $added_tiers |
+		([$removed_labels[] | select(tier_label)] | length) as $removed_tiers |
+		([$signed_labels[] | select(tier_label)] | length) as $signed_tiers |
+		([$current_labels[] | select(tier_label)] | length) as $current_tiers |
 		$current.state == $signed.state
 		and $current.state_reason == $signed.state_reason
 		and $current.locked == $signed.locked
 		and $current.active_lock_reason == $signed.active_lock_reason
 		and $current.milestone == $signed.milestone
 		and $current.lock_anchor == $signed.lock_anchor
-		and ([($current_labels - $signed_labels)[], ($signed_labels - $current_labels)[]] | unique | all(allowed_label))
+		and ([$added_labels[], $removed_labels[]] | unique | all(allowed_label))
+		and (if ($added_tiers + $removed_tiers) > 0 then $signed_tiers == 0 and $current_tiers == 1 and $added_tiers == 1 and $removed_tiers == 0 else true end)
 		and ($current.assignees != $signed.assignees or $current.labels != $signed.labels)
 	' <<<"$current_snapshot" >/dev/null 2>&1; then
 		return 1

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1065,8 +1065,10 @@ _approval_verify_locked_issue_continuity() {
 	candidate=$(jq -cS --argjson lifecycle "$signed_lifecycle" '.lifecycle = $lifecycle' <<<"$current_snapshot") || return 1
 	candidate_digest=$(approval_snapshot_v2_digest "$candidate") || return 2
 	[[ "$candidate_digest" == "$signed_digest" ]] || return 1
+	# #aidevops:trust-boundary — deterministic tier backfill may only select a
+	# canonical workload tier; timeline authorization below still binds its actor.
 	if ! jq -e --argjson signed "$signed_lifecycle" '
-		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:in-review" or . == "status:in-progress";
+		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:in-review" or . == "status:in-progress" or . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		.lifecycle as $current |
 		($current.labels | map(.name)) as $current_labels |
 		($signed.labels | map(.name)) as $signed_labels |
@@ -1093,7 +1095,7 @@ _approval_verify_locked_issue_continuity() {
 	while IFS=$'\t' read -r event actor subject actor_id actor_type; do
 		[[ -n "$event" ]] || continue
 		case "$event:$subject" in
-		assigned:* | unassigned:* | labeled:needs-maintainer-review | unlabeled:needs-maintainer-review | labeled:auto-dispatch | unlabeled:auto-dispatch | labeled:status:available | unlabeled:status:available | labeled:status:queued | unlabeled:status:queued | labeled:status:in-review | unlabeled:status:in-review | labeled:status:in-progress | unlabeled:status:in-progress) ;;
+		assigned:* | unassigned:* | labeled:needs-maintainer-review | unlabeled:needs-maintainer-review | labeled:auto-dispatch | unlabeled:auto-dispatch | labeled:status:available | unlabeled:status:available | labeled:status:queued | unlabeled:status:queued | labeled:status:in-review | unlabeled:status:in-review | labeled:status:in-progress | unlabeled:status:in-progress | labeled:tier:simple | labeled:tier:standard | labeled:tier:thinking) ;;
 		*) return 1 ;;
 		esac
 		# #aidevops:trust-boundary — GitHub's official Actions bot has no

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -421,8 +421,9 @@ test_post_approval_linked_references() {
 }
 
 write_locked_issue_fixture() {
+	local include_tier="${1:-true}"
 	write_baseline_fixtures
-	jq '.locked = true | .active_lock_reason = "resolved" | .labels = [{id:6,node_id:"L_6",name:"external-contributor"},{id:7,node_id:"L_7",name:"origin:interactive"},{id:8,node_id:"L_8",name:"review:approve"},{id:9,node_id:"L_9",name:"tier:standard"}] | .assignees = []' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	jq --arg include_tier "$include_tier" '.locked = true | .active_lock_reason = "resolved" | .labels = ([{id:6,node_id:"L_6",name:"external-contributor"},{id:7,node_id:"L_7",name:"origin:interactive"},{id:8,node_id:"L_8",name:"review:approve"}] + if $include_tier == "true" then [{id:9,node_id:"L_9",name:"tier:standard"}] else [] end) | .assignees = []' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	jq '.[0] += [{id:418,node_id:"EV_418",event:"locked",created_at:"2026-01-01T00:04:00Z",actor:{id:1,node_id:"U_1",login:"maintainer",type:"User"}}]' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
 	append_signed_comment issue 41 "2026-01-01T00:05:00Z" 4199
 	return 0
@@ -435,6 +436,8 @@ append_issue_timeline_event() {
 }
 
 test_locked_issue_continuity() {
+	local event_json=""
+	local tier=""
 	# Production regression from the first #30153 signature: approval-helper
 	# performed the trusted handoff, then the narrowly scoped repository workflow
 	# filled the one missing default status label under github-actions[bot].
@@ -478,6 +481,24 @@ test_locked_issue_continuity() {
 	append_issue_timeline_event '{"id":420,"node_id":"EV_420","event":"assigned","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'
 	append_issue_timeline_event '{"id":421,"node_id":"EV_421","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
 	assert_verify "trusted allowlisted mutations preserve continuously locked issue approval" issue 41 VERIFIED 0
+
+	for tier in simple standard thinking; do
+		write_locked_issue_fixture false
+		jq --arg tier "tier:${tier}" '.labels += [{id:10,node_id:"L_10",name:$tier}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+		event_json=$(jq -nc --arg tier "tier:${tier}" '{id:4211,node_id:"EV_4211",event:"labeled",created_at:"2026-01-01T00:06:00Z",actor:{id:1,login:"maintainer",type:"User"},label:{name:$tier}}')
+		append_issue_timeline_event "$event_json"
+		assert_verify "trusted ${tier} tier backfill preserves continuously locked issue approval" issue 41 VERIFIED 0
+	done
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4212,"node_id":"EV_4212","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":2,"login":"contributor","type":"User"},"label":{"name":"tier:standard"}}'
+	assert_verify "untrusted tier backfill remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels |= map(select(.name != "tier:standard"))' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4213,"node_id":"EV_4213","event":"unlabeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+	assert_verify "trusted tier removal remains stale" issue 41 STALE_APPROVAL 4
 
 	write_locked_issue_fixture
 	jq '.labels = [{id:8,node_id:"L_8",name:"security"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -45,7 +45,12 @@ set -euo pipefail
 [[ "${1:-}" == "api" ]] || exit 1
 endpoint="${2:-}"
 if [[ -n "${GH_FAIL_ENDPOINT:-}" && "$endpoint" == *"${GH_FAIL_ENDPOINT}"* ]]; then
-	exit 1
+	fail_count_file="${FIXTURES}/gh-fail-count"
+	fail_count=0
+	[[ ! -f "$fail_count_file" ]] || fail_count=$(<"$fail_count_file")
+	fail_count=$((fail_count + 1))
+	printf '%s\n' "$fail_count" >"$fail_count_file"
+	[[ "$fail_count" -le "${GH_FAIL_ENDPOINT_AFTER:-0}" ]] || exit 1
 fi
 case "$endpoint" in
 	user) printf '%s\n' "${GH_AUTH_USER:-maintainer}" ;;
@@ -473,7 +478,8 @@ test_locked_issue_tier_backfill_continuity() {
 	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	append_issue_timeline_event '{"id":42115,"node_id":"EV_42115","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
 	rc=0
-	output=$(GH_FAIL_ENDPOINT="issues/41/timeline" run_verify issue 41) || rc=$?
+	rm -f "${FIXTURES}/gh-fail-count"
+	output=$(GH_FAIL_ENDPOINT="issues/41/timeline" GH_FAIL_ENDPOINT_AFTER=1 run_verify issue 41) || rc=$?
 	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
 		print_result "tier backfill timeline uncertainty fails closed" 0
 	else

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -437,6 +437,8 @@ append_issue_timeline_event() {
 
 test_locked_issue_continuity() {
 	local event_json=""
+	local output=""
+	local rc=0
 	local tier=""
 	# Production regression from the first #30153 signature: approval-helper
 	# performed the trusted handoff, then the narrowly scoped repository workflow
@@ -489,6 +491,28 @@ test_locked_issue_continuity() {
 		append_issue_timeline_event "$event_json"
 		assert_verify "trusted ${tier} tier backfill preserves continuously locked issue approval" issue 41 VERIFIED 0
 	done
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42111,"node_id":"EV_42111","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
+	assert_verify "adding a second canonical tier remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:simple"},{id:11,node_id:"L_11",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42112,"node_id":"EV_42112","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:simple"}}'
+	append_issue_timeline_event '{"id":42113,"node_id":"EV_42113","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
+	assert_verify "adding multiple canonical tiers remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42114,"node_id":"EV_42114","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+	rc=0
+	output=$(GH_FAIL_ENDPOINT="collaborators/maintainer/permission" run_verify issue 41) || rc=$?
+	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
+		print_result "tier backfill permission uncertainty fails closed" 0
+	else
+		print_result "tier backfill permission uncertainty fails closed" 1 "expected=API_ERROR/6, actual=${output}/${rc}"
+	fi
 
 	write_locked_issue_fixture false
 	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -471,6 +471,17 @@ test_locked_issue_tier_backfill_continuity() {
 
 	write_locked_issue_fixture false
 	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42115,"node_id":"EV_42115","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+	rc=0
+	output=$(GH_FAIL_ENDPOINT="issues/41/timeline" run_verify issue 41) || rc=$?
+	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
+		print_result "tier backfill timeline uncertainty fails closed" 0
+	else
+		print_result "tier backfill timeline uncertainty fails closed" 1 "expected=API_ERROR/6, actual=${output}/${rc}"
+	fi
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	append_issue_timeline_event '{"id":4212,"node_id":"EV_4212","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":2,"login":"contributor","type":"User"},"label":{"name":"tier:standard"}}'
 	assert_verify "untrusted tier backfill remains stale" issue 41 STALE_APPROVAL 4
 

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -435,11 +435,53 @@ append_issue_timeline_event() {
 	return 0
 }
 
-test_locked_issue_continuity() {
+test_locked_issue_tier_backfill_continuity() {
 	local event_json=""
 	local output=""
 	local rc=0
 	local tier=""
+	for tier in simple standard thinking; do
+		write_locked_issue_fixture false
+		jq --arg tier "tier:${tier}" '.labels += [{id:10,node_id:"L_10",name:$tier}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+		event_json=$(jq -nc --arg tier "tier:${tier}" '{id:4211,node_id:"EV_4211",event:"labeled",created_at:"2026-01-01T00:06:00Z",actor:{id:1,login:"maintainer",type:"User"},label:{name:$tier}}')
+		append_issue_timeline_event "$event_json"
+		assert_verify "trusted ${tier} tier backfill preserves continuously locked issue approval" issue 41 VERIFIED 0
+	done
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42111,"node_id":"EV_42111","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
+	assert_verify "adding a second canonical tier remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:simple"},{id:11,node_id:"L_11",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42112,"node_id":"EV_42112","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:simple"}}'
+	append_issue_timeline_event '{"id":42113,"node_id":"EV_42113","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
+	assert_verify "adding multiple canonical tiers remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":42114,"node_id":"EV_42114","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+	output=$(GH_FAIL_ENDPOINT="collaborators/maintainer/permission" run_verify issue 41) || rc=$?
+	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
+		print_result "tier backfill permission uncertainty fails closed" 0
+	else
+		print_result "tier backfill permission uncertainty fails closed" 1 "expected=API_ERROR/6, actual=${output}/${rc}"
+	fi
+
+	write_locked_issue_fixture false
+	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4212,"node_id":"EV_4212","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":2,"login":"contributor","type":"User"},"label":{"name":"tier:standard"}}'
+	assert_verify "untrusted tier backfill remains stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels |= map(select(.name != "tier:standard"))' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4213,"node_id":"EV_4213","event":"unlabeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+	assert_verify "trusted tier removal remains stale" issue 41 STALE_APPROVAL 4
+	return 0
+}
+
+test_locked_issue_continuity() {
 	# Production regression from the first #30153 signature: approval-helper
 	# performed the trusted handoff, then the narrowly scoped repository workflow
 	# filled the one missing default status label under github-actions[bot].
@@ -483,46 +525,6 @@ test_locked_issue_continuity() {
 	append_issue_timeline_event '{"id":420,"node_id":"EV_420","event":"assigned","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'
 	append_issue_timeline_event '{"id":421,"node_id":"EV_421","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
 	assert_verify "trusted allowlisted mutations preserve continuously locked issue approval" issue 41 VERIFIED 0
-
-	for tier in simple standard thinking; do
-		write_locked_issue_fixture false
-		jq --arg tier "tier:${tier}" '.labels += [{id:10,node_id:"L_10",name:$tier}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-		event_json=$(jq -nc --arg tier "tier:${tier}" '{id:4211,node_id:"EV_4211",event:"labeled",created_at:"2026-01-01T00:06:00Z",actor:{id:1,login:"maintainer",type:"User"},label:{name:$tier}}')
-		append_issue_timeline_event "$event_json"
-		assert_verify "trusted ${tier} tier backfill preserves continuously locked issue approval" issue 41 VERIFIED 0
-	done
-
-	write_locked_issue_fixture
-	jq '.labels += [{id:10,node_id:"L_10",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-	append_issue_timeline_event '{"id":42111,"node_id":"EV_42111","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
-	assert_verify "adding a second canonical tier remains stale" issue 41 STALE_APPROVAL 4
-
-	write_locked_issue_fixture false
-	jq '.labels += [{id:10,node_id:"L_10",name:"tier:simple"},{id:11,node_id:"L_11",name:"tier:thinking"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-	append_issue_timeline_event '{"id":42112,"node_id":"EV_42112","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:simple"}}'
-	append_issue_timeline_event '{"id":42113,"node_id":"EV_42113","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
-	assert_verify "adding multiple canonical tiers remains stale" issue 41 STALE_APPROVAL 4
-
-	write_locked_issue_fixture false
-	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-	append_issue_timeline_event '{"id":42114,"node_id":"EV_42114","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
-	rc=0
-	output=$(GH_FAIL_ENDPOINT="collaborators/maintainer/permission" run_verify issue 41) || rc=$?
-	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
-		print_result "tier backfill permission uncertainty fails closed" 0
-	else
-		print_result "tier backfill permission uncertainty fails closed" 1 "expected=API_ERROR/6, actual=${output}/${rc}"
-	fi
-
-	write_locked_issue_fixture false
-	jq '.labels += [{id:10,node_id:"L_10",name:"tier:standard"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-	append_issue_timeline_event '{"id":4212,"node_id":"EV_4212","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":2,"login":"contributor","type":"User"},"label":{"name":"tier:standard"}}'
-	assert_verify "untrusted tier backfill remains stale" issue 41 STALE_APPROVAL 4
-
-	write_locked_issue_fixture
-	jq '.labels |= map(select(.name != "tier:standard"))' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
-	append_issue_timeline_event '{"id":4213,"node_id":"EV_4213","event":"unlabeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
-	assert_verify "trusted tier removal remains stale" issue 41 STALE_APPROVAL 4
 
 	write_locked_issue_fixture
 	jq '.labels = [{id:8,node_id:"L_8",name:"security"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
@@ -593,6 +595,7 @@ main() {
 	test_trusted_lifecycle_comments
 	test_post_approval_linked_references
 	test_locked_issue_continuity
+	test_locked_issue_tier_backfill_continuity
 
 	reset_and_sign pr 42
 	local marker_drift="<!-- aidevops-signed-approval --> unsigned external drift"


### PR DESCRIPTION
## Summary

Allow only canonical tier backfill events by trusted repository writers to preserve continuously locked issue approvals

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: the committed worktree approval-helper verified live locked issue #30276 as VERIFIED with reason proven-locked-continuity; 55 content-binding tests and all approval-helper regression tests pass; ShellCheck and local linters pass

Resolves #30285


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 44m and 416,133 tokens on this with the user in an interactive session.