### PR TITLE
GH#30287: fix: permit explicit parent issue enrichment

### DIFF
--- a/.agents/scripts/issue-sync-helper-enrich.sh
+++ b/.agents/scripts/issue-sync-helper-enrich.sh
@@ -337,15 +337,15 @@ _enrich_check_rate_limit() {
 	[[ $_rc -ne 0 || -z "$_rl_json" ]] && return 1
 	_rl_remaining=$(printf '%s' "$_rl_json" | jq -r '.resources.graphql.remaining // 9999' 2>/dev/null || echo "9999")
 	if [[ "$_rl_remaining" -ge "$threshold" ]]; then
-		return 1  # healthy — proceed
+		return 1 # healthy — proceed
 	fi
 	_rl_reset=$(printf '%s' "$_rl_json" | jq -r '.resources.graphql.reset // 0' 2>/dev/null || echo "0")
 	local _reset_time
-	_reset_time=$(date -d "@${_rl_reset}" '+%H:%M:%SZ' 2>/dev/null \
-		|| TZ=UTC date -r "$_rl_reset" '+%H:%M:%SZ' 2>/dev/null \
-		|| echo "unknown")
+	_reset_time=$(date -d "@${_rl_reset}" '+%H:%M:%SZ' 2>/dev/null ||
+		TZ=UTC date -r "$_rl_reset" '+%H:%M:%SZ' 2>/dev/null ||
+		echo "unknown")
 	echo "::warning::GraphQL rate-limit too low for enrich, skipping this cycle (remaining=${_rl_remaining}, reset=${_reset_time}, threshold=${threshold}) — GH#20129"
-	return 0  # tell caller to skip
+	return 0 # tell caller to skip
 }
 
 # _enrich_prefetch_issues_map: fetch all open issues in one batch call and
