### PR TITLE
GH#30315: provision managed labels before gh creates

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -95,6 +95,9 @@ source "${_SHIM_DIR}/gh-native-transport-lib.sh"
 # shellcheck source=./gh-api-guards-lib.sh
 # shellcheck disable=SC1091  # sibling library resolved at runtime via $_SHIM_DIR
 source "${_SHIM_DIR}/gh-api-guards-lib.sh"
+# shellcheck source=./managed-label-provisioning-lib.sh
+# shellcheck disable=SC1091  # sibling library resolved at runtime via $_SHIM_DIR
+source "${_SHIM_DIR}/managed-label-provisioning-lib.sh"
 # shellcheck source=./gh-write-policy-lib.sh
 # shellcheck disable=SC1091  # sibling library resolved at runtime via $_SHIM_DIR
 source "${_SHIM_DIR}/gh-write-policy-lib.sh"
@@ -1011,6 +1014,10 @@ if [[ "${SHIM_TEST_MODE:-}" == "1" ]]; then
 	done
 	exit 0
 fi
+
+# Managed-label provisioning is a write and must happen only after all normal
+# authorization, privacy, and local preparation gates accept the native create.
+_shim_ensure_requested_managed_labels_for_create || true
 
 # GH#21857: instrument write commands (issue comment/create/edit, pr create/
 # comment/edit) — these all use the GraphQL endpoint.

--- a/.agents/scripts/gh-write-policy-lib.sh
+++ b/.agents/scripts/gh-write-policy-lib.sh
@@ -11,6 +11,8 @@
 
 [[ -n "${_GH_WRITE_POLICY_LIB_LOADED:-}" ]] && return 0
 _GH_WRITE_POLICY_LIB_LOADED=1
+_SHIM_ORIGIN_INTERACTIVE_LABEL="origin:interactive"
+_SHIM_MANAGED_LABEL_SET=""
 
 if [[ -z "${_SHIM_DIR:-}" ]]; then
 	_gh_write_policy_path="${BASH_SOURCE[0]%/*}"
@@ -679,6 +681,57 @@ _shim_normalize_dispatch_labels() {
 	return 0
 }
 
+_shim_managed_label_inventory_runner() {
+	local repo="$1"
+	# The generic provisioner consumes gh's projected name stream, whereas the
+	# explicit paginator owns raw JSON pages. Keep native pagination for this
+	# bounded inventory while retaining the normal transport attribution.
+	AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="managed-label-inventory-rest" \
+		_shim_run_transport "$REAL_GH" rest gh_managed_label_inventory 0 \
+		api "/repos/${repo}/labels?per_page=100" --paginate --jq '.[].name'
+	return $?
+}
+
+_shim_managed_label_create_runner() {
+	local repo="$1"
+	local label_name="$2"
+	local label_description="$3"
+	local label_color="$4"
+	AIDEVOPS_GH_ROUTE_DECISION="managed-label-create-rest" \
+		_shim_run_transport "$REAL_GH" rest gh_managed_label_create 0 \
+		label create "$label_name" --repo "$repo" \
+		--description "$label_description" --color "$label_color" >/dev/null 2>&1
+	return $?
+}
+
+_shim_ensure_origin_labels_for_create() {
+	local repo=""
+	repo=$(_shim_target_repo_slug "${_modified_args[@]}" 2>/dev/null || true)
+	[[ -n "$repo" ]] || return 0
+	managed_labels_ensure_origin_set "$repo" \
+		_shim_managed_label_inventory_runner _shim_managed_label_create_runner
+	return $?
+}
+
+_shim_ensure_tracking_labels_for_create() {
+	local repo=""
+	repo=$(_shim_target_repo_slug "${_modified_args[@]}" 2>/dev/null || true)
+	[[ -n "$repo" ]] || return 0
+	managed_labels_ensure_tracking_set "$repo" \
+		_shim_managed_label_inventory_runner _shim_managed_label_create_runner
+	return $?
+}
+
+_shim_ensure_requested_managed_labels_for_create() {
+	case "$_SHIM_MANAGED_LABEL_SET" in
+	origin) _shim_ensure_origin_labels_for_create ;;
+	tracking) _shim_ensure_tracking_labels_for_create ;;
+	*) return 0 ;;
+	esac
+	return $?
+}
+
 _shim_normalize_interactive_tracking_issue_create() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]] || return 0
 	[[ -z "${FULL_LOOP_HEADLESS:-}${AIDEVOPS_HEADLESS:-}${OPENCODE_HEADLESS:-}${GITHUB_ACTIONS:-}" ]] || return 0
