### PR TITLE
GH#30274: prevent stale recovery from displacing live interactive sessions

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -146,6 +146,10 @@ if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/shared-repo-state-guard.sh" ]]; then
 	# shellcheck source=shared-repo-state-guard.sh
 	source "${DISPATCH_CLAIM_HELPER_DIR}/shared-repo-state-guard.sh"
 fi
+if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/interactive-claim-fence.sh" ]]; then
+	# shellcheck source=interactive-claim-fence.sh
+	source "${DISPATCH_CLAIM_HELPER_DIR}/interactive-claim-fence.sh"
+fi
 if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-override-resolve.sh" ]]; then
 	# shellcheck disable=SC1091
 	source "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-override-resolve.sh"
@@ -1095,6 +1099,12 @@ _guard_no_active_assignment_read_only() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local runner="$3"
+	if declare -F _interactive_claim_fence_blocks_dispatch >/dev/null 2>&1 &&
+		_interactive_claim_fence_blocks_dispatch "$issue_number" "$repo_slug"; then
+		printf 'CLAIM_BLOCKED: live_interactive_owner issue=#%s repo=%s\n' \
+			"$issue_number" "$repo_slug"
+		return 1
+	fi
 	local dedup_helper="${DISPATCH_ASSIGNMENT_GUARD_HELPER:-${DISPATCH_CLAIM_HELPER_DIR}/dispatch-dedup-helper.sh}"
 	if [[ ! -x "$dedup_helper" ]]; then
 		printf 'CLAIM_BLOCKED: assignment_guard_unavailable issue=#%s repo=%s helper=%s\n' \

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -72,6 +72,10 @@ CLAIM_HELPER="${SCRIPT_DIR}/dispatch-claim-helper.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+# Live interactive ownership is stronger than GitHub-visible activity age.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/interactive-claim-fence.sh"
+
 # GH#18917: cost circuit breaker extracted to keep this file below 2000 lines.
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/dispatch-dedup-cost.sh"

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -1070,6 +1070,8 @@ _stale_assignment_load_threshold_context() {
 	return 0
 }
 
