### PR TITLE
GH#30278: fix: prevent adjective closing references

### DIFF
--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -95,7 +95,13 @@ override = `tier:thinking`.
      `Closes #NNN`") still auto-closes the issue on merge. Rephrase to avoid
      the literal keyword+hash+number sequence: "will use a closing keyword",
      "will resolve with a Closes-hash-NNN", or split the `#` from the number.
-     Canonical foot-gun: t2190 session PR #19680. -->
+      **Adjective-form foot-gun (GH#30278).** Never write
+      `closed #NNN`, `fixed #NNN`, or `resolved #NNN` as descriptive prose.
+      GitHub and pulse treat these adjective forms as closing clauses just as
+      they treat `Closes #NNN`. For superseded or historical work, use
+      `superseded by #NNN`, `addressed in #NNN`, or `see #NNN (closed)`.
+
+      Canonical foot-gun: t2190 session PR #19680. -->
 
 <!-- TODO(t2219): delete this comment block once t2219 (GH#19719) merges.
 


### PR DESCRIPTION
## Summary

Documented that adjective-form closing references in worker PR prose must use non-closing alternatives.

## Files Changed

.agents/templates/brief-template.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh; bash .agents/scripts/tests/test-brief-template-third-party-deps.sh; .agents/scripts/linters-local.sh

Resolves #30278


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 73,595 tokens on this as a headless worker.