@@ -686,8 +739,9 @@ _shim_normalize_interactive_tracking_issue_create() {
 	local title=""
 	title="$(_shim_issue_create_get_title 2>/dev/null || true)"
 	[[ "$title" =~ ^(t[0-9]+(\.[0-9]+)*|GH#[0-9]+):[[:space:]] ]] || return 0
+	_SHIM_MANAGED_LABEL_SET="tracking"
 
-	_shim_issue_create_has_label_prefix "origin:" || _modified_args+=(--label "origin:interactive")
+	_shim_issue_create_has_label_prefix "origin:" || _modified_args+=(--label "$_SHIM_ORIGIN_INTERACTIVE_LABEL")
 	_shim_issue_create_has_label_prefix "status:" || _modified_args+=(--label "status:in-review")
 	_shim_issue_create_has_type_label || _modified_args+=(--label "bug")
 	return 0
@@ -697,11 +751,19 @@ _shim_normalize_pr_create_origin() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:create" ]] || return 0
 	# Respect an explicit immutable origin. Raw gh callers otherwise receive the
 	# same session provenance as gh_create_pr so worker drafts are recoverable.
-	_shim_issue_create_has_label_prefix "origin:" && return 0
-	local origin_label="origin:interactive"
+	if _shim_issue_create_has_label_prefix "origin:"; then
+		if _shim_issue_create_has_label "origin:worker" ||
+			_shim_issue_create_has_label "$_SHIM_ORIGIN_INTERACTIVE_LABEL" ||
+			_shim_issue_create_has_label "origin:worker-takeover"; then
+			_SHIM_MANAGED_LABEL_SET="origin"
+		fi
+		return 0
+	fi
+	local origin_label="$_SHIM_ORIGIN_INTERACTIVE_LABEL"
 	if _shim_is_headless_automation; then
 		origin_label="origin:worker"
 	fi
+	_SHIM_MANAGED_LABEL_SET="origin"
 	_modified_args+=(--label "$origin_label")
 	return 0
 }

--- a/.agents/scripts/managed-label-provisioning-lib.sh
+++ b/.agents/scripts/managed-label-provisioning-lib.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared managed-label provisioning primitives
+# =============================================================================
+# Callers provide inventory and create runner functions so wrapper and PATH-shim
+# transports share one canonical label catalogue without recursive gh calls.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_MANAGED_LABEL_PROVISIONING_LIB_LOADED:-}" ]] && return 0
+_MANAGED_LABEL_PROVISIONING_LIB_LOADED=1
+
+_MANAGED_ORIGIN_LABEL_SPECS=(
+	"origin:worker" "Created by headless/pulse worker session" "C5DEF5"
+	"origin:interactive" "Created by interactive user session" "BFD4F2"
+	"origin:worker-takeover" "Worker took over from interactive session" "D4C5F9"
+)
+
+managed_label_snapshot_has() {
+	local snapshot="$1"
+	local expected_name="$2"
+	local actual_name=""
+	while IFS= read -r actual_name; do
+		[[ "$actual_name" == "$expected_name" ]] && return 0
+	done <<<"$snapshot"
+	return 1
+}
+
+managed_labels_ensure_specs() {
+	local repo="$1"
+	local inventory_runner="$2"
+	local create_runner="$3"
+	shift 3
+	[[ -n "$repo" && -n "$inventory_runner" && -n "$create_runner" ]] || return 1
+	[[ $(($# % 3)) -eq 0 ]] || return 1
+
+	local labels_snapshot=""
+	labels_snapshot=$("$inventory_runner" "$repo") || return 1
+	local label_name=""
+	local label_description=""
+	local label_color=""
+	while [[ $# -gt 0 ]]; do
+		label_name="$1"
+		label_description="$2"
+		label_color="$3"
+		shift 3
+		if ! managed_label_snapshot_has "$labels_snapshot" "$label_name"; then
+			"$create_runner" "$repo" "$label_name" "$label_description" "$label_color" || return 1
+			labels_snapshot="${labels_snapshot}${labels_snapshot:+$'\n'}${label_name}"
+		fi
+	done
+	return 0
+}
+
+managed_labels_ensure_origin_set() {
+	local repo="$1"
+	local inventory_runner="$2"
+	local create_runner="$3"
+	managed_labels_ensure_specs "$repo" "$inventory_runner" "$create_runner" \
+		"${_MANAGED_ORIGIN_LABEL_SPECS[@]}"
+	return $?
+}
+
+managed_labels_ensure_tracking_set() {
+	local repo="$1"
+	local inventory_runner="$2"
+	local create_runner="$3"
+	local -a tracking_specs=(
+		"${_MANAGED_ORIGIN_LABEL_SPECS[@]}"
+		"status:in-review" "PR open, awaiting review/merge" "5319E7"
+		"bug" "Something isn't working" "D73A4A"
+	)
+	managed_labels_ensure_specs "$repo" "$inventory_runner" "$create_runner" \
+		"${tracking_specs[@]}"
+	return $?
+}

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1273,6 +1273,9 @@ _save_cleanup_scope() {
 # See shared-gh-wrappers.sh for full documentation.
 
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+# shellcheck source=./managed-label-provisioning-lib.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
+_source_shared_module_with_retry "${_SC_SELF%/*}/managed-label-provisioning-lib.sh"
 # shellcheck source=./shared-gh-wrappers.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
 _source_shared_module_with_retry "${_SC_SELF%/*}/shared-gh-wrappers.sh"

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -995,25 +995,18 @@ _ensure_origin_labels_for_args() {
 ensure_origin_labels_exist() {
 	local repo="$1"
 	[[ -z "$repo" ]] && return 1
-	local labels_snapshot=""
-	labels_snapshot=$(_gh_managed_label_names_snapshot "$repo") || return 1
-	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:worker"; then
-		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
-			_gh_with_timeout write gh label create "origin:worker" --repo "$repo" \
-			--description "Created by headless/pulse worker session" \
-			--color "C5DEF5" 2>/dev/null || return 1
-	fi
-	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:interactive"; then
-		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
-			_gh_with_timeout write gh label create "origin:interactive" --repo "$repo" \
-			--description "Created by interactive user session" \
-			--color "BFD4F2" 2>/dev/null || return 1
-	fi
-	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:worker-takeover"; then
-		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
-			_gh_with_timeout write gh label create "origin:worker-takeover" --repo "$repo" \
-			--description "Worker took over from interactive session" \
-			--color "D4C5F9" 2>/dev/null || return 1
-	fi
-	return 0
+	managed_labels_ensure_origin_set "$repo" \
+		_gh_managed_label_names_snapshot _gh_managed_label_create_runner
+	return $?
+}
+
+_gh_managed_label_create_runner() {
+	local repo="$1"
+	local label_name="$2"
+	local label_description="$3"
+	local label_color="$4"
+	AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+		_gh_with_timeout write gh label create "$label_name" --repo "$repo" \
+		--description "$label_description" --color "$label_color" 2>/dev/null
+	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -507,11 +507,8 @@ _gh_managed_label_names_snapshot() {
 _gh_managed_label_snapshot_has() {
 	local snapshot="$1"
 	local expected_name="$2"
-	local actual_name=""
-	while IFS= read -r actual_name; do
-		[[ "$actual_name" == "$expected_name" ]] && return 0
-	done <<<"$snapshot"
-	return 1
+	managed_label_snapshot_has "$snapshot" "$expected_name"
+	return $?
 }
 
 # =============================================================================
@@ -795,6 +792,10 @@ NON_TASK_LABELS=(
 #   - ISSUE_STATUS_LABELS, NON_TASK_LABELS (status)
 #   - _gh_with_timeout (status)
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" ]]; then
+	# shellcheck source=managed-label-provisioning-lib.sh
+	# shellcheck disable=SC1091  # sub-library resolved at runtime via $_SHARED_GH_WRAPPERS_DIR
+	source "$_SHARED_GH_WRAPPERS_DIR/managed-label-provisioning-lib.sh"
+
 	# shellcheck source=shared-gh-wrappers-session.sh
 	# shellcheck disable=SC1091  # sub-library resolved at runtime via $_SHARED_GH_WRAPPERS_DIR
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-session.sh"

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -290,6 +290,60 @@ else
 	_fail "explicit raw pr origin normalization" "count=${origin_count} argv: $argv"
 fi
 
+_reset_log
+STUB_MANAGED_LABELS="bug" \
+	"$SHIM_RUN" pr create --repo owner/repo --title "fresh repo" --body "For #25901" 2>/dev/null
+argv=$(_read_argv)
+created_origin_count=$(grep -c '^label create origin:' "$STUB_GH_LABEL_LOG" 2>/dev/null || true)
+if [[ "$created_origin_count" -eq 3 ]] &&
+	[[ "$argv" == *$'--label\norigin:interactive'* ]]; then
+	_pass "fresh repo provisions canonical origins before raw pr create"
+else
+	_fail "fresh repo origin provisioning" "creates=${created_origin_count} calls: $(cat "$STUB_GH_CALL_LOG") argv: $argv"
+fi
+
+_reset_log
+STUB_MANAGED_LABELS="bug" \
+	"$SHIM_RUN" pr create --repo owner/repo --title "explicit canonical" \
+	--label "origin:worker" --body "For #25901" 2>/dev/null
+created_origin_count=$(grep -c '^label create origin:' "$STUB_GH_LABEL_LOG" 2>/dev/null || true)
+if [[ "$created_origin_count" -eq 3 ]]; then
+	_pass "explicit canonical origin receives missing-label provisioning"
+else
+	_fail "explicit canonical origin provisioning" "creates=${created_origin_count} calls: $(cat "$STUB_GH_CALL_LOG")"
+fi
+
+_reset_log
+STUB_MANAGED_LABELS="bug" \
+	"$SHIM_RUN" pr create --repo owner/repo --title "explicit custom" \
+	--label "origin:custom" --body "For #25901" 2>/dev/null
+if [[ ! -s "$STUB_GH_LABEL_LOG" ]]; then
+	_pass "arbitrary origin label is never auto-provisioned"
+else
+	_fail "arbitrary origin provisioning guard" "creates: $(cat "$STUB_GH_LABEL_LOG")"
+fi
+
+_reset_log
+STUB_MANAGED_LABEL_INVENTORY_FAIL=1 \
+	"$SHIM_RUN" pr create --repo owner/repo --title "inventory unavailable" \
+	--body "For #25901" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'--label\norigin:interactive'* ]] && [[ ! -s "$STUB_GH_LABEL_LOG" ]]; then
+	_pass "inventory failure preserves native pr-create fallback"
+else
+	_fail "inventory failure fallback" "argv: $argv creates: $(cat "$STUB_GH_LABEL_LOG")"
+fi
+
+_reset_log
+SHIM_TEST_MODE=1 STUB_MANAGED_LABELS="bug" \
+	"$SHIM_RUN" pr create --repo owner/repo --title "test mode" \
+	--body "For #25901" >/dev/null 2>&1
+if [[ ! -s "$STUB_GH_LABEL_LOG" ]]; then
+	_pass "shim test mode performs no managed-label writes"
+else
+	_fail "shim test-mode label-write guard" "creates: $(cat "$STUB_GH_LABEL_LOG")"
+fi
+
 echo ""
 echo "Test 6a: issue-first repos block PR creation without linked issue"
 _reset_log

--- a/.agents/scripts/tests/test-gh-shim-routing-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-routing-cases.sh
@@ -325,6 +325,20 @@ else
 	_fail "tracking issue label normalization" "argv: $argv"
 fi
 
+_reset_log
+STUB_MANAGED_LABELS="origin:worker" \
+	"$SHIM_RUN" issue create --repo owner/repo --title "t3565: Fresh labels" \
+	--body "tracking body" 2>/dev/null
+argv=$(_read_argv)
+if grep -q '^label create origin:interactive ' "$STUB_GH_LABEL_LOG" &&
+	grep -q '^label create status:in-review ' "$STUB_GH_LABEL_LOG" &&
+	grep -q '^label create bug ' "$STUB_GH_LABEL_LOG" &&
+	[[ "$argv" == *$'--label\norigin:interactive'* ]]; then
+	_pass "fresh repo provisions every shim-injected tracking label"
+else
+	_fail "fresh tracking-label provisioning" "argv: $argv creates: $(cat "$STUB_GH_LABEL_LOG") calls: $(cat "$STUB_GH_CALL_LOG")"
+fi
+
 # =============================================================================
 # Test 17: raw issue normalization respects explicit labels and headless mode
 # =============================================================================
@@ -372,6 +386,21 @@ fi
 # =============================================================================
 echo ""
 echo "Test 18: headless external write guard blocks raw comments"
+_reset_log
+if AIDEVOPS_HEADLESS=1 "$SHIM_RUN" pr create --repo external/repo \
+	--title "blocked create" --body "For #123" 2>"$TMP/guard-create.err"; then
+	_fail "headless pr create guard" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && [[ ! -s "$STUB_GH_LABEL_LOG" ]] &&
+		grep -q "external-write-guard" "$TMP/guard-create.err"; then
+		_pass "blocked headless pr create performs no label writes"
+	else
+		_fail "headless pr create label-write guard" \
+			"argv: $argv creates: $(cat "$STUB_GH_LABEL_LOG") err: $(cat "$TMP/guard-create.err")"
+	fi
+fi
+
 _reset_log
 if AIDEVOPS_HEADLESS=1 "$SHIM_RUN" issue comment 123 --repo external/repo --body "uninstigated" 2>"$TMP/guard-issue.err"; then
 	_fail "headless issue comment guard" "write unexpectedly passed"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -82,6 +82,20 @@ fi
 if [[ -n "${STUB_GH_CALL_LOG:-}" ]]; then
 	printf '%s\t%s\n' "${1:-}" "${2:-}" >>"$STUB_GH_CALL_LOG"
 fi
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/labels\?per_page=100$ ]]; then
+	[[ "${STUB_MANAGED_LABEL_INVENTORY_FAIL:-0}" != "1" ]] || exit 42
+	managed_labels="${STUB_MANAGED_LABELS-}"
+	if [[ -z "${STUB_MANAGED_LABELS+x}" ]]; then
+		managed_labels=$'origin:worker\norigin:interactive\norigin:worker-takeover\nstatus:in-review\nbug'
+	fi
+	printf '%s\n' "$managed_labels"
+	exit 0
+fi
+if [[ "$1" == "label" && "$2" == "create" ]]; then
+	[[ -z "${STUB_GH_LABEL_LOG:-}" ]] || printf '%s\n' "$*" >>"$STUB_GH_LABEL_LOG"
+	[[ "${STUB_MANAGED_LABEL_CREATE_FAIL:-0}" != "1" ]] || exit 43
+	exit 0
+fi
 : >"$STUB_GH_LOG"
 for arg in "$@"; do
 	printf '%s\n' "$arg" >>"$STUB_GH_LOG"
@@ -273,6 +287,7 @@ cp "$SHIM" "$TMP/scripts/gh"
 chmod +x "$TMP/scripts/gh"
 cp "$REPO_DIR/.agents/scripts/gh-native-transport-lib.sh" "$TMP/scripts/gh-native-transport-lib.sh"
 cp "$REPO_DIR/.agents/scripts/gh-api-guards-lib.sh" "$TMP/scripts/gh-api-guards-lib.sh"
+cp "$REPO_DIR/.agents/scripts/managed-label-provisioning-lib.sh" "$TMP/scripts/managed-label-provisioning-lib.sh"
 cp "$REPO_DIR/.agents/scripts/gh-write-policy-lib.sh" "$TMP/scripts/gh-write-policy-lib.sh"
 cp "$REPO_DIR/.agents/scripts/gh-api-instrument.sh" "$TMP/scripts/gh-api-instrument.sh"
 cp "$REPO_DIR/.agents/scripts/gh-quota-attribution-lib.sh" "$TMP/scripts/gh-quota-attribution-lib.sh"
@@ -298,6 +313,7 @@ export STUB_GH_BODY_LOG="$TMP/gh-body.log"
 export STUB_GH_BODY_PATH_LOG="$TMP/gh-body-path.log"
 export STUB_GH_MAIN_CALL_LOG="$TMP/gh-main-call.log"
 export STUB_GH_CALL_LOG="$TMP/gh-call.log"
+export STUB_GH_LABEL_LOG="$TMP/gh-label.log"
 
 SHIM_RUN="$TMP/scripts/gh"
 
@@ -318,6 +334,10 @@ _reset_log() {
 	: >"$STUB_GH_BODY_PATH_LOG"
 	: >"$STUB_GH_MAIN_CALL_LOG"
 	: >"$STUB_GH_CALL_LOG"
+	: >"$STUB_GH_LABEL_LOG"
+	unset STUB_MANAGED_LABELS
+	unset STUB_MANAGED_LABEL_INVENTORY_FAIL
+	unset STUB_MANAGED_LABEL_CREATE_FAIL
 	return 0
 }
 

--- a/.agents/scripts/tests/test-managed-label-provisioning.sh
+++ b/.agents/scripts/tests/test-managed-label-provisioning.sh
@@ -84,6 +84,15 @@ assert_count "missing solved label is created once" 1 'gh label create solved:in
 assert_count "present origin labels are not recreated" 0 'gh label create origin:worker --repo'
 assert_count "present solved labels are not recreated" 0 'gh label create solved:worker --repo'
 
+# Tracking creation reuses the canonical origin set and adds its own labels.
+: >"$CALL_LOG"
+TEST_LABEL_SNAPSHOT=$'origin:worker\norigin:interactive\norigin:worker-takeover'
+managed_labels_ensure_tracking_set owner/repo \
+	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
+assert_count "tracking set provisions status label" 1 'gh label create status:in-review '
+assert_count "tracking set provisions bug label" 1 'gh label create bug '
+assert_count "tracking set reuses present origins" 0 'gh label create origin:'
+
 # Failed inventory is fail-closed: do not fan out speculative writes or cache.
 : >"$CALL_LOG"
 _ORIGIN_LABELS_ENSURED=""


### PR DESCRIPTION
## Summary

Provision canonical origin and tracking labels before raw gh create calls, sharing one create-time catalogue across the PATH shim and shell wrappers.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-write-policy-lib.sh, .agents/scripts/managed-label-provisioning-lib.sh, .agents/scripts/shared-constants.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-shim-core-cases.sh, .agents/scripts/tests/test-gh-shim-routing-cases.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-managed-label-provisioning.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with the hermetic PATH-shim transport: 138 assertions cover fresh repositories, native create fallback, policy-gated writes, and test-mode isolation; 12 managed-label assertions, wrapper suites, ShellCheck, and changed-file local linters also pass.

Resolves #30315


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.266 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 53m and 558,395 tokens on this with the user in an interactive session.