### PR TITLE
t18244: Make generated writing and GitHub briefs reader-first

### DIFF
--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -29,6 +29,13 @@ Avoiding AI patterns is half the job. Sterile, voiceless writing is as obvious a
 
 **Soulless signs:** uniform sentence length, no opinions, no uncertainty, no first-person, no humour, reads like a press release. **Fix:** Have opinions. Vary rhythm. Acknowledge mixed feelings. Use "I" when it fits. Be specific. Let some mess in.
 
+### Evidence for a known voice
+
+- Prefer explicit corrections and approved before/after edits.
+- Use current published copy as supporting evidence; treat older copy cautiously.
+- Do not infer public voice from hurried prompts, punctuation, or chat formatting.
+- Humanise the prose, not technical facts, identifiers, or verification steps.
+
 ## Patterns
 
 Format: **#. Name** — *trigger words* — problem — fix.

--- a/.agents/content/production-writing.md
+++ b/.agents/content/production-writing.md
@@ -24,7 +24,7 @@ model: standard
 - **Hook-first in every format** -- First line/sentence/second must hook
 - **8-second dialogue chunks** for AI video -- Longer blocks cause unnatural pacing
 - **Platform-native voice** -- No cross-posting smell (each platform has distinct expectations)
-- **One CTA per piece** -- Clarity beats comprehensiveness
+- **At most one genuine CTA** -- Omit it when no action is useful
 - **Scene-by-scene for video** -- Include B-roll directions, not just dialogue
 
 <!-- AI-CONTEXT-END -->
@@ -33,7 +33,7 @@ model: standard
 
 Before generating any content:
 
-1. What is the one thing the reader should do after reading this?
+1. What should the reader understand, decide, or do? Do not invent an action.
 2. Is value front-loaded -- useful from the first paragraph alone?
 3. Is every section earning its place, or padding?
 4. Does the tone match the context deliberately, not by default?
@@ -65,8 +65,8 @@ Target: 8-15 min (1,200-2,200 words); example timeline below runs ~11 min. Every
 ## SCENE 4: [Proof/Examples] (8:00-10:00)
 [Narration]  [Visual: ...]
 
-## CTA (10:00-10:30)
-[Soft sell -- natural transition from content]
+## CTA (optional, 10:00-10:30)
+[If useful: soft sell -- natural transition from content]
 [Visual: end screen, subscribe animation]
 
 ## END SCREEN (10:30-11:00)