@@ -404,6 +404,15 @@ _enrich_check_active_claim() {
 		# a redundant metadata read. GH#28498: inspection must never invoke stale
 		# recovery, which can mutate a live interactive owner's claim.
 		_dedup_result=$(ISSUE_META_JSON="$pre_fetched_json" "$_dedup_helper" is-assigned-read-only "$num" "$repo" "$_user" 2>/dev/null) || true
+		# GH#30287: parent-task and no-auto-dispatch prohibit worker dispatch,
+		# but do not represent a foreign owner. An explicitly targeted, forced
+		# maintainer repair may migrate a legacy body through enrich. Keep every
+		# other signal fail-closed, including uncertain metadata and live claims.
+		if [[ "${ENRICH_EXPLICIT_FORCED_TARGET:-false}" == "true" &&
+			("$_dedup_result" == PARENT_TASK_BLOCKED\ * || "$_dedup_result" == NO_AUTO_DISPATCH_BLOCKED\ *) ]]; then
+			print_info "Allowing explicit forced enrich for #$num ($task_id) despite dispatch-only blocker: $_dedup_result (GH#30287)"
+			return 1
+		fi
 		if [[ -n "$_dedup_result" ]]; then
 			print_warning "Skipping enrich for #$num ($task_id) — active claim detected: $_dedup_result (GH#19856)"
 			return 0
@@ -431,6 +440,11 @@ cmd_enrich() {
 	local target_task="${1:-}"
 	_init_cmd || return 1
 	local repo="$_CMD_REPO" todo_file="$_CMD_TODO" project_root="$_CMD_ROOT"
+	ENRICH_EXPLICIT_FORCED_TARGET=false
+	if [[ -n "$target_task" && "${FORCE_ENRICH:-false}" == "true" ]]; then
+		ENRICH_EXPLICIT_FORCED_TARGET=true
+	fi
+	export ENRICH_EXPLICIT_FORCED_TARGET
 	# Keep the actor cache scoped to this command invocation, even when callers
 	# source the helper and invoke cmd_enrich more than once in the same shell.
 	unset AIDEVOPS_ENRICH_ACTOR AIDEVOPS_ENRICH_ACTOR_RESOLVED

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -365,14 +365,9 @@ _enrich_process_task() {
 		print_error "Skipping enrich for $task_id — empty description; fix TODO entry before retrying (t2377)"
 		return 0
 	fi
-	if [[ "$DRY_RUN" == "true" ]]; then
-		local _dry_tier_msg=""
-		[[ -n "$tier_label" ]] && _dry_tier_msg=" tier=${tier_label}(replace)"
-		print_info "[DRY-RUN] Would enrich #$num ($task_id) labels=${labels}${_dry_tier_msg}"
-		echo "ENRICHED"
-		return 0
+	if [[ "$DRY_RUN" != "true" ]]; then
+		require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$num" || return 1
 	fi
-	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$num" || return 1
 
 	# t2165: fetch title, body, and labels in a single gh issue view call and
 	# forward to helpers.
@@ -395,6 +390,13 @@ _enrich_process_task() {
 	# GH#19856: cross-runner dedup guard — abort if another runner holds
 	# an active claim.
 	if _enrich_check_active_claim "$num" "$repo" "$task_id" "$_state_json"; then
+		return 0
+	fi
+	if [[ "$DRY_RUN" == "true" ]]; then
+		local _dry_tier_msg=""
+		[[ -n "$tier_label" ]] && _dry_tier_msg=" tier=${tier_label}(replace)"
+		print_info "[DRY-RUN] Would enrich #$num ($task_id) labels=${labels}${_dry_tier_msg}"
+		echo "ENRICHED"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-enrich-dedup-guard.sh
+++ b/.agents/scripts/tests/test-enrich-dedup-guard.sh
@@ -195,19 +195,42 @@ fi
 # path must block enrichment without edit/comment recovery writes (GH#28498).
 : >"$GH_WRITE_LOG"
 export AIDEVOPS_SESSION_USER="runnerB"
-active_claim_json='{"state":"OPEN","assignees":[{"login":"runnerA"}],"labels":[{"name":"origin:interactive"},{"name":"status:in-review"}]}'
-if _enrich_check_active_claim 123 "test/repo" "t28498" "$active_claim_json" >/dev/null 2>&1 \
-	&& [[ ! -s "$GH_WRITE_LOG" ]]; then
+active_claim_json='{"number":123,"state":"OPEN","assignees":[{"login":"runnerA"}],"labels":[{"name":"origin:interactive"},{"name":"status:in-review"}]}'
+if _enrich_check_active_claim 123 "test/repo" "t28498" "$active_claim_json" >/dev/null 2>&1 &&
+	[[ ! -s "$GH_WRITE_LOG" ]]; then
 	print_result "enrich guard blocks active interactive claim with zero GitHub writes" 0
 else
 	print_result "enrich guard blocks active interactive claim with zero GitHub writes" 1 "(guard passed or emitted a write)"
 fi
 
+# An explicit, forced single-task repair may bypass dispatch-only labels, but
+# never a foreign claim or uncertain metadata. This is limited to the enrich
+# migration path; dispatch-dedup-helper itself remains unchanged.
+parent_task_json='{"number":123,"state":"OPEN","assignees":[],"labels":[{"name":"parent-task"}]}'
+parent_no_auto_json='{"number":123,"state":"OPEN","assignees":[],"labels":[{"name":"parent-task"},{"name":"no-auto-dispatch"}]}'
+export ENRICH_EXPLICIT_FORCED_TARGET=true
+if ! _enrich_check_active_claim 123 "test/repo" "t30287" "$parent_task_json" >/dev/null 2>&1; then
+	print_result "forced single-task enrich permits parent-task dispatch blocker" 0
+else
+	print_result "forced single-task enrich permits parent-task dispatch blocker" 1 "(unexpected block)"
+fi
+if ! _enrich_check_active_claim 123 "test/repo" "t30287" "$parent_no_auto_json" >/dev/null 2>&1; then
+	print_result "forced single-task enrich permits parent-task plus no-auto-dispatch" 0
+else
+	print_result "forced single-task enrich permits parent-task plus no-auto-dispatch" 1 "(unexpected block)"
+fi
+if _enrich_check_active_claim 123 "test/repo" "t30287" "$active_claim_json" >/dev/null 2>&1; then
+	print_result "forced single-task enrich still blocks foreign active owner" 0
+else
+	print_result "forced single-task enrich still blocks foreign active owner" 1 "(unexpected pass)"
+fi
+unset ENRICH_EXPLICIT_FORCED_TARGET
+
 # A structurally blocked task must return before authoritative body composition.
 # This keeps broad no-op sweeps on their prefetched, read-only path (GH#30021).
 TODO_FIXTURE="${TEST_ROOT}/TODO.md"
 mkdir -p "${TEST_ROOT}/todo/tasks"
-printf '%s\n' '- [ ] t30021: Blocked fixture #bug ref:GH#123' >"$TODO_FIXTURE"
+printf '%s\n' '- [ ] t30021 Blocked fixture #bug ref:GH#123' >"$TODO_FIXTURE"
 compose_issue_body() {
 	printf 'compose\n' >>"${TEST_ROOT}/compose-calls.log"
 	printf 'unexpected body\n'
@@ -220,7 +243,7 @@ require_task_issue_mapping() {
 ENRICH_PREFETCH_FILE="${TEST_ROOT}/prefetch.json"
 printf '%s\n' "[$active_claim_json]" >"$ENRICH_PREFETCH_FILE"
 if _enrich_process_task "t30021" "test/repo" "$TODO_FIXTURE" "$TEST_ROOT" \
-	'- [ ] t30021: Blocked fixture #bug ref:GH#123' >/dev/null 2>&1 &&
+	'- [ ] t30021 Blocked fixture #bug ref:GH#123' >/dev/null 2>&1 &&
 	[[ ! -s "${TEST_ROOT}/compose-calls.log" ]]; then
 	print_result "blocked enrich task returns before authoritative body composition" 0
 else
@@ -231,12 +254,35 @@ unset ENRICH_PREFETCH_FILE
 # Metadata uncertainty must also fail closed without trying recovery writes.
 : >"$GH_WRITE_LOG"
 write_stub_gh '{}' true
-if _enrich_check_active_claim 123 "test/repo" "t28498" "" >/dev/null 2>&1 \
-	&& [[ ! -s "$GH_WRITE_LOG" ]]; then
+if _enrich_check_active_claim 123 "test/repo" "t28498" "" >/dev/null 2>&1 &&
+	[[ ! -s "$GH_WRITE_LOG" ]]; then
 	print_result "enrich guard fails closed on uncertain metadata with zero GitHub writes" 0
 else
 	print_result "enrich guard fails closed on uncertain metadata with zero GitHub writes" 1 "(guard passed or emitted a write)"
 fi
+
+# Dry-run must inspect the same guard as execution rather than claiming a
+# mutation that execution would skip. The structural exception is activated
+# only by the explicit forced single-task command state.
+DRY_RUN=true
+ENRICH_EXPLICIT_FORCED_TARGET=false
+ENRICH_PREFETCH_FILE="${TEST_ROOT}/prefetch-parity.json"
+printf '%s\n' "[$active_claim_json]" >"$ENRICH_PREFETCH_FILE"
+if ! _enrich_process_task "t30021" "test/repo" "$TODO_FIXTURE" "$TEST_ROOT" \
+	'- [ ] t30021 Blocked fixture #bug ref:GH#123' 2>&1 | grep -q 'Would enrich'; then
+	print_result "dry-run and execution both block a foreign active owner" 0
+else
+	print_result "dry-run and execution both block a foreign active owner" 1 "(dry-run bypassed guard)"
+fi
+ENRICH_EXPLICIT_FORCED_TARGET=true
+printf '%s\n' "[$parent_task_json]" >"$ENRICH_PREFETCH_FILE"
+if _enrich_process_task "t30021" "test/repo" "$TODO_FIXTURE" "$TEST_ROOT" \
+	'- [ ] t30021 Blocked fixture #bug ref:GH#123' 2>&1 | grep -q 'Would enrich'; then
+	print_result "dry-run predicts forced parent-task enrichment" 0
+else
+	print_result "dry-run predicts forced parent-task enrichment" 1 "(dry-run did not match execution guard)"
+fi
+unset DRY_RUN ENRICH_EXPLICIT_FORCED_TARGET ENRICH_PREFETCH_FILE
 
 # Part 3b — _ensure_issue_body_has_brief also has the guard
 if grep -q 'is-assigned-read-only' "${TEST_SCRIPTS_DIR}/pulse-dispatch-core.sh"; then


### PR DESCRIPTION
## Summary

Allows explicit forced single-task enrich operations to bypass only parent-task or no-auto-dispatch dispatch blockers while retaining fail-closed foreign-owner and uncertain-metadata guards. Dry-run now evaluates the same guard as execution, with regression coverage.

## Files Changed

.agents/scripts/issue-sync-helper-enrich.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/tests/test-enrich-dedup-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-enrich-dedup-guard.sh; ShellCheck changed shell files; .agents/scripts/linters-local.sh --changed

Resolves #30287


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 63,558 tokens on this as a headless worker.