### PR TITLE
GH#30310: prevent unsafe OpenCode database vacuum

### DIFF
--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -73,6 +73,13 @@ if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
 	source "${SCRIPT_DIR}/shared-constants.sh"
 fi
 
+# Reuse the portable filesystem-capacity probe when available. Standalone
+# copies without the library fail closed only when a VACUUM would run.
+# shellcheck source=disk-capacity-lib.sh
+if [[ -f "${SCRIPT_DIR}/disk-capacity-lib.sh" ]]; then
+	source "${SCRIPT_DIR}/disk-capacity-lib.sh"
+fi
+
 # Color fallbacks (GH#18702 pattern): guard each assignment so we don't
 # clobber readonlies from shared-constants.sh when sourced.
 [[ -z "${RED+x}" ]] && RED=$'\033[0;31m'
@@ -104,6 +111,8 @@ readonly LOG_FILE="${STATE_DIR}/maintenance.log"
 # Thresholds — overrideable via env for advanced users.
 # VACUUM_FREELIST_THRESHOLD: only VACUUM if free pages > this fraction (default 10%)
 : "${VACUUM_FREELIST_THRESHOLD:=0.10}"
+# Legacy variable name: this now controls compact-large reporting only. Size
+# alone is not evidence that VACUUM can reclaim space.
 : "${FORCE_VACUUM_SIZE_MB:=500}"
 : "${AUTO_MIN_SECONDS_BETWEEN:=518400}"
 : "${WAL_LARGE_THRESHOLD_MB:=500}"
@@ -116,6 +125,7 @@ readonly LOG_FILE="${STATE_DIR}/maintenance.log"
 : "${OPENCODE_DB_MAINTENANCE_HOUR:=4}"
 : "${OPENCODE_DB_MAINTENANCE_MINUTE:=0}"
 : "${OPENCODE_DB_MAINTENANCE_MODE:=auto}"
+readonly VACUUM_FREE_SPACE_MULTIPLIER=3
 
 # Scheduler (macOS launchd) — used by cmd_install / cmd_uninstall / cmd_status.
 # Linux systemd/cron install is handled by .agents/scripts/setup/modules/schedulers.sh
@@ -831,7 +841,7 @@ _maintain_preflight() {
 }
 
 # _maintain_should_vacuum <before_bytes>