+# GH#30274: a live interactive stamp + owned worktree outranks age and absent
+# headless-worker evidence, so the function checks that fence before API reads.
 _is_stale_assignment() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -1086,7 +1088,7 @@ _is_stale_assignment() {
 	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
 	# that the assignment is stale — block this pulse cycle and retry next cycle.
 	local comments_json
-	if ! comments_json=$(_stale_assignment_fetch_comments_json "$issue_number" "$repo_slug"); then
+	if _interactive_claim_fence_blocks_dispatch "$issue_number" "$repo_slug" || ! comments_json=$(_stale_assignment_fetch_comments_json "$issue_number" "$repo_slug"); then
 		# Cannot fetch comments — cannot determine staleness. Fail-CLOSED:
 		# keep the existing assignment protection for this pulse cycle.
 		return 1

--- a/.agents/scripts/interactive-claim-fence.sh
+++ b/.agents/scripts/interactive-claim-fence.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Live interactive ownership fence shared by stale recovery, dispatch, and merge.
+
+[[ -n "${_INTERACTIVE_CLAIM_FENCE_LOADED:-}" ]] && return 0
+_INTERACTIVE_CLAIM_FENCE_LOADED=1
+
+_ICF_SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$_ICF_SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && _ICF_SCRIPT_DIR="."
+if ! declare -F _is_process_alive_and_matches >/dev/null 2>&1; then
+	# shellcheck source=shared-constants.sh
+	source "${_ICF_SCRIPT_DIR}/shared-constants.sh"
+fi
+if ! declare -F check_worktree_owner >/dev/null 2>&1; then
+	# shellcheck source=shared-worktree-registry.sh
+	source "${_ICF_SCRIPT_DIR}/shared-worktree-registry.sh"
+fi
+
+_icf_stamp_path() {
+	local issue="$1"
+	local repo_slug="$2"
+	local stamp_dir="${CLAIM_STAMP_DIR:-${HOME}/.aidevops/.agent-workspace/interactive-claims}"
+	printf '%s/%s-%s.json' "$stamp_dir" "${repo_slug//\//-}" "$issue"
+	return 0
+}
+
+_icf_worktree_repo_slug() {
+	local worktree_path="$1"
+	local remote_url=""
+	remote_url=$(git -C "$worktree_path" remote get-url origin 2>/dev/null) || return 1
+	remote_url=${remote_url%.git}
+	remote_url=${remote_url#*github.com:}
+	remote_url=${remote_url#*github.com/}
+	[[ "$remote_url" =~ ^[^/]+/[^/]+$ ]] || return 1
+	printf '%s' "$remote_url"
+	return 0
+}
+
+_icf_stamp_owner_is_live() {
+	local stamp_file="$1"
+	local stamp_host=""
+	local local_host=""
+	local owner_pid=""
+	local owner_hash=""
+	stamp_host=$(jq -r '.hostname // empty' "$stamp_file" 2>/dev/null) || return 2
+	local_host=$(hostname 2>/dev/null || printf '%s' "unknown")
+	# Another host owns its liveness decision. Its matching durable stamp and
+	# worktree remain authoritative until that host explicitly releases them.
+	[[ -n "$stamp_host" && "$stamp_host" != "$local_host" ]] && return 0
+	owner_pid=$(jq -r '.pid // empty' "$stamp_file" 2>/dev/null) || return 2
+	owner_hash=$(jq -r '.owner_argv_hash // empty' "$stamp_file" 2>/dev/null) || return 2
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 2
+	if _is_process_alive_and_matches "$owner_pid" "${WORKER_PROCESS_PATTERN:-opencode|claude|Claude}" "$owner_hash"; then
+		return 0
+	fi
+	return 1
+}
+
+# Exit 0: verified live owner. Exit 1: absent or proven dead. Exit 2: matching
+# ownership evidence exists but cannot be disproved safely.
+_interactive_claim_fence_status() {
+	local issue="$1"
+	local repo_slug="$2"
+	local stamp_file=""
+	local worktree_path=""
+	local worktree_slug=""
+	local stamp_pid=""
+	local owner_info=""
+	local registry_pid=""
+	[[ "$issue" =~ ^[1-9][0-9]*$ && "$repo_slug" =~ ^[^/]+/[^/]+$ ]] || return 2
+	stamp_file=$(_icf_stamp_path "$issue" "$repo_slug")
+	[[ -f "$stamp_file" ]] || return 1
+	jq -e --arg slug "$repo_slug" --argjson issue "$issue" \
+		'.slug == $slug and .issue == $issue' "$stamp_file" >/dev/null 2>&1 || return 2
+	worktree_path=$(jq -r '.worktree_path // empty' "$stamp_file" 2>/dev/null) || return 2
+	[[ -n "$worktree_path" && -d "$worktree_path" ]] || return 2
+	worktree_slug=$(_icf_worktree_repo_slug "$worktree_path") || return 2
+	[[ "$worktree_slug" == "$repo_slug" ]] || return 2
+	stamp_pid=$(jq -r '.pid // empty' "$stamp_file" 2>/dev/null) || return 2
+	owner_info=$(check_worktree_owner "$worktree_path" 2>/dev/null) || return 2
+	registry_pid=${owner_info%%|*}
+	[[ "$registry_pid" =~ ^[1-9][0-9]*$ && "$registry_pid" == "$stamp_pid" ]] || return 2
+	_icf_stamp_owner_is_live "$stamp_file"
+	return $?
+}
+
+_interactive_claim_fence_blocks_dispatch() {
+	local issue="$1"
+	local repo_slug="$2"
+	local fence_rc=0
+	_interactive_claim_fence_status "$issue" "$repo_slug" || fence_rc=$?
+	[[ "$fence_rc" -eq 0 || "$fence_rc" -eq 2 ]]
+}
+
+_icf_worktree_has_unmerged_work() {
+	local worktree_path="$1"
+	local default_branch=""
+	local ahead_count=""
+	[[ -z "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]] || return 0
+	default_branch=$(git -C "$worktree_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || return 2
+	default_branch=${default_branch#refs/remotes/origin/}
+	[[ -n "$default_branch" ]] || return 2
+	ahead_count=$(git -C "$worktree_path" rev-list --count "origin/${default_branch}..HEAD" 2>/dev/null) || return 2
+	[[ "$ahead_count" =~ ^[0-9]+$ ]] || return 2
+	[[ "$ahead_count" -gt 0 ]] && return 0
+	return 1
+}
+
+# Block only a duplicate PR. The PR whose exact head is owned by the live
+# interactive worktree remains eligible for its session's normal merge path.
+_interactive_claim_fence_blocks_merge() {
+	local issue="$1"
+	local repo_slug="$2"
+	local candidate_head="$3"
+	local fence_rc=0
+	local stamp_file=""
+	local worktree_path=""
+	local worktree_head=""
+	_interactive_claim_fence_status "$issue" "$repo_slug" || fence_rc=$?
+	[[ "$fence_rc" -eq 1 ]] && return 1
+	[[ "$fence_rc" -eq 2 ]] && return 0
+	stamp_file=$(_icf_stamp_path "$issue" "$repo_slug")
+	worktree_path=$(jq -r '.worktree_path // empty' "$stamp_file" 2>/dev/null) || return 0
+	worktree_head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null) || return 0
+	[[ -n "$candidate_head" && "$candidate_head" == "$worktree_head" ]] && return 1
+	_icf_worktree_has_unmerged_work "$worktree_path" || fence_rc=$?
+	[[ "$fence_rc" -eq 0 || "$fence_rc" -eq 2 ]]
+}

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -218,6 +218,10 @@ _pulse_merge_ready_pr_json_fields() {
 _PULSE_MERGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_PULSE_MERGE_DIR}/shared-claim-lifecycle.sh"
 
+# Final duplicate-implementation fence for live interactive issue owners.
+# shellcheck source=interactive-claim-fence.sh
+source "${_PULSE_MERGE_DIR}/interactive-claim-fence.sh"
+
 # Source shared phase-filing helpers (t2740). auto_file_next_phase is called
 # from _handle_post_merge_actions to auto-file the next phase child issue
 # when a phase child PR merges for a parent-task issue.
@@ -394,6 +398,11 @@ _check_pr_merge_gates() {
 	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
 	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
 	_PULSE_REVIEW_GATE_EVIDENCE=""
+	if [[ -n "$linked_issue" ]] &&
+		_interactive_claim_fence_blocks_merge "$linked_issue" "$repo_slug" "$expected_head_sha"; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has a live interactive owner with different unmerged work (GH#30274)" >>"$LOGFILE"
+		return 1
+	fi
 
 	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge.
 	#

--- a/.agents/scripts/tests/test-interactive-claim-fence.sh
+++ b/.agents/scripts/tests/test-interactive-claim-fence.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Deterministic regression for the #30147 stale-recovery/duplicate-worker order.
+
+set -uo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d -t gh30274.XXXXXX)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+export CLAIM_STAMP_DIR="${TEST_ROOT}/claims"
+mkdir -p "$CLAIM_STAMP_DIR" "${HOME}/.aidevops/.agent-workspace"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); printf 'PASS %s\n' "$1"; return 0; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); printf 'FAIL %s\n' "$1"; return 0; }
+
+# Source the production helper, then replace external probes with deterministic
+# fixtures while retaining its stamp/worktree/head decision flow.
+# shellcheck source=../interactive-claim-fence.sh
+source "${SCRIPTS_DIR}/interactive-claim-fence.sh"
+_is_process_alive_and_matches() { [[ "$1" == "4242" ]]; }
+check_worktree_owner() { printf '4242|session-30147||30147|2026-08-14T19:54:06Z\n'; return 0; }
+
+WORKTREE="${TEST_ROOT}/worktree"
+REMOTE="${TEST_ROOT}/remote.git"
+git init --bare "$REMOTE" >/dev/null 2>&1 || exit 1
+git init "$WORKTREE" >/dev/null 2>&1 || exit 1
+git -C "$WORKTREE" config user.email test@example.invalid
+git -C "$WORKTREE" config user.name Test
+git -C "$WORKTREE" remote add origin "https://github.com/owner/repo.git"
+printf 'base\n' >"${WORKTREE}/fixture.txt"
+git -C "$WORKTREE" add fixture.txt
+git -C "$WORKTREE" commit -m base >/dev/null 2>&1
+git -C "$WORKTREE" branch -M main
+git -C "$WORKTREE" remote set-url --push origin "$REMOTE"
+git -C "$WORKTREE" push -u origin main >/dev/null 2>&1
+git -C "$WORKTREE" remote set-head origin main >/dev/null 2>&1
+
+STAMP="${CLAIM_STAMP_DIR}/owner-repo-30147.json"
+jq -n --arg worktree "$WORKTREE" --arg host "$(hostname 2>/dev/null || printf unknown)" \
+	'{issue:30147,slug:"owner/repo",worktree_path:$worktree,pid:4242,hostname:$host,owner_argv_hash:"fixture"}' >"$STAMP"
+
+if _interactive_claim_fence_blocks_dispatch 30147 owner/repo; then
+	pass "live interactive owner blocks dispatch beyond GitHub age thresholds"
+else
+	fail "live interactive owner blocks dispatch beyond GitHub age thresholds"
+fi
+
+printf 'interactive work\n' >>"${WORKTREE}/fixture.txt"
+git -C "$WORKTREE" add fixture.txt
+git -C "$WORKTREE" commit -m "interactive work" >/dev/null 2>&1
+WORKTREE_HEAD=$(git -C "$WORKTREE" rev-parse HEAD)
+if _interactive_claim_fence_blocks_merge 30147 owner/repo deadbeef; then
+	pass "different worker head cannot merge over unmerged interactive commits"
+else
+	fail "different worker head cannot merge over unmerged interactive commits"
+fi
+if _interactive_claim_fence_blocks_merge 30147 owner/repo "$WORKTREE_HEAD"; then
+	fail "interactive owner's exact head remains merge eligible"
+else
+	pass "interactive owner's exact head remains merge eligible"
+fi
+
+# Lock the event ordering: stale recovery must consult the local ownership fence
+# before comments, two-hour age, missing worker PID, or recovery mutation.
+STALE_FETCH_CALLED=0
+STALE_RECOVER_CALLED=0
+_stale_assignment_fetch_comments_json() { STALE_FETCH_CALLED=1; printf '[]'; return 0; }
+_recover_stale_assignment() { STALE_RECOVER_CALLED=1; return 0; }
+# shellcheck source=../dispatch-dedup-stale.sh
+source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
+if _is_stale_assignment 30147 owner/repo marcusquinn; then
+	fail "#30147 ordering preserves live ownership before stale recovery"
+elif [[ "$STALE_FETCH_CALLED" -eq 0 && "$STALE_RECOVER_CALLED" -eq 0 ]]; then
+	pass "#30147 ordering preserves live ownership before stale recovery"
+else
+	fail "#30147 ordering preserves live ownership before stale recovery"
+fi
+
+_is_process_alive_and_matches() { return 1; }
+if _interactive_claim_fence_blocks_dispatch 30147 owner/repo; then
+	fail "proven-dead local interactive owner remains dispatch-blocking"
+else
+	pass "proven-dead local interactive owner remains recoverable"
+fi
+
+printf '\n%s tests, %s failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-stale-recovery-age-floor.sh
+++ b/.agents/scripts/tests/test-stale-recovery-age-floor.sh
@@ -127,7 +127,7 @@ fi
 
 # gh pr list → empty (no open PR for stale recovery to detect)
 if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
-	printf ''
+	printf '[]\n'
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

Added a shared live-owner fence that protects authoritative interactive claim stamps and linked worktrees from stale recovery, queued worker publication, and duplicate PR merge.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh, .agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/interactive-claim-fence.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-interactive-claim-fence.sh, .agents/scripts/tests/test-stale-recovery-age-floor.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed the production fence against hermetic Git worktree, stamp, owner-registry, stale-recovery, dispatch, and merge-head fixtures; all focused suites plus ShellCheck and linters-local --changed passed.

Resolves #30274


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 16m and 220,916 tokens on this with the user in an interactive session.