### PR TITLE
GH#30276: authenticate CI repair worker identity

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -1144,6 +1144,32 @@ _ci_repair_session_identity() {
 }
 
 #######################################
+# Resolve CI repair identity from the active gh credential context.
+# Caller-provided environment identity is never accepted as authority.
+#######################################
+_ci_repair_resolve_runner_login() {
+	local runner_login=""
+
+	# #aidevops:trust-boundary — bind worker ownership to authenticated GitHub
+	# identity rather than a mutable environment variable.
+	runner_login=$(gh api user --jq '.login // ""' 2>/dev/null || true)
+	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		printf '%s\n' "$runner_login"
+		return 0
+	fi
+
+	runner_login=$(gh api graphql \
+		-f 'query=query { viewer { login } }' \
+		--jq '.data.viewer.login // ""' 2>/dev/null || true)
+	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		printf '%s\n' "$runner_login"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Launch through the runtime's native detach path and publish its process identity.
 #######################################
 _ci_repair_launch_worker() {
@@ -1164,16 +1190,21 @@ _ci_repair_launch_worker() {
 	local process_start=""
 	local session_identity=""
 	local dispatched_status=""
+	local runner_login=""
 	local wait_count=0
 	local wait_max="${AIDEVOPS_CI_REPAIR_SESSION_LOCK_WAIT_STEPS:-200}"
 	local process_pattern="${WORKER_PROCESS_PATTERN:-opencode|claude|Claude}|headless-runtime-helper"
 
 	[[ "$wait_max" =~ ^[0-9]+$ ]] || wait_max=200
+	runner_login=$(_ci_repair_resolve_runner_login) || {
+		printf '%s\n' "[pulse-wrapper] _ci_repair_launch_worker: authenticated GitHub runner identity unavailable for ${repo_slug} PR #${pr_number}; launch blocked" >>"$LOGFILE"
+		return 1
+	}
 	launch_output=$(env \
 		HEADLESS=1 WORKER_ISSUE_NUMBER="$linked_issue" WORKER_REPO_SLUG="$repo_slug" \
 		WORKER_WORKTREE_PATH="$worktree_path" GITHUB_REPOSITORY="$repo_slug" \
 		WORKER_NO_EXIT_PUSH=1 WORKER_PROCESS_PATTERN="$process_pattern" AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1 \
-		WORKER_GITHUB_LOGIN="${AIDEVOPS_PULSE_RUNNER_LOGIN:-}" \
+		WORKER_GITHUB_LOGIN="$runner_login" \
 		AIDEVOPS_PR_REPAIR_NUMBER="$pr_number" AIDEVOPS_PR_REPAIR_HEAD_SHA="$pr_head_sha" \
 		AIDEVOPS_PR_REPAIR_HEAD_REF="$pr_head_ref" AIDEVOPS_PR_REPAIR_FINGERPRINT="$failure_fingerprint" \
 		AIDEVOPS_PR_REPAIR_OWNERSHIP_MODE="linked-issue" \

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -53,11 +53,15 @@ setup_test_env() {
 	unset TEST_INITIAL_PR_HEAD_SHA
 	unset TEST_INITIAL_PR_HEAD_EMPTY
 	unset TEST_WORKTREE_ADD_FAIL
+	unset TEST_GH_REST_FAIL
+	unset TEST_GH_REST_LOGIN
+	unset TEST_GH_GRAPHQL_FAIL
+	unset TEST_GH_GRAPHQL_LOGIN
+	unset AIDEVOPS_PULSE_RUNNER_LOGIN
 	export AIDEVOPS_CI_REPAIR_STATE_DIR="${TEST_ROOT}/repair-state"
 	export AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
 	export AIDEVOPS_HEADLESS_RUNTIME_DIR="${TEST_ROOT}/headless-runtime"
 	export AIDEVOPS_CI_REPAIR_SESSION_LOCK_WAIT_STEPS="0"
-	export AIDEVOPS_PULSE_RUNNER_LOGIN="expected-runner"
 	mkdir -p "${TEST_ROOT}/repo"
 	TEST_PR_HEAD_SHA="abcdef0123456789abcdef0123456789abcdef01"
 	export TEST_PR_HEAD_SHA
@@ -204,9 +208,28 @@ if [[ "${1:-} ${2:-}" == "run view" ]]; then
 	esac
 	exit 0
 fi
+
 GHEOF
+	_append_gh_auth_mock_routes
 	_append_gh_mock_routes
 	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+_append_gh_auth_mock_routes() {
+	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
+	if [[ "${1:-} ${2:-}" == "api user" ]]; then
+		[[ "${TEST_GH_REST_FAIL:-0}" == "1" ]] && exit 1
+		printf '%s\n' "${TEST_GH_REST_LOGIN:-expected-runner}"
+		exit 0
+	fi
+
+	if [[ "${1:-} ${2:-}" == "api graphql" ]]; then
+		[[ "${TEST_GH_GRAPHQL_FAIL:-0}" == "1" ]] && exit 1
+		printf '%s\n' "${TEST_GH_GRAPHQL_LOGIN:-expected-runner}"
+		exit 0
+	fi
+GHEOF
 	return 0
 }
 
@@ -443,6 +466,7 @@ define_feedback_helpers() {
 		_ci_repair_claim_lease
 		_ci_repair_create_worktree
 		_ci_repair_session_identity
+		_ci_repair_resolve_runner_login
 		_ci_repair_launch_worker
 		_ci_repair_write_prompt
 		_ci_repair_legacy_lease_is_active
@@ -755,6 +779,57 @@ test_changes_requested_empty_labels_refresh_current_metadata() {
 		print_result "refreshed empty PR labels preserve review routing" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
 	else
 		print_result "empty PR labels refresh current metadata before review routing" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_resolves_authenticated_runner_identity() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines authenticated CI repair identity helpers" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local resolved_login=""
+	local rc=0
+	resolved_login=$(AIDEVOPS_PULSE_RUNNER_LOGIN="forged-runner" _ci_repair_resolve_runner_login) || rc=$?
+	if [[ "$rc" -eq 0 && "$resolved_login" == "expected-runner" ]]; then
+		print_result "CI repair identity ignores caller environment and uses authenticated REST viewer" 0
+	else
+		print_result "CI repair identity ignores caller environment and uses authenticated REST viewer" 1 "login=${resolved_login:-missing}, rc=${rc}"
+	fi
+
+	rc=0
+	resolved_login=$(TEST_GH_REST_FAIL=1 TEST_GH_GRAPHQL_LOGIN="graphql-runner" _ci_repair_resolve_runner_login) || rc=$?
+	if [[ "$rc" -eq 0 && "$resolved_login" == "graphql-runner" ]]; then
+		print_result "CI repair identity uses authenticated GraphQL viewer fallback" 0
+	else
+		print_result "CI repair identity uses authenticated GraphQL viewer fallback" 1 "login=${resolved_login:-missing}, rc=${rc}"
+	fi
+
+	mkdir -p "${TEST_ROOT}/lease-success"
+	: >"$GH_LOG"
+	rc=0
+	AIDEVOPS_PULSE_RUNNER_LOGIN="forged-runner" _ci_repair_launch_worker \
+		"${TEST_ROOT}/lease-success" "$AIDEVOPS_HEADLESS_RUNTIME_HELPER" "owner/repo" "100" "42" \
+		"$TEST_PR_HEAD_SHA" "feature/repair" "fingerprint" "${TEST_ROOT}/worktrees/repair" \
+		"1" "ci-repair-auth-success" "${TEST_ROOT}/prompt.md" || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -qF '|expected-runner|run --role worker' "$GH_LOG"; then
+		print_result "authenticated CI repair identity reaches worker launch" 0
+	else
+		print_result "authenticated CI repair identity reaches worker launch" 1 "rc=${rc}, log=$(<"$GH_LOG")"
+	fi
+
+	: >"$GH_LOG"
+	rc=0
+	TEST_GH_REST_FAIL=1 TEST_GH_GRAPHQL_FAIL=1 _ci_repair_launch_worker \
+		"${TEST_ROOT}/lease" "$AIDEVOPS_HEADLESS_RUNTIME_HELPER" "owner/repo" "100" "42" \
+		"$TEST_PR_HEAD_SHA" "feature/repair" "fingerprint" "${TEST_ROOT}/worktrees/repair" \
+		"1" "ci-repair-auth-test" "${TEST_ROOT}/prompt.md" || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "CI repair launch fails closed without authenticated identity" 1 "launch unexpectedly succeeded"
+	elif grep -qF 'run --role worker' "$GH_LOG"; then
+		print_result "CI repair launch fails closed without authenticated identity" 1 "worker helper was invoked"
+	else
+		print_result "CI repair launch fails closed without authenticated identity" 0
 	fi
 	teardown_test_env
 	return 0
@@ -1225,6 +1300,7 @@ main() {
 	test_rest_missing_review_decision_refreshes_before_ci_route
 	test_coderabbit_nits_ok_dismissed_once_before_late_gate
 	test_changes_requested_empty_labels_refresh_current_metadata
+	test_ci_repair_resolves_authenticated_runner_identity
 	test_ci_repair_dedupes_identical_evidence_for_same_head
 	test_ci_repair_dedupes_changed_evidence_for_same_head
 	test_ci_repair_respects_live_legacy_lease


### PR DESCRIPTION
## Summary

Resolve CI repair ownership identity from the active GitHub credential context before launch, with authenticated GraphQL fallback and fail-closed behavior

## Files Changed

.agents/scripts/pulse-merge-feedback.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: CI repair routing suite executed the real resolver and launcher with REST identity, GraphQL fallback, forged environment override, successful detached worker propagation, and unavailable-auth failure; 35 tests passed; headless ownership and campaign-shadow compatibility suites passed; ShellCheck and local linters passed

Resolves #30276


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 31m and 627,807 tokens on this with the user in an interactive session.