-# Echoes "true"/"false" based on size and freelist thresholds.
+# Echoes "true"/"false" based only on reclaimable freelist fragmentation.
 _maintain_should_vacuum() {
 	local before_bytes="$1"
 	local freelist_count page_count size_mb
@@ -843,19 +853,47 @@ _maintain_should_vacuum() {
 		printf '%s %s %s %s' true "$freelist_count" "$page_count" "$size_mb"
 		return 0
 	fi
-	if [[ "$size_mb" -ge "$FORCE_VACUUM_SIZE_MB" ]]; then
-		printf '%s %s %s %s' true "$freelist_count" "$page_count" "$size_mb"
-		return 0
-	fi
 	printf '%s %s %s %s' false "$freelist_count" "$page_count" "$size_mb"
 	return 0
 }
 
+# _maintain_vacuum_capacity <before_bytes>
+# Emits "available_kb required_kb reason". VACUUM may need one database-sized
+# temporary copy plus one database-sized WAL. Requiring 3x the DB size as free
+# space reserves an additional database-sized safety margin.
+_maintain_vacuum_capacity() {
+	local before_bytes="$1"
+	local db_kb=$(((before_bytes + 1023) / 1024))
+	local required_kb=$((db_kb * VACUUM_FREE_SPACE_MULTIPLIER))
+	local available_kb=0
+	local reason="capacity-unknown"
+
+	if ! declare -f aidevops_disk_capacity_snapshot >/dev/null 2>&1; then
+		printf '%s %s %s' "$available_kb" "$required_kb" "$reason"
+		return 2
+	fi
+	if ! aidevops_disk_capacity_snapshot "$OPENCODE_DB"; then
+		printf '%s %s %s' "$available_kb" "$required_kb" "$reason"
+		return 2
+	fi
+	available_kb="$AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB"
+	if [[ "$available_kb" -lt "$required_kb" ]]; then
+		reason="insufficient-capacity"
+		printf '%s %s %s' "$available_kb" "$required_kb" "$reason"
+		return 1
+	fi
+	printf '%s %s %s' "$available_kb" "$required_kb" "available"
+	return 0
+}
+
 # _maintain_run_steps <before_bytes>
-# Runs the SQLite maintenance steps. Echoes "step_failures vacuum_ran".
+# Runs the SQLite maintenance steps. Echoes
+# "step_failures vacuum_ran vacuum_deferred".
 _maintain_run_steps() {
 	local before_bytes="$1"
 	local step_failures=0
+	local vacuum_ran=false
+	local vacuum_deferred=false
 
 	# Step 1: Truncate WAL — fold pending writes back into main DB and shrink the WAL file.
 	print_info "Step 1/3: wal_checkpoint(TRUNCATE)..."
@@ -880,36 +918,49 @@ _maintain_run_steps() {
 	read -r do_vacuum freelist_count page_count size_mb <<<"$vacuum_decision"
 
 	if [[ "$do_vacuum" == true ]]; then
-		print_info "Step 3/3: VACUUM (DB ${size_mb} MB, ${freelist_count}/${page_count} free pages)..."
-		local vacuum_err
-		if ! vacuum_err=$(sqlite3 "$OPENCODE_DB" "VACUUM;" 2>&1); then
-			print_error "VACUUM failed: ${vacuum_err}"
-			_log ERROR "VACUUM failed: ${vacuum_err}"
-			step_failures=$((step_failures + 1))
+		local capacity_result capacity_rc=0 available_kb=0 required_kb=0 capacity_reason=""
+		capacity_result=$(_maintain_vacuum_capacity "$before_bytes") || capacity_rc=$?
+		read -r available_kb required_kb capacity_reason <<<"$capacity_result"
+		if [[ "$capacity_rc" -ne 0 ]]; then
+			vacuum_deferred=true
+			print_warning "Step 3/3: VACUUM deferred (${capacity_reason}; available ${available_kb} KiB, required ${required_kb} KiB)"
+			_log WARN "VACUUM deferred: reason=${capacity_reason} available_kb=${available_kb} required_kb=${required_kb}"
+		else
+			print_info "Step 3/3: VACUUM (DB ${size_mb} MB, ${freelist_count}/${page_count} free pages; ${available_kb} KiB available)..."
+			local vacuum_err
+			vacuum_ran=true
+			if ! vacuum_err=$(sqlite3 "$OPENCODE_DB" "VACUUM;" 2>&1); then
+				print_error "VACUUM failed: ${vacuum_err}"
+				_log ERROR "VACUUM failed: ${vacuum_err}"
+				step_failures=$((step_failures + 1))
+			fi
 		fi
 	else
-		print_info "Step 3/3: VACUUM skipped (low fragmentation: ${freelist_count}/${page_count} free pages, ${size_mb} MB < ${FORCE_VACUUM_SIZE_MB} MB)"
+		print_info "Step 3/3: VACUUM skipped (low fragmentation: ${freelist_count}/${page_count} free pages, ${size_mb} MB)"
 	fi
 
 	# VACUUM itself can write a large WAL. The manual 2026-05-01 run saw
 	# maintenance report success while opencode.db-wal grew to DB-size. Always
 	# checkpoint again after VACUUM so success means "DB compact and WAL folded".
-	print_info "Final step: post-VACUUM wal_checkpoint(TRUNCATE)..."
-	local final_ckpt
-	if ! final_ckpt=$("$SQLITE3_BIN" "$OPENCODE_DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>&1); then
-		print_warning "post-VACUUM wal_checkpoint failed (non-fatal): ${final_ckpt}"
-		_log WARN "post-VACUUM wal_checkpoint failed: ${final_ckpt}"
-		step_failures=$((step_failures + 1))
-	elif [[ "$final_ckpt" == 1\|* ]]; then
-		print_warning "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
-		_log WARN "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
-		step_failures=$((step_failures + 1))
+	if [[ "$vacuum_ran" == true ]]; then
+		print_info "Final step: post-VACUUM wal_checkpoint(TRUNCATE)..."
+		local final_ckpt
+		if ! final_ckpt=$("$SQLITE3_BIN" "$OPENCODE_DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>&1); then
+			print_warning "post-VACUUM wal_checkpoint failed (non-fatal): ${final_ckpt}"
+			_log WARN "post-VACUUM wal_checkpoint failed: ${final_ckpt}"
+			step_failures=$((step_failures + 1))
+		elif [[ "$final_ckpt" == 1\|* ]]; then
+			print_warning "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
+			_log WARN "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
+			step_failures=$((step_failures + 1))
+		fi
 	fi
 
-	printf '%s %s' "$step_failures" "$do_vacuum"
+	printf '%s %s %s' "$step_failures" "$vacuum_ran" "$vacuum_deferred"
+	return 0
 }
 
-# _maintain_write_state <before_bytes> <after_bytes> <before_wal> <after_wal> <duration> <do_vacuum> <step_failures>
+# _maintain_write_state <before_bytes> <after_bytes> <before_wal> <after_wal> <duration> <vacuum_ran> <vacuum_deferred> <step_failures>
 # Writes last-run.json and prints the summary.
 _maintain_write_state() {
 	local before_bytes="$1"
@@ -917,11 +968,16 @@ _maintain_write_state() {
 	local before_wal="$3"
 	local after_wal="$4"
 	local duration="$5"
-	local do_vacuum="$6"
-	local step_failures="$7"
+	local vacuum_ran="$6"
+	local vacuum_deferred="$7"
+	local step_failures="$8"
 	local reclaimed=$((before_bytes - after_bytes))
 	local outcome="success"
-	[[ "$step_failures" -gt 0 ]] && outcome="partial"
+	if [[ "$step_failures" -gt 0 ]]; then
+		outcome="partial"
+	elif [[ "$vacuum_deferred" == true ]]; then
+		outcome="deferred"
+	fi
 
 	mkdir -p "$STATE_DIR"
 	cat >"$STATE_FILE" <<EOF
@@ -934,12 +990,19 @@ _maintain_write_state() {
   "bytes_reclaimed": $reclaimed,
   "wal_before": $before_wal,
   "wal_after": $after_wal,
-  "vacuum_ran": $do_vacuum,
+  "vacuum_ran": $vacuum_ran,
+  "vacuum_deferred": $vacuum_deferred,
   "step_failures": $step_failures
 }
 EOF
 
-	print_success "Maintenance complete in ${duration}s"
+	if [[ "$outcome" == "partial" ]]; then
+		print_warning "Maintenance partially completed in ${duration}s"
+	elif [[ "$outcome" == "deferred" ]]; then
+		print_warning "Maintenance deferred after safe preliminary steps in ${duration}s"
+	else
+		print_success "Maintenance complete in ${duration}s"
+	fi
 	print_info "DB:  $(_db_size_human "$before_bytes") → $(_db_size_human "$after_bytes") (reclaimed $(_db_size_human "$reclaimed"))"
 	print_info "WAL: $(_db_size_human "$before_wal") → $(_db_size_human "$after_wal")"
 	_log INFO "done: outcome=$outcome duration=${duration}s reclaimed=${reclaimed} step_failures=${step_failures}"
@@ -974,8 +1037,8 @@ cmd_maintain() {
 
 	local steps_result
 	steps_result=$(_maintain_run_steps "$before_bytes")
-	local step_failures do_vacuum
-	read -r step_failures do_vacuum <<<"$steps_result"
+	local step_failures vacuum_ran vacuum_deferred
+	read -r step_failures vacuum_ran vacuum_deferred <<<"$steps_result"
 
 	local end_epoch after_bytes after_wal duration
 	end_epoch=$(date +%s)
@@ -984,7 +1047,7 @@ cmd_maintain() {
 	duration=$((end_epoch - start_epoch))
 
 	_maintain_write_state "$before_bytes" "$after_bytes" "$before_wal" "$after_wal" \
-		"$duration" "$do_vacuum" "$step_failures"
+		"$duration" "$vacuum_ran" "$vacuum_deferred" "$step_failures"
 
 	if [[ "$step_failures" -gt 0 ]]; then
 		return 10
@@ -1437,8 +1500,8 @@ Subcommands:
 What maintenance does:
   1. wal_checkpoint(TRUNCATE) — folds pending writes back into main DB
   2. PRAGMA optimize         — refreshes query planner stats
-  3. VACUUM (conditional)    — reclaims free pages; runs when DB >500MB
-                               OR free-page fraction >10%
+  3. VACUUM (conditional)    — reclaims free pages only when the free-page
+                               fraction exceeds 10% and 3x DB size is free
 
 Why it helps:
   opencode SQLite locks ("database is locked") surface when a writer holds
@@ -1448,7 +1511,7 @@ Why it helps:
 
 Environment variables (advanced):
   VACUUM_FREELIST_THRESHOLD    Fraction of free pages triggering VACUUM (default 0.10)
-  FORCE_VACUUM_SIZE_MB         Always VACUUM above this size (default 500)
+  FORCE_VACUUM_SIZE_MB         Compact-large reporting threshold (default 500)
   AUTO_MIN_SECONDS_BETWEEN     Throttle for auto mode (default 518400 = 6 days)
   WAL_LARGE_THRESHOLD_MB       Warn/report large WAL above this size (default 500)
   MAINTENANCE_WINDOW_KEEP_SESSIONS  Archive keep target for maintenance-window (default 500)

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -173,16 +173,121 @@ fi
 # processes running. The sandbox DB is separate (XDG_DATA_HOME), so
 # --force here only waives the *process count* check, not any real risk.
 
-# Lower thresholds so VACUUM is exercised even on tiny synthetic DB
+# Lower the fragmentation threshold so VACUUM is exercised on the synthetic DB.
 set +e
-out=$(VACUUM_FREELIST_THRESHOLD=0.01 FORCE_VACUUM_SIZE_MB=0 _run_helper maintain --force 2>&1)
+out=$(VACUUM_FREELIST_THRESHOLD=0.01 _run_helper maintain --force 2>&1)
 rc=$?
 set -e
-if [[ "$rc" -eq 0 ]] && grep -q "Maintenance complete" <<<"$out"; then
+if [[ "$rc" -eq 0 ]] && grep -q "Step 3/3: VACUUM (" <<<"$out" && grep -q "Maintenance complete" <<<"$out"; then
 	_pass "maintain succeeds on synthetic DB"
 else
 	_fail "maintain failed (rc=$rc) — output: $out"
 fi
+
+# -----------------------------------------------------------------------------
+# Test 5b: compact DB is not vacuumed solely because it exceeds the size marker
+# -----------------------------------------------------------------------------
+
+set +e
+out=$(VACUUM_FREELIST_THRESHOLD=0.99 FORCE_VACUUM_SIZE_MB=0 _run_helper maintain --force 2>&1)
+rc=$?
+set -e
+state_file="$SANDBOX/fakehome/.aidevops/.agent-workspace/work/opencode-maintenance/last-run.json"
+if [[ "$rc" -eq 0 ]] && grep -q "VACUUM skipped (low fragmentation" <<<"$out" &&
+	grep -q '"outcome": "success"' "$state_file" &&
+	grep -q '"vacuum_ran": false' "$state_file"; then
+	_pass "compact DB is not vacuumed solely because it is large"
+else
+	_fail "compact DB unexpectedly selected VACUUM (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 5c: insufficient or unknown capacity safely defers VACUUM
+# -----------------------------------------------------------------------------
+
+capacity_bin="$SANDBOX/capacity-bin"
+mkdir -p "$capacity_bin"
+cat >"$capacity_bin/df" <<'MOCK_DF_LOW'
+#!/usr/bin/env bash
+printf '%s\n' 'Filesystem 1024-blocks Used Available Capacity Mounted on'
+printf '%s\n' 'mock 1000 999 1 100% /'
+exit 0
+MOCK_DF_LOW
+chmod +x "$capacity_bin/df"
+
+set +e
+out=$(PATH="$capacity_bin:$PATH" VACUUM_FREELIST_THRESHOLD=0 _run_helper maintain --force 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q "VACUUM deferred (insufficient-capacity" <<<"$out" &&
+	grep -q "Maintenance deferred after safe preliminary steps" <<<"$out" &&
+	grep -q '"outcome": "deferred"' "$state_file" &&
+	grep -q '"vacuum_deferred": true' "$state_file" &&
+	grep -q '"vacuum_ran": false' "$state_file"; then
+	_pass "insufficient capacity defers VACUUM without reporting success"
+else
+	_fail "insufficient capacity did not defer VACUUM safely (rc=$rc) — output: $out"
+fi
+
+cat >"$capacity_bin/df" <<'MOCK_DF_UNKNOWN'
+#!/usr/bin/env bash
+exit 1
+MOCK_DF_UNKNOWN
+chmod +x "$capacity_bin/df"
+
+set +e
+out=$(PATH="$capacity_bin:$PATH" VACUUM_FREELIST_THRESHOLD=0 _run_helper maintain --force 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q "VACUUM deferred (capacity-unknown" <<<"$out" &&
+	grep -q '"outcome": "deferred"' "$state_file" &&
+	grep -q '"vacuum_ran": false' "$state_file"; then
+	_pass "unknown capacity fails closed before VACUUM"
+else
+	_fail "unknown capacity did not fail closed (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 5d: attempted VACUUM failure remains a partial non-success outcome
+# -----------------------------------------------------------------------------
+
+cat >"$capacity_bin/df" <<'MOCK_DF_HIGH'
+#!/usr/bin/env bash
+printf '%s\n' 'Filesystem 1024-blocks Used Available Capacity Mounted on'
+printf '%s\n' 'mock 1000000000 1 999999999 1% /'
+exit 0
+MOCK_DF_HIGH
+cat >"$capacity_bin/sqlite3" <<'MOCK_SQLITE'
+#!/usr/bin/env bash
+last_arg=""
+for candidate in "$@"; do
+	last_arg="$candidate"
+done
+if [[ "$last_arg" == "VACUUM;" ]]; then
+	printf '%s\n' 'database or disk is full' >&2
+	exit 1
+fi
+exec "$REAL_SQLITE3" "$@"
+MOCK_SQLITE
+chmod +x "$capacity_bin/df" "$capacity_bin/sqlite3"
+real_sqlite3=$(command -v sqlite3)
+
+set +e
+out=$(PATH="$capacity_bin:$PATH" REAL_SQLITE3="$real_sqlite3" VACUUM_FREELIST_THRESHOLD=0 _run_helper maintain --force 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 10 ]] && grep -q "VACUUM failed: database or disk is full" <<<"$out" &&
+	grep -q "Maintenance partially completed" <<<"$out" &&
+	grep -q '"outcome": "partial"' "$state_file" &&
+	grep -q '"vacuum_ran": true' "$state_file"; then
+	_pass "failed VACUUM remains a partial non-success outcome"
+else
+	_fail "failed VACUUM outcome was inaccurate (rc=$rc) — output: $out"
+fi
+rm -rf "$capacity_bin"
+
+# Restore a successful compact state for the existing notice/throttle fixtures.
+VACUUM_FREELIST_THRESHOLD=0.99 _run_helper maintain --force >/dev/null
 
 # -----------------------------------------------------------------------------
 # Test 6: state file is written after maintain


### PR DESCRIPTION
## Summary

Stop selecting VACUUM solely by database size, require three times the database size in free filesystem capacity before fragmented-database rewrites, and record deferred or partial outcomes accurately.

## Files Changed

.agents/scripts/opencode-db-maintenance-helper.sh, .agents/scripts/tests/test-opencode-db-maintenance.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 32 OpenCode database maintenance tests passed; 5 disk-capacity tests passed; ShellCheck, bash syntax, diff checks, complexity checks, and local linters passed.

Resolves #30310


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.266 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 44m and 472,800 tokens on this with the user in an interactive session.