### PR TITLE
GH#30301: Fix quota-safe privacy checks

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -873,24 +873,32 @@ while [[ $_i -lt ${#_modified_args[@]} ]]; do
 		_body_file_eq=1
 		;;
 	--comment)
-		_comment_idx=$_i
-		_comment_val="${_modified_args[_i + 1]:-}"
-		_comment_eq=0
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+			_comment_idx=$_i
+			_comment_val="${_modified_args[_i + 1]:-}"
+			_comment_eq=0
+		fi
 		;;
 	--comment=*)
-		_comment_idx=$_i
-		_comment_val="${_modified_args[_i]#--comment=}"
-		_comment_eq=1
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+			_comment_idx=$_i
+			_comment_val="${_modified_args[_i]#--comment=}"
+			_comment_eq=1
+		fi
 		;;
 	-c)
-		_comment_idx=$_i
-		_comment_val="${_modified_args[_i + 1]:-}"
-		_comment_eq=0
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+			_comment_idx=$_i
+			_comment_val="${_modified_args[_i + 1]:-}"
+			_comment_eq=0
+		fi
 		;;
 	-c=*)
-		_comment_idx=$_i
-		_comment_val="${_modified_args[_i]#-c=}"
-		_comment_eq=1
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+			_comment_idx=$_i
+			_comment_val="${_modified_args[_i]#-c=}"
+			_comment_eq=1
+		fi
 		;;
 	esac
 	_i=$((_i + 1))

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -873,28 +873,32 @@ while [[ $_i -lt ${#_modified_args[@]} ]]; do
 		_body_file_eq=1
 		;;
 	--comment)
-		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ||
+			"${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:close" ]]; then
 			_comment_idx=$_i
 			_comment_val="${_modified_args[_i + 1]:-}"
 			_comment_eq=0
 		fi
 		;;
 	--comment=*)
-		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ||
+			"${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:close" ]]; then
 			_comment_idx=$_i
 			_comment_val="${_modified_args[_i]#--comment=}"
 			_comment_eq=1
 		fi
 		;;
 	-c)
-		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ||
+			"${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:close" ]]; then
 			_comment_idx=$_i
 			_comment_val="${_modified_args[_i + 1]:-}"
 			_comment_eq=0
 		fi
 		;;
 	-c=*)