@@ -83,7 +83,7 @@ Target: 30-60 sec (75-150 words). Hook in first 1-3 seconds. Fast cuts (1-3s per
 [Setup -- 5-12 seconds]
 [Payoff -- 10-20 seconds]
 [Twist or reinforcement -- 5-10 seconds]
-[CTA -- 3 seconds]
+[Optional CTA -- 3 seconds, only when the piece has a genuine next action]
 
 CAPTION: [Full text for silent viewers]
 SOUND: [Mood/genre suggestion]
@@ -94,7 +94,7 @@ CUTS: [Cut timing -- e.g., "cut every 1.5s"]
 
 #### X (Twitter)
 
-**Thread**: POST 1 (HOOK, under 280 chars, standalone value) → POST 2 (expand) → POST 3-7 (one point per post, each standalone) → POST 8 (CTA: follow, bookmark, reply).
+**Thread**: POST 1 (HOOK, under 280 chars, standalone value) → POST 2 (expand) → POST 3-7 (one point per post, each standalone) → final post (genuine CTA or final useful point).
 
 **Single post**: Under 280 chars. Front-load value. Personality-forward.
 
@@ -109,7 +109,7 @@ Target: 1,200-1,500 characters. Professional but not corporate.
 
 [Key takeaway -- one sentence]
 
-[CTA -- question or invitation to discuss]
+[Optional CTA -- a genuine question or useful next action]
 
 #hashtag1 #hashtag2 #hashtag3
 ```
@@ -129,7 +129,7 @@ Body:
 
 ### Blog Draft
 
-**SEO rules**: Target keyword in H1, first paragraph, and 1-2 H2s. 1,500-2,500 words. 3-5 internal links. Meta title under 60 chars (keyword-front-loaded). Meta description under 155 chars with CTA.
+**SEO rules**: Target keyword in H1, first paragraph, and 1-2 H2s. 1,500-2,500 words. 3-5 internal links. Meta title under 60 chars (keyword-front-loaded). Meta description under 155 chars with clear value; add a CTA only when useful.
 
 ```text
 # [H1 -- Target keyword, under 60 chars]
@@ -151,8 +151,8 @@ Body:
 - [Bullet 2]
 - [Bullet 3]
 
-## [CTA Section]
-[Natural transition to offer/next step]
+## [Optional CTA Section]
+[Include only when there is a useful offer or next step]
 ```
 
 ### Email Copy
@@ -167,7 +167,7 @@ PREVIEW: [Under 90 chars -- extends the subject line]
 
 [Body -- single narrative thread]
 
-[CTA -- one clear action, button or link]
+[Optional CTA -- one clear action, button, or link when the email needs one]
 
 P.S. [Secondary hook or bonus value]
 ```
@@ -205,7 +205,7 @@ EMAIL 5 (Day 7): Last chance + FAQ
 
 ## OUTRO (15:00-16:00)
 - [Summary -- one sentence]
-- [CTA -- subscribe, review, share]
+- [Optional CTA -- subscribe, review, or share when useful]
 - [Next episode tease]
 
 ## SHOW NOTES
@@ -231,7 +231,7 @@ EMAIL 5 (Day 7): Last chance + FAQ
 
 - [ ] Hook in first line/sentence
 - [ ] Voice matches platform (see table above)
-- [ ] Single clear CTA
+- [ ] At most one useful CTA; omitted when no action is needed
 - [ ] Platform-native language (no cross-posting smell)
 - [ ] Video: dialogue chunks under 8s, captions included, B-roll directions present
 - [ ] Blog: SEO elements present (meta title, description, keywords)

--- a/.agents/scripts/brief-readiness-parser.awk
+++ b/.agents/scripts/brief-readiness-parser.awk
@@ -47,7 +47,9 @@ BEGIN {
 
 mode == "unfenced" {
 	if (update_fence($0)) next
-	if (!in_fence) print
+	line = $0
+	if (tolower(line) ~ /^## done when[[:space:]]*$/) line = "## Acceptance Criteria"
+	if (!in_fence) print line
 	next
 }
 
@@ -75,6 +77,7 @@ mode == "visible" {
 		}
 		break
 	}
+	if (tolower(line) ~ /^## done when[[:space:]]*$/) line = "## Acceptance Criteria"
 	if (length(line) > 0) print line
 	next
 }

--- a/.agents/scripts/issue-sync-lib-compose.sh
+++ b/.agents/scripts/issue-sync-lib-compose.sh
@@ -36,6 +36,9 @@
 [[ -n "${_ISSUE_SYNC_LIB_COMPOSE_LOADED:-}" ]] && return 0
 _ISSUE_SYNC_LIB_COMPOSE_LOADED=1
 
+ISSUE_SYNC_DETAILS_OPEN="<details>"
+ISSUE_SYNC_DETAILS_CLOSE="</details>"
+
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	# Pure-bash dirname replacement — avoids external binary dependency
@@ -169,8 +172,8 @@ _post_parent_task_no_markers_warning() {
 	# t2572: comments API caps at 30/page; --paginate concatenates. Cannot
 	# combine --slurp with --jq (gh api rejects). Stream per-page and count.
 	existing=$(gh api --paginate "repos/${slug}/issues/${issue_num}/comments" \
-		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
-		| wc -l | tr -d ' ') || existing=""
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" |
+		wc -l | tr -d ' ') || existing=""
 	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
 		return 1
 	fi
@@ -292,19 +295,19 @@ _compose_issue_plan_sections() {
 
 	local extra_sections
 	extra_sections=$(extract_plan_extra_sections "$plan_section")
-	[[ -n "$extra_sections" ]] && body="$body"$'\n\n'"<details><summary>Plan: Context &amp; Architecture</summary>"$'\n'"$extra_sections"$'\n\n'"</details>"
+	[[ -n "$extra_sections" ]] && body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary>Plan: Context &amp; Architecture</summary>"$'\n'"$extra_sections"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 
 	local progress
 	progress=$(extract_plan_progress "$plan_section")
-	[[ -n "$progress" ]] && body="$body"$'\n\n'"<details><summary>Plan: Progress</summary>"$'\n\n'"$progress"$'\n\n'"</details>"
+	[[ -n "$progress" ]] && body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary>Plan: Progress</summary>"$'\n\n'"$progress"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 
 	local decisions
 	decisions=$(extract_plan_decisions "$plan_section")
-	[[ -n "$decisions" ]] && body="$body"$'\n\n'"<details><summary>Plan: Decision Log</summary>"$'\n\n'"$decisions"$'\n\n'"</details>"
+	[[ -n "$decisions" ]] && body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary>Plan: Decision Log</summary>"$'\n\n'"$decisions"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 
 	local discoveries
 	discoveries=$(extract_plan_discoveries "$plan_section")
-	[[ -n "$discoveries" ]] && body="$body"$'\n\n'"<details><summary>Plan: Discoveries</summary>"$'\n\n'"$discoveries"$'\n\n'"</details>"
+	[[ -n "$discoveries" ]] && body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary>Plan: Discoveries</summary>"$'\n\n'"$discoveries"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 
 	echo "$body"
 	return 0
@@ -334,7 +337,7 @@ _compose_issue_related_files() {
 			rel_path="${file#"$project_root"/}"
 			file_summary=$(extract_file_summary "$file" 30)
 			if [[ -n "$file_summary" ]]; then
-				body="$body"$'\n\n'"<details><summary><code>$rel_path</code></summary>"$'\n\n'"$file_summary"$'\n\n'"</details>"
+				body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary><code>$rel_path</code></summary>"$'\n\n'"$file_summary"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 			else
 				body="$body"$'\n\n'"- [\`$rel_path\`]($rel_path)"
 			fi
@@ -393,7 +396,7 @@ _compose_issue_content() {
 	local blocks="$4"
 	local notes="$5"
 
-	[[ -n "$description" ]] && body="$body"$'\n\n'"## Description"$'\n\n'"$description"
+	[[ -n "$description" ]] && body="$body"$'\n\n'"## Outcome"$'\n\n'"$description"
 	[[ -n "$blocked_by" ]] && body="$body"$'\n\n'"**Blocked by:** \`$blocked_by\`"
 	[[ -n "$blocks" ]] && body="$body"$'\n'"**Blocks:** \`$blocks\`"
 	[[ -n "$notes" ]] && body="$body"$'\n\n'"## Notes"$'\n\n'"$notes"
@@ -415,7 +418,7 @@ _compose_issue_brief_workflow_reference() {
 		return 0
 	fi
 
-	body="$body"$'\n\n'"## Brief Workflow"$'\n\n'"This issue body is composed under \`.agents/workflows/brief.md\`. Newly queued auto-dispatch work must pass its \`Dispatch Readiness Contract (brief schema v2)\`: complete write surface, hazards and compatibility, executable verification mapped to affected surfaces, and positive plus negative/regression acceptance criteria."
+	body="$body"$'\n\n'"$ISSUE_SYNC_DETAILS_OPEN"$'\n'"<summary>Brief workflow contract</summary>"$'\n\n'"## Brief Workflow"$'\n\n'"This issue body is composed under \`.agents/workflows/brief.md\`. Newly queued auto-dispatch work must pass its \`Dispatch Readiness Contract (brief schema v2)\`: complete write surface, hazards and compatibility, executable verification mapped to affected surfaces, and positive plus negative/regression acceptance criteria."$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 
 	echo "$body"
 	return 0
@@ -516,9 +519,8 @@ _compose_issue_sections() {
 
 # Extract worker guidance from the brief's "How" section (t1900).
 # Promotes the complete schema-v2 How contract, including write surface,
-# hazards/compatibility, and verification-before-dispatch sections.
-# into a top-level "Worker Guidance" section in the issue body so workers
-# see actionable context immediately without reading the full brief.
+# hazards/compatibility, and verification-before-dispatch sections. The raw
+# headings remain machine-readable inside a collapsed reader-facing section.
 # Arguments:
 #   $1 - current body text
 #   $2 - brief_file path
@@ -547,6 +549,7 @@ _compose_issue_worker_guidance() {
 	# Historical briefs retain the t2063 heading gate. Schema-v2 briefs use the
 	# complete readiness validator so placeholder-only guidance is never promoted.
 	local has_files has_steps is_schema_v2
+	local promote=0
 	has_files=$(echo "$how_section" | grep -ic '### Files to Modify\|EDIT:\|NEW:' || true)
 	has_steps=$(echo "$how_section" | grep -ic '### Implementation Steps' || true)
 	is_schema_v2=$(grep -cF '<!-- aidevops:brief-schema=v2 -->' "$brief_file" || true)
@@ -556,10 +559,25 @@ _compose_issue_worker_guidance() {
 		local brief_body=""
 		brief_body=$(<"$brief_file")
 		if [[ -f "$readiness_helper" ]] && bash "$readiness_helper" check --body "$brief_body" >/dev/null 2>&1; then
-			body="$body"$'\n\n'"## Worker Guidance"$'\n\n'"$how_section"
+			promote=1
 		fi
 	elif [[ "$has_files" -gt 0 || "$has_steps" -gt 0 ]]; then
-		body="$body"$'\n\n'"## Worker Guidance"$'\n\n'"$how_section"
+		promote=1
+	fi
+
+	if [[ "$promote" -eq 1 ]]; then
+		local done_when=""
+		if ! printf '%s\n' "$body" | grep -qiE '^## (Done when|Acceptance Criteria)[[:space:]]*$'; then
+			done_when=$(awk '
+				/^## Acceptance [Cc]riteria[[:space:]]*$/ { capture=1; next }
+				/^## / && capture { exit }
+				capture && /^- \[[ xX]\]/ { print }
+			' "$brief_file")
+		fi
+		if [[ -n "$done_when" ]]; then
+			body="$body"$'\n\n'"## Done when"$'\n\n'"$done_when"
+		fi
+		body="$body"$'\n\n'"$ISSUE_SYNC_DETAILS_OPEN"$'\n'"<summary>Worker implementation contract</summary>"$'\n\n'"## Worker Guidance"$'\n\n'"$how_section"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 	fi
 
 	echo "$body"
@@ -580,14 +598,19 @@ _compose_issue_brief() {
 	fi
 
 	local brief_content
-	brief_content=$(awk '
+	local drop_promoted_how=0
+	[[ "$body" == *"## Worker Guidance"* ]] && drop_promoted_how=1
+	brief_content=$(awk -v drop_how="$drop_promoted_how" '
 		BEGIN { in_front=0; front_done=0 }
 		/^---$/ && !front_done { in_front=!in_front; if(!in_front) front_done=1; next }
-		!in_front { print }
+		!in_front && /^# / { next }
+		!in_front && drop_how == 1 && /^## How([[:space:](]|$)/ { in_how=1; next }
+		!in_front && in_how && /^## / { in_how=0 }
+		!in_front && !in_how { print }
 	' "$brief_file")
 
 	if [[ -n "$brief_content" && ${#brief_content} -gt 10 ]]; then
-		body="$body"$'\n\n'"## Task Brief"$'\n\n'"$brief_content"
+		body="$body"$'\n\n'"$ISSUE_SYNC_DETAILS_OPEN"$'\n'"<summary>Full task brief and audit context</summary>"$'\n\n'"## Task Brief"$'\n\n'"$brief_content"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 	fi
 
 	echo "$body"

--- a/.agents/scripts/issue-sync-lib-compose.sh
+++ b/.agents/scripts/issue-sync-lib-compose.sh
@@ -599,14 +599,18 @@ _compose_issue_brief() {
 
 	local brief_content
 	local drop_promoted_how=0
+	local drop_promoted_acceptance=0
 	[[ "$body" == *"## Worker Guidance"* ]] && drop_promoted_how=1
-	brief_content=$(awk -v drop_how="$drop_promoted_how" '
+	[[ "$body" == *"## Done when"* ]] && drop_promoted_acceptance=1
+	brief_content=$(awk -v drop_how="$drop_promoted_how" -v drop_acceptance="$drop_promoted_acceptance" '
 		BEGIN { in_front=0; front_done=0 }
 		/^---$/ && !front_done { in_front=!in_front; if(!in_front) front_done=1; next }
 		!in_front && /^# / { next }
 		!in_front && drop_how == 1 && /^## How([[:space:](]|$)/ { in_how=1; next }
 		!in_front && in_how && /^## / { in_how=0 }
-		!in_front && !in_how { print }
+		!in_front && drop_acceptance == 1 && /^## Acceptance [Cc]riteria[[:space:]]*$/ { in_acceptance=1; next }
+		!in_front && in_acceptance && /^## / { in_acceptance=0 }
+		!in_front && !in_how && !in_acceptance { print }
 	' "$brief_file")
 
 	if [[ -n "$brief_content" && ${#brief_content} -gt 10 ]]; then

--- a/.agents/scripts/tests/test-brief-inline-classifier.sh
+++ b/.agents/scripts/tests/test-brief-inline-classifier.sh
@@ -356,11 +356,14 @@ fi
 promoted_body=$(_compose_issue_worker_guidance "base body" "$TMP/brief-schema-v2.md")
 result=$(_compose_issue_brief "$promoted_body" "$TMP/brief-schema-v2.md")
 files_heading_count=$(printf '%s\n' "$result" | awk '/^### Files to Modify$/ {n++} END {print n+0}')
-if [[ "$files_heading_count" == "1" ]] && [[ "$result" == *"<summary>Worker implementation contract</summary>"* ]] && [[ "$result" == *"<summary>Full task brief and audit context</summary>"* ]]; then
-	pass "B4 promoted implementation contract is not duplicated in the full brief"
+criterion_count=$(printf '%s\n' "$result" | awk '/Readers observe one complete state record\./ {n++} END {print n+0}')
+readiness_output=$("$READINESS_HELPER" check --body "$result")
+readiness_rc=$?
+if [[ "$files_heading_count" == "1" ]] && [[ "$criterion_count" == "1" ]] && [[ "$result" != *"## Acceptance Criteria"* ]] && [[ "$result" == *"<summary>Worker implementation contract</summary>"* ]] && [[ "$result" == *"<summary>Full task brief and audit context</summary>"* ]] && [[ $readiness_rc -eq 0 ]] && [[ "$readiness_output" == *"WORKER_READY=true"* ]]; then
+	pass "B4 promoted implementation and completion contracts are not duplicated"
 else
-	fail "B4 promoted contract deduplication" \
-		"expected one Files to Modify heading across collapsed worker and full brief sections, got $files_heading_count"
+	fail "B4 promoted contract deduplication and readiness" \
+		"expected one implementation heading, one criterion, no duplicate acceptance heading, and worker-ready output; files=$files_heading_count criteria=$criterion_count readiness=$readiness_rc output=$readiness_output"
 fi
 
 # Test B5: generated TODO descriptions use a reader-first Outcome heading

--- a/.agents/scripts/tests/test-brief-inline-classifier.sh
+++ b/.agents/scripts/tests/test-brief-inline-classifier.sh
@@ -231,10 +231,10 @@ shellcheck state.sh
 BRIEF
 
 result=$(_compose_issue_worker_guidance "base body" "$TMP/brief-schema-v2.md")
-if [[ "$result" == *"## Worker Guidance"* ]] && [[ "$result" == *"### Complete Write Surface"* ]] && [[ "$result" == *"### Hazards and Compatibility"* ]] && [[ "$result" == *"### Verification Before Dispatch"* ]]; then
-	pass "A4 complete schema-v2 sections are promoted together"
+if [[ "$result" == *"## Done when"* ]] && [[ "$result" == *"<summary>Worker implementation contract</summary>"* ]] && [[ "$result" == *"## Worker Guidance"* ]] && [[ "$result" == *"### Complete Write Surface"* ]] && [[ "$result" == *"### Hazards and Compatibility"* ]] && [[ "$result" == *"### Verification Before Dispatch"* ]]; then
+	pass "A4 complete schema-v2 sections are promoted behind a reader summary"
 else
-	fail "A4 schema-v2 promotion" "expected all new readiness sections in Worker Guidance"
+	fail "A4 schema-v2 promotion" "expected Done when plus all readiness sections in collapsed Worker Guidance"
 fi
 
 # Test A5: incomplete schema-v2 guidance is not promoted
@@ -327,20 +327,20 @@ Test frontmatter stripping.
 BRIEF
 
 result=$(_compose_issue_brief "base body" "$TMP/brief-with-frontmatter.md")
-if [[ "$result" == *"## Task Brief"* ]] && [[ "$result" != *"mode: subagent"* ]]; then
-	pass "B1 full brief appended with frontmatter stripped"
+if [[ "$result" == *"<summary>Full task brief and audit context</summary>"* ]] && [[ "$result" == *"## Task Brief"* ]] && [[ "$result" != *"mode: subagent"* ]] && [[ "$result" != *"# t9003: brief with frontmatter"* ]]; then
+	pass "B1 full brief collapsed with frontmatter and duplicate title stripped"
 else
 	fail "B1 frontmatter strip + append" \
-		"expected '## Task Brief' present and 'mode: subagent' absent"
+		"expected collapsed Task Brief without frontmatter or duplicate title"
 fi
 
 # Test B2: central brief workflow reference is appended once
 result=$(_compose_issue_brief_workflow_reference "base body")
-if [[ "$result" == *"## Brief Workflow"* ]] && [[ "$result" == *".agents/workflows/brief.md"* ]]; then
-	pass "B2 brief workflow reference appended"
+if [[ "$result" == *"<summary>Brief workflow contract</summary>"* ]] && [[ "$result" == *"## Brief Workflow"* ]] && [[ "$result" == *".agents/workflows/brief.md"* ]]; then
+	pass "B2 brief workflow reference appended behind a collapsed summary"
 else
 	fail "B2 brief workflow reference" \
-		"expected Brief Workflow section with .agents/workflows/brief.md pointer"
+		"expected collapsed Brief Workflow section with .agents/workflows/brief.md pointer"
 fi
 
 result=$(_compose_issue_brief_workflow_reference "$result")
@@ -350,6 +350,25 @@ if [[ "$case_count" == "1" ]]; then
 else
 	fail "B3 brief workflow reference idempotency" \
 		"expected one Brief Workflow section, got $case_count"
+fi
+
+# Test B4: promoted How content appears once in the composed raw body
+promoted_body=$(_compose_issue_worker_guidance "base body" "$TMP/brief-schema-v2.md")
+result=$(_compose_issue_brief "$promoted_body" "$TMP/brief-schema-v2.md")
+files_heading_count=$(printf '%s\n' "$result" | awk '/^### Files to Modify$/ {n++} END {print n+0}')
+if [[ "$files_heading_count" == "1" ]] && [[ "$result" == *"<summary>Worker implementation contract</summary>"* ]] && [[ "$result" == *"<summary>Full task brief and audit context</summary>"* ]]; then
+	pass "B4 promoted implementation contract is not duplicated in the full brief"
+else
+	fail "B4 promoted contract deduplication" \
+		"expected one Files to Modify heading across collapsed worker and full brief sections, got $files_heading_count"
+fi
+
+# Test B5: generated TODO descriptions use a reader-first Outcome heading
+result=$(_compose_issue_content "metadata" "Change the rendered body." "" "" "")
+if [[ "$result" == *"## Outcome"* ]] && [[ "$result" != *"## Description"* ]]; then
+	pass "B5 generated issue content uses Outcome instead of Description"
+else
+	fail "B5 reader-first issue outcome" "expected Outcome heading without Description"
 fi
 
 # =============================================================================
@@ -479,6 +498,13 @@ export PATH
 source "$HELPER" >/dev/null 2>&1 || true
 PATH="$STUB_BIN:$PATH"
 export PATH
+
+# This test owns enrich classification, not the shared public-write guard.
+# Keep edits observable through the gh stub without requiring live repo state.
+gh_issue_edit_safe() {
+	gh issue edit "$@"
+	return $?
+}
 
 # Setup for Class D tests — simulate PROJECT_ROOT + brief paths
 D_REPO_ROOT="$TMP/drepo"

--- a/.agents/scripts/tests/test-brief-readiness.sh
+++ b/.agents/scripts/tests/test-brief-readiness.sh
@@ -449,6 +449,9 @@ ${BODY_V2_COMPLETE}
 
 </details>"
 
+BODY_V2_DONE_WHEN=$(printf '%s\n' "$BODY_V2_COMPLETE" | sed \
+	-e 's/^## Acceptance Criteria$/## Done when/')
+
 # Short concrete paths remain substantive, and Bun is a supported verifier.
 # shellcheck disable=SC2016
 BODY_V2_SHORT_PATH_BUN=$(printf '%s\n' "$BODY_V2_COMPLETE" | sed \
@@ -860,6 +863,15 @@ if [[ $rc -eq 0 && "$output" == *"WORKER_READY=true"* && "$output" == *"VALIDATI
 	pass "T32: collapsed worker contract remains schema-v2 ready"
 else
 	fail "T32: collapsed worker contract readiness" "got exit $rc, output: $output"
+fi
+
+# --- Test 33: reader-facing Done when is accepted as the criteria contract ---
+output=$("$HELPER" check --body "$BODY_V2_DONE_WHEN")
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"WORKER_READY=true"* && "$output" == *"VALIDATION_ERRORS=none"* ]]; then
+	pass "T33: Done when remains schema-v2 ready"
+else
+	fail "T33: Done when readiness alias" "got exit $rc, output: $output"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-brief-readiness.sh
+++ b/.agents/scripts/tests/test-brief-readiness.sh
@@ -442,6 +442,13 @@ BODY_V2_WITH_COMMAND_PLACEHOLDER="${BODY_V2_COMPLETE}
 
 <details><summary>Verification still required</summary>Run <command> before dispatch.</details>"
 
+BODY_V2_COLLAPSED_CONTRACT="<details>
+<summary>Worker implementation contract</summary>
+
+${BODY_V2_COMPLETE}
+
+</details>"
+
 # Short concrete paths remain substantive, and Bun is a supported verifier.
 # shellcheck disable=SC2016
 BODY_V2_SHORT_PATH_BUN=$(printf '%s\n' "$BODY_V2_COMPLETE" | sed \
@@ -571,7 +578,7 @@ mkdir -p "$TMP_REPO/todo/tasks"
 
 # Stub gh command for offline testing
 GH_STUB_DIR=$(mktemp -d)
-cat > "$GH_STUB_DIR/gh" <<'GHSTUB'
+cat >"$GH_STUB_DIR/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 # Stub gh for test-brief-readiness.sh
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
@@ -604,7 +611,7 @@ else
 fi
 
 # Check stub does not duplicate full template (should be ≤20 lines)
-line_count=$(wc -l < "$brief_file" 2>/dev/null || echo 999)
+line_count=$(wc -l <"$brief_file" 2>/dev/null || echo 999)
 if [[ $line_count -le 25 ]]; then
 	pass "T7c: stub brief is ≤25 lines ($line_count)"
 else
@@ -612,7 +619,7 @@ else
 fi
 
 # --- Test 8: Stub skips if brief already exists ---
-echo "# Existing brief" > "$brief_file"
+echo "# Existing brief" >"$brief_file"
 PATH="$GH_STUB_DIR:$PATH" "$HELPER" stub "t9999" "12345" "owner/repo" "$TMP_REPO" 2>/dev/null
 existing_content=$(cat "$brief_file")
 if [[ "$existing_content" == "# Existing brief" ]]; then
@@ -624,7 +631,7 @@ fi
 # --- Test 9: Similarity scoring ---
 # Create a brief that mostly duplicates the worker-ready body
 sim_brief_file=$(mktemp)
-printf '%s\n' "$BODY_WORKER_READY" > "$sim_brief_file"
+printf '%s\n' "$BODY_WORKER_READY" >"$sim_brief_file"
 
 output=$("$HELPER" similarity "$sim_brief_file" --body "$BODY_WORKER_READY" 2>/dev/null)
 sim_rc=$?
@@ -639,7 +646,7 @@ else
 fi
 
 # Low similarity: brief with different content
-echo "Completely different content that shares nothing with the issue body whatsoever" > "$sim_brief_file"
+echo "Completely different content that shares nothing with the issue body whatsoever" >"$sim_brief_file"
 output=$("$HELPER" similarity "$sim_brief_file" --body "$BODY_WORKER_READY" 2>/dev/null)
 similarity=$(printf '%s\n' "$output" | grep '^SIMILARITY=' | sed 's/SIMILARITY=//')
 
@@ -844,6 +851,15 @@ if [[ "$output" == *"WORKER_READY=false"* && "$output" == *"placeholder:unfilled
 	pass "T31: generated wrappers preserve and reject inner <command> placeholders"
 else
 	fail "T31: generated wrapper inner-text preservation" "output: $output"
+fi
+
+# --- Test 32: a complete schema-v2 contract remains ready inside details ---
+output=$("$HELPER" check --body "$BODY_V2_COLLAPSED_CONTRACT")
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"WORKER_READY=true"* && "$output" == *"VALIDATION_ERRORS=none"* ]]; then
+	pass "T32: collapsed worker contract remains schema-v2 ready"
+else
+	fail "T32: collapsed worker contract readiness" "got exit $rc, output: $output"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -124,7 +124,17 @@ brief unless that brief has been migrated to this complete contract.
 
 ## Core Rule
 
-**The brief IS the product.** A vague brief wastes high-capability reasoning, while a mechanically complete brief can run reliably at a lower workload tier. Invest the effort in decision-relevant context, not question or token quotas.
+**The executable contract is the product.** A vague brief wastes high-capability reasoning, while a mechanically complete brief can run reliably at a lower workload tier. Invest in decision-relevant context, not length, repetition, question quotas, or token quotas.
+
+### Reader-first rendering
+
+Rendered GitHub content serves people and workers from the same source:
+
+1. Put the outcome, reason, and completion conditions in the initial reading path.
+2. State each full fact or section once; a short reader summary may index the detailed contract.
+3. Collapse long implementation, provenance, and audit sections instead of deleting them.
+4. Preserve exact paths, commands, constraints, hazards, recovery steps, and acceptance criteria under stable headings in the raw body.
+5. Humanise surrounding prose, not technical identifiers or verification evidence.
 
 For maintained repositories, publishing a worker-ready implementation issue is
 the decision to implement it. Add `auto-dispatch` at creation and do not ask for

--- a/.agents/workflows/brief/templates.md
+++ b/.agents/workflows/brief/templates.md
@@ -10,28 +10,31 @@ Templates for GitHub-written content. Shared formatting rules: `workflows/brief.
 Wrap tier content in this structure for `gh issue create`:
 
 ```markdown
-## Description
+## Outcome
 
 {1-2 sentence summary of what needs to change and why}
+
+## Done when
+
+- [ ] {observable positive criterion}
+- [ ] {negative or regression criterion}
+- [ ] Lint clean
+- [ ] No unrelated changes
+
+<details>
+<summary>Worker implementation contract</summary>
 
 ## Implementation
 
 {Tier-appropriate content from tier-simple.md, tier-standard.md, or tier-thinking.md}
 
-## Acceptance Criteria
-
-- [ ] {criterion with verify block if possible}
-- [ ] Lint clean
-- [ ] No unrelated changes
-
-## Done When
-
-{Concrete, machine-verifiable completion signal — the worker does not stop until these are true}
+## Verification
 
 - `{lint/test command}` exits 0
 - PR exists with `Closes #{issue_number}` in body
 - MERGE_SUMMARY comment posted on PR
 - Issue closed with closing comment linking PR
+</details>
 ```
 
 Always include a tier label: `tier:simple`, `tier:standard`, or `tier:thinking`.
@@ -91,21 +94,23 @@ Follow `templates/escalation-report-template.md` (covers: what was attempted, st
 For worker-created PRs. Serves review bots and human reviewers.
 
 ```markdown
-## Summary
+## Outcome
 
 {1-3 bullet points: what changed and why}
-
-## Changes
-
-- `{file_path}` — {what changed in this file}
 
 ## Verification
 
 - {Test output, lint results, or manual verification}
 
-## Linked Issue
+<!-- Add a Risks and rollback section only when material. -->
 
 Closes #{issue_number}
+
+<details>
+<summary>Files changed and implementation notes</summary>
+
+- `{file_path}` — {what changed in this file}
+</details>
 ```
 
 **Rules** (from `AGENTS.md` "Traceability"):

--- a/TODO.md
+++ b/TODO.md
@@ -1279,6 +1279,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18243 Complete the privacy-safe marketing optimization contract #bug #interactive #auto-dispatch ~11h tier:thinking ref:GH#30275 logged:2026-08-15 started:2026-08-15 pr:#30282 completed:2026-08-15
 
+- [ ] t18244 Make generated writing and GitHub briefs reader-first #content #documentation #feat #publication:pending ref:GH#30305
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Ground known-voice guidance in direct evidence, make CTAs conditional, and collapse machine-dense issue and PR context behind reader summaries without changing dialogue defaults.

## Files Changed

.agents/content/humanise.md, .agents/content/production-writing.md, .agents/scripts/issue-sync-lib-compose.sh, .agents/scripts/tests/test-brief-inline-classifier.sh, .agents/scripts/tests/test-brief-readiness.sh, .agents/workflows/brief.md, .agents/workflows/brief/templates.md, TODO.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — 22 inline-classifier assertions, 39 readiness assertions, 14 issue-body-format assertions, 41 verify-brief assertions, 13 canonical task-ID assertions, 27 held-body-sync assertions, and changed plus full strict linter suites.

Resolves #30305


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.265 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 19m and 1,048,675 tokens on this with the user in an interactive session.