### PR TITLE
GH#30320: optimize pulse event classification

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -154,7 +154,11 @@ dps-notify-cooldown|pulse-dirty-pr-sweep.sh|694|PR #.*notify skipped.*cooldown|N
 dps-sweep-complete|pulse-dirty-pr-sweep.sh|858|sweep complete:|Dirty PR sweep pass completed (summary)
 dps-sweep-stop|pulse-dirty-pr-sweep.sh|822|stop flag present.*skipping sweep|Dirty PR sweep skipped — stop flag present
 INVENTORY
+	return 0
 }
+
+_RULE_INVENTORY=$(_build_rule_inventory)
+readonly _RULE_INVENTORY
 
 # Shared path resolution and retry helpers.
 # shellcheck source=./pulse-diagnose-utils.sh
@@ -377,34 +381,41 @@ _issue_blocker_summary_json() {
 #   2026-04-21T17:45:03Z  ... or [2026-04-21T17:45:03Z] ...
 _extract_timestamp() {
 	local line="$1"
-	local ts
+	local output_var="${2:-}"
+	local timestamp_value="$_UNKNOWN"
 	# ISO timestamp at start of line or after [
-	ts=$(printf '%s' "$line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z?' | head -1)
-	if [[ -n "$ts" ]]; then
-		echo "$ts"
-		return 0
+	if [[ "$line" =~ ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z?) ]]; then
+		timestamp_value="${BASH_REMATCH[1]}"
 	fi
-	echo "$_UNKNOWN"
+	if [[ -n "$output_var" ]]; then
+		printf -v "$output_var" '%s' "$timestamp_value"
+	else
+		printf '%s\n' "$timestamp_value"
+	fi
 	return 0
 }
 
 # Classify a single log line against the rule inventory.
-# Args: $1 = log line
-# Outputs: rule_id|script|line_range|description  (or "unclassified" if no match)
+# Args: $1 = log line, $2 = optional output variable
+# Outputs or assigns: rule_id|script|line_range|description
 _classify_log_line() {
 	local line="$1"
-	local inventory
-	inventory=$(_build_rule_inventory)
+	local output_var="${2:-}"
+	local result="${_UNCLASSIFIED}|||Unclassified pulse log entry"
 
 	while IFS='|' read -r rule_id script line_range regex description; do
 		[[ -z "$rule_id" ]] && continue
-		if printf '%s' "$line" | grep -qE "$regex" 2>/dev/null; then
-			printf '%s|%s|%s|%s' "$rule_id" "$script" "$line_range" "$description"
-			return 0
+		if [[ "$line" =~ $regex ]]; then
+			result="${rule_id}|${script}|${line_range}|${description}"
+			break
 		fi
-	done <<< "$inventory"
+	done <<< "$_RULE_INVENTORY"
 
-	printf '%s|||Unclassified pulse log entry\n' "$_UNCLASSIFIED"
+	if [[ -n "$output_var" ]]; then
+		printf -v "$output_var" '%s' "$result"
+	else
+		printf '%s\n' "$result"
+	fi
 	return 0
 }
 
@@ -783,8 +794,8 @@ _cmd_pr_build_events() {
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
 		local ts classification
-		ts=$(_extract_timestamp "$line")
-		classification=$(_classify_log_line "$line")
+		_extract_timestamp "$line" ts
+		_classify_log_line "$line" classification
 
 		local rule_id script line_range description
 		IFS='|' read -r rule_id script line_range description <<< "$classification"
@@ -998,8 +1009,7 @@ cmd_rules() {
 		esac
 	done
 
-	local inventory
-	inventory=$(_build_rule_inventory)
+	local inventory="$_RULE_INVENTORY"
 	local count=0
 
 	if [[ "$json_output" -eq 1 ]]; then
@@ -1449,8 +1459,8 @@ _render_issue_linked_prs() {
 				[[ -z "$log_line" ]] && continue
 				event_count=$((event_count + 1))
 				local ts="" classification="" rule_id="" script_name="" line_range="" description=""
-				ts=$(_extract_timestamp "$log_line")
-				classification=$(_classify_log_line "$log_line")
+				_extract_timestamp "$log_line" ts
+				_classify_log_line "$log_line" classification
 				IFS='|' read -r rule_id script_name line_range description <<< "$classification"
 				[[ "$rule_id" == "$_UNCLASSIFIED" && "$verbose" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
 				printf '    %s  %b%-25s%b  %s\n' \

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -264,6 +264,10 @@ if [[ "$*" == *"pr view"*"29285"* ]]; then
   fi
   exit 0
 fi
+if [[ "$*" == *"pr view"*"30321"* ]]; then
+  echo '{"number":30321,"title":"classifier performance fixture","state":"OPEN","author":{"login":"worker"},"mergedAt":null,"closedAt":null,"createdAt":"2026-08-16T20:00:00Z","labels":[],"reviewDecision":"","mergeStateStatus":"CLEAN","headRefName":"feature/performance-fixture","baseRefName":"main","isDraft":false}'
+  exit 0
+fi
 if [[ "$*" == *"issue view"*"21860"* ]]; then
   cat <<'JSON'
 {"number":21860,"title":"t3206: worker re-dispatch loops on same branch","state":"OPEN","author":{"login":"marcusquinn"},"createdAt":"2026-04-26T08:00:00Z","closedAt":null,"labels":[{"name":"auto-dispatch"},{"name":"status:queued"}],"assignees":[]}
@@ -368,6 +372,36 @@ if command -v jq >/dev/null 2>&1; then
 		FAIL=$((FAIL + 1))
 		printf '  ✗ JSON rules array has ≥30 entries (got %s)\n' "$jq_count"
 	fi
+fi
+
+# --- Test 3b: event classification has no per-line external processes ---
+printf '\nTest 3b: event classification hot path\n'
+classifier_body=$(awk '/^_classify_log_line\(\)/ { capture=1 } capture { print } capture && /^}/ { exit }' "$HELPER")
+timestamp_body=$(awk '/^_extract_timestamp\(\)/ { capture=1 } capture { print } capture && /^}/ { exit }' "$HELPER")
+assert_not_contains "classifier avoids external grep" "grep" "$classifier_body"
+assert_not_contains "timestamp extraction avoids external grep" "grep" "$timestamp_body"
+assert_contains "classifier uses Bash regex matching" "=~ \$regex" "$classifier_body"
+
+PERF_LOGFILE="${TMPDIR_TEST}/pulse-performance.log"
+: >"$PERF_LOGFILE"
+for perf_index in $(seq 1 1000); do
+	printf '2026-08-16T20:00:%02dZ [pulse-mystery] unknown event %d for PR #30321\n' \
+		"$((perf_index % 60))" "$perf_index" >>"$PERF_LOGFILE"
+done
+perf_started=$(date +%s)
+output=$(PULSE_DIAGNOSE_LOGFILE="$PERF_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="${TMPDIR_TEST}/performance-logdir" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" pr 30321 --repo marcusquinn/aidevops 2>&1) || true
+perf_elapsed=$(($(date +%s) - perf_started))
+assert_contains "large event set preserves unclassified count" "Unclassified pulse events: 1000" "$output"
+TOTAL=$((TOTAL + 1))
+if [[ "$perf_elapsed" -lt 15 ]]; then
+	PASS=$((PASS + 1))
+	printf '  ✓ 1000-event classification finishes within 15s (got %ss)\n' "$perf_elapsed"
+else
+	FAIL=$((FAIL + 1))
+	printf '  ✗ 1000-event classification finishes within 15s (got %ss)\n' "$perf_elapsed"
 fi
 
 # --- Test 4: PR #20329 — escalated dirty PR (notify + admin-bypass merge) ---


### PR DESCRIPTION
## Summary

Cache the pulse diagnostic rule inventory once and remove per-event grep, timestamp, and classifier subprocesses while preserving existing output semantics.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 134/134 focused pulse diagnostic tests; ShellCheck clean; linters-local.sh passed; 1000-event regression completed in 5s under a 15s ceiling.

Resolves #30320


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.267 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 10m and 572,340 tokens on this with the user in an interactive session.