-		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ]]; then
+		if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:close" ||
+			"${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:close" ]]; then
 			_comment_idx=$_i
 			_comment_val="${_modified_args[_i]#-c=}"
 			_comment_eq=1

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -123,19 +123,27 @@ privacy_is_target_public() {
 		privacy_log WARN "gh CLI not installed — fail-open, allowing push to $slug"
 		return 2
 	fi
-	if ! "$gh_bin" auth status >/dev/null 2>&1; then
-		privacy_log WARN "gh not authenticated — fail-open, allowing push to $slug"
-		return 2
-	fi
-
 	# Use `.private | tostring` — NOT `.private // "unknown"`. The `//` operator
 	# treats `false` as null-ish, so `.private // "unknown"` returns "unknown"
 	# for every public repo. `tostring` returns "true", "false", or "null".
-	local is_private
-	is_private=$("$gh_bin" api "repos/${slug}" --jq '.private | tostring' 2>/dev/null) || {
-		privacy_log WARN "gh api repos/${slug} failed — fail-open"
-		return 2
-	}
+	# Do not gate this request on `gh auth status`: gh validates credentials via
+	# REST /user and reports an authenticated token as "invalid" when that REST
+	# resource is rate-limited. Query the required property directly, then fall
+	# back to GraphQL because its quota is independent from REST core quota.
+	local is_private owner repo graphql_query
+	owner="${slug%%/*}"
+	repo="${slug#*/}"
+	# shellcheck disable=SC2016 # GraphQL variables must reach gh literally.
+	graphql_query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){isPrivate}}'
+	if ! is_private=$("$gh_bin" api "repos/${slug}" --jq '.private | tostring' 2>/dev/null); then
+		is_private=$("$gh_bin" api graphql \
+			-f "query=${graphql_query}" \
+			-F "owner=${owner}" -F "name=${repo}" \
+			--jq '.data.repository.isPrivate | tostring' 2>/dev/null) || {
+			privacy_log WARN "gh REST and GraphQL privacy probes failed for $slug — fail-open"
+			return 2
+		}
+	fi
 
 	case "$is_private" in
 	true)

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -138,7 +138,7 @@ privacy_is_target_public() {
 	if ! is_private=$("$gh_bin" api "repos/${slug}" --jq '.private | tostring' 2>/dev/null); then
 		is_private=$("$gh_bin" api graphql \
 			-f "query=${graphql_query}" \
-			-F "owner=${owner}" -F "name=${repo}" \
+			-f "owner=${owner}" -f "name=${repo}" \
 			--jq '.data.repository.isPrivate | tostring' 2>/dev/null) || {
 			privacy_log WARN "gh REST and GraphQL privacy probes failed for $slug — fail-open"
 			return 2

--- a/.agents/scripts/test-privacy-guard-shim.sh
+++ b/.agents/scripts/test-privacy-guard-shim.sh
@@ -212,14 +212,23 @@ mkdir -p "$REAL_GH_DIR"
 RECORD_FILE="${TMP}/gh-invocation.log"
 AUTH_RECORD_FILE="${TMP}/gh-auth-invocation.log"
 API_RECORD_FILE="${TMP}/gh-api-invocation.log"
+REST_RATE_LIMIT_FILE="${TMP}/rest-rate-limited"
 cat >"$REAL_GH_DIR/gh" <<STUB
 #!/usr/bin/env bash
 if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then
 	printf '%s\n' "REAL_GH_AUTH_INVOKED" > '$AUTH_RECORD_FILE'
-	exit 0
+	exit 1
 fi
 if [[ "\${1:-}" == "api" && "\${2:-}" == repos/* ]]; then
-	printf '%s\n' "REAL_GH_API_INVOKED" > '$API_RECORD_FILE'
+	printf '%s\n' "REST" >> '$API_RECORD_FILE'
+	if [[ -f '$REST_RATE_LIMIT_FILE' ]]; then
+		exit 1
+	fi
+	printf '%s\n' false
+	exit 0
+fi
+if [[ "\${1:-}" == "api" && "\${2:-}" == "graphql" ]]; then
+	printf '%s\n' "GRAPHQL" >> '$API_RECORD_FILE'
 	printf '%s\n' false
 	exit 0
 fi
@@ -275,16 +284,32 @@ run_shim() {
 	return 0
 }
 
-# -- Test 2.0: cold privacy probes bypass the active shim and use native gh
+# -- Test 2.0: cold privacy probes bypass the active shim and query the target
+# directly instead of trusting `gh auth status`.
 rm -f "$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
 	"$RECORD_FILE" "$AUTH_RECORD_FILE" "$API_RECORD_FILE"
 out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean cold-cache content" 2>&1)
 rc=$?
-if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] &&
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && ! -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] &&
+	grep -q '^REST$' "$API_RECORD_FILE" &&
 	[[ "$out" != *"gh not authenticated"* ]]; then
-	pass "cold privacy probes use native gh without shim recursion"
+	pass "cold privacy probe does not trust gh auth status"
 else
-	fail "expected native auth/API/final invocations without auth warning. rc=$rc out='$out'"
+	fail "expected native REST/final invocations without auth-status probe. rc=$rc out='$out'"
+fi
+
+# -- Test 2.0a: REST quota exhaustion falls back to authenticated GraphQL.
+rm -f "$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
+	"$RECORD_FILE" "$AUTH_RECORD_FILE" "$API_RECORD_FILE"
+touch "$REST_RATE_LIMIT_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean quota fallback content" 2>&1)
+rc=$?
+rm -f "$REST_RATE_LIMIT_FILE"
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && ! -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] &&
+	grep -q '^REST$' "$API_RECORD_FILE" && grep -q '^GRAPHQL$' "$API_RECORD_FILE"; then
+	pass "REST quota exhaustion falls back to GraphQL privacy probe"
+else
+	fail "expected REST then GraphQL privacy probes without auth-status probe. rc=$rc out='$out'"
 fi
 
 # Restore the warm cache used by the remaining integration cases.

--- a/.agents/scripts/test-privacy-guard-shim.sh
+++ b/.agents/scripts/test-privacy-guard-shim.sh
@@ -213,6 +213,7 @@ RECORD_FILE="${TMP}/gh-invocation.log"
 AUTH_RECORD_FILE="${TMP}/gh-auth-invocation.log"
 API_RECORD_FILE="${TMP}/gh-api-invocation.log"
 REST_RATE_LIMIT_FILE="${TMP}/rest-rate-limited"
+REQUIRE_RAW_FIELDS_FILE="${TMP}/require-raw-graphql-fields"
 cat >"$REAL_GH_DIR/gh" <<STUB
 #!/usr/bin/env bash
 if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then
@@ -229,6 +230,11 @@ if [[ "\${1:-}" == "api" && "\${2:-}" == repos/* ]]; then
 fi
 if [[ "\${1:-}" == "api" && "\${2:-}" == "graphql" ]]; then
 	printf '%s\n' "GRAPHQL" >> '$API_RECORD_FILE'
+	if [[ -f '$REQUIRE_RAW_FIELDS_FILE' ]]; then
+		for arg in "\$@"; do
+			[[ "\$arg" != "-F" ]] || exit 1
+		done
+	fi
 	printf '%s\n' false
 	exit 0
 fi
@@ -302,12 +308,13 @@ fi
 rm -f "$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
 	"$RECORD_FILE" "$AUTH_RECORD_FILE" "$API_RECORD_FILE"
 touch "$REST_RATE_LIMIT_FILE"
-out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean quota fallback content" 2>&1)
+touch "$REQUIRE_RAW_FIELDS_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo 123/true --title "test" --body "Clean quota fallback content" 2>&1)
 rc=$?
-rm -f "$REST_RATE_LIMIT_FILE"
+rm -f "$REST_RATE_LIMIT_FILE" "$REQUIRE_RAW_FIELDS_FILE"
 if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && ! -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] &&
 	grep -q '^REST$' "$API_RECORD_FILE" && grep -q '^GRAPHQL$' "$API_RECORD_FILE"; then
-	pass "REST quota exhaustion falls back to GraphQL privacy probe"
+	pass "REST quota exhaustion falls back with string-safe GraphQL variables"
 else
 	fail "expected REST then GraphQL privacy probes without auth-status probe. rc=$rc out='$out'"
 fi

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -78,6 +78,22 @@ for close_form in long equals short; do
 	fi
 done
 
+for close_form in long equals short; do
+	_reset_log
+	case "$close_form" in
+	long) "$SHIM_RUN" pr close 125 --repo owner/repo --comment "close evidence" 2>/dev/null ;;
+	equals) "$SHIM_RUN" pr close 125 --repo owner/repo --comment="close evidence" 2>/dev/null ;;
+	short) "$SHIM_RUN" pr close 125 --repo owner/repo -c "close evidence" 2>/dev/null ;;
+	esac
+	argv=$(_read_argv)
+	close_count=$(grep -c '^close$' "$STUB_GH_LOG" 2>/dev/null || true)
+	if [[ "$argv" == *"<!-- aidevops:sig -->"* && "$close_count" -eq 1 ]]; then
+		_pass "${close_form} PR-close comment signs exactly one close mutation"
+	else
+		_fail "${close_form} PR-close comment signing" "argv: $argv"
+	fi
+done
+
 _reset_log
 "$SHIM_RUN" issue close 124 --repo owner/repo --reason completed 2>/dev/null
 argv=$(_read_argv)


### PR DESCRIPTION
## Summary

- stop using `gh auth status` as a prerequisite for repository-visibility checks
- fall back from the REST repository probe to GraphQL when REST quota is exhausted
- preserve `pr review --comment --body` privacy scanning by limiting comment-value parsing to `issue close`

## Evidence

GitHub CLI validates `gh auth status` through REST `/user`. During the observed REST throttling, that endpoint returned HTTP 403 and CLI reported the stored token as invalid, while authenticated GraphQL `viewer.login` still succeeded. The privacy guard trusted the false-negative status and blocked a release PR.

The base privacy-shim suite also failed its review-body leak case because boolean `pr review --comment` consumed the following `--body` flag as though it were an `issue close --comment` value.

## Verification

- `.agents/scripts/test-privacy-guard-shim.sh` — 28/28 passed
- `.agents/scripts/test-privacy-guard.sh` — 27/27 passed
- `.agents/scripts/tests/test-gh-shim.sh` — 128/128 passed
- `shellcheck .agents/scripts/privacy-guard-helper.sh .agents/scripts/test-privacy-guard-shim.sh .agents/scripts/gh`
- `git diff --check`

Resolves #30301

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 4h 40m and 1,415,809 tokens on this with the user in an interactive session.