### PR TITLE
GH#30309: handle unset OpenCode temp environment

### DIFF
--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -1652,9 +1652,10 @@ cmd_remote_interactive() {
 main() {
     aidevops_init_temp_workspace || { print_error "Could not initialize aidevops temporary workspace"; return 1; }
     prepend_aidevops_gh_shim || return 1
-    TMP="${TMP:-${TMPDIR}}"
-    TEMP="${TEMP:-${TMPDIR}}"
-    export TMP TEMP
+    TMPDIR="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+    TMP="${TMP:-$TMPDIR}"
+    TEMP="${TEMP:-$TMPDIR}"
+    export TMPDIR TMP TEMP
     case "${1:-}" in
     conversation)
         shift || true

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -220,6 +220,17 @@ else
     _fail "isolated launcher output unexpected: ${output}"
 fi
 
+output=$(env -u TMPDIR -u TMP -u TEMP PATH="${fake_bin}:$PATH" HOME="${home_dir}" \
+    AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --dir "${launch_dir}" --session-id unset-host-temp -- --version 2>&1)
+if [[ "${output}" == *"TMPDIR=/tmp"* ]] \
+    && [[ "${output}" == *"TMP=/tmp"* ]] \
+    && [[ "${output}" == *"TEMP=/tmp"* ]]; then
+    _pass "launcher supplies conventional runtime scratch defaults when host variables are unset"
+else
+    _fail "launcher unset-host temporary environment fallback failed: ${output}"
+fi
+
 rm -f "${fake_log}"
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" FAKE_OPENCODE_LOG="${fake_log}" \
     "${HELPER}" --dir "${launch_dir}" --session-id test-session -- --version 2>&1)


### PR DESCRIPTION
## Summary

Initialize TMPDIR, TMP, and TEMP through an unset-safe conventional fallback while preserving explicit host values.

## Files Changed

.agents/scripts/opencode-launcher-helper.sh, .agents/scripts/tests/test-opencode-launcher-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 30 launcher tests pass; direct all-unset Tabby dry-run succeeds; ShellCheck clean; closeout bundle b6683a3e1b7f358018b338df17bd7702d641b73a899d835583a20637d524a398.

Resolves #30309


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.266 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 21m and 228,855 tokens on this with the user in an interactive session.