### PR TITLE
GH#30323 GH#30324 GH#30325: Fix planning publication intent

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -536,6 +536,12 @@ create_github_issue() {
 	local description="$2"
 	local labels="$3"
 	local repo_path="$4"
+	local canonical_labels="$labels"
+	local skip_wrapper_auto_assignment=0
+	if [[ ",${canonical_labels}," == *",auto-dispatch,"* ||
+		",${canonical_labels}," == *",parent-task,"* ]]; then
+		skip_wrapper_auto_assignment=1
+	fi
 
 	cd "$repo_path" || return 1
 
@@ -651,7 +657,8 @@ create_github_issue() {
 	[[ -n "$labels" ]] && create_args+=(--label "$labels")
 
 	local issue_url
-	if ! issue_url=$(gh_create_issue "${create_args[@]}" 2>&1); then
+	if ! issue_url=$(AIDEVOPS_GH_SKIP_AUTO_ASSIGNMENT="$skip_wrapper_auto_assignment" \
+		gh_create_issue "${create_args[@]}" 2>&1); then
 		log_warn "Failed to create GitHub issue: $issue_url"
 		return 1
 	fi
@@ -724,7 +731,7 @@ create_github_issue() {
 	# the TODO entry is never written. This call closes that gap idempotently.
 	# GH#21473: pass $title (one-liner), not $description (full body).
 	if ! _converge_created_issue_ref \
-		"$_task_id_for_todo" "$issue_num" "$title" "$labels" "$repo_path"; then
+		"$_task_id_for_todo" "$issue_num" "$title" "$canonical_labels" "$repo_path"; then
 		log_warn "Created issue #${issue_num}, but failed to persist task mapping for ${_task_id_for_todo}"
 		return 1
 	fi

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -577,7 +577,7 @@ commit_planning_files() {
 	current_branch=$(git -C "$repo_root" symbolic-ref --short HEAD 2>/dev/null) || return 1
 	local default_branch=""
 	default_branch=$(_todo_default_branch "$repo_root")
-	if [[ "$current_branch" == "$default_branch" ]] && _todo_branch_requires_planning_pr "$repo_root" "$default_branch"; then
+	if _todo_branch_requires_planning_pr "$repo_root" "$default_branch"; then
 		todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"
 		local publication_rc=$?
 		[[ "$publication_rc" -eq 0 ]] &&
@@ -587,7 +587,7 @@ commit_planning_files() {
 	local changed_paths=""
 	changed_paths=$(_planning_publish_changed_paths "$repo_root")
 	if AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
-		planning_publish "$repo_root" "$commit_msg" origin "$current_branch" "$changed_paths"; then
+		planning_publish "$repo_root" "$commit_msg" origin "$default_branch" "$changed_paths"; then
 		if [[ "$PLANNING_PUBLISHED_COMMIT" != "$PLANNING_PUBLICATION_SOURCE_HEAD" &&
 			(-z "$PLANNING_PUBLICATION_RECEIPT" || -z "$PLANNING_PUBLICATION_HANDOFF_ID") ]]; then
 			log_error "Planning files reached the remote branch, but no verified checkout-free merge handoff receipt is available"

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -571,7 +571,12 @@ gh_create_issue() {
 	local issue_output rc auto_assignee="" target_repo=""
 	target_repo=$(_gh_extract_repo_from_args "$@" 2>/dev/null || true)
 	if ! _gh_wrapper_args_have_assignee "$@"; then
-		if _gh_wrapper_args_have_label "$_GH_CREATE_AUTO_DISPATCH_LABEL" "$@"; then
+		if [[ "${AIDEVOPS_GH_SKIP_AUTO_ASSIGNMENT:-0}" == 1 ]]; then
+			# GH#30325: pending publication withholds auto-dispatch from the
+			# issue, so trusted callers pass the original ownership intent
+			# separately for the shared GraphQL/REST creation path.
+			print_info "[INFO] caller ownership policy skips self-assignment"
+		elif _gh_wrapper_args_have_label "$_GH_CREATE_AUTO_DISPATCH_LABEL" "$@"; then
 			# t2157/t2406: auto-dispatch means worker-owned; skip self-assignment.
 			print_info "[INFO] auto-dispatch label present — skipping self-assignment per t2157"
 		else

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -519,12 +519,11 @@ _todo_commit_push_inner() {
 
 	current_branch=$(_todo_current_branch "$repo_path")
 	default_branch=$(_todo_default_branch "$repo_path")
-	if [[ -n "$current_branch" && -n "$default_branch" && "$current_branch" == "$default_branch" ]]; then
-		if _todo_branch_requires_planning_pr "$repo_path" "$default_branch"; then
-			printf '%s\n' "[todo_commit_push] Default branch ${default_branch} requires PR publication for planning files" >>"$log_target"
-			_todo_create_planning_pr "$repo_path" "$commit_msg" "$files" "$current_branch" "$default_branch" "$log_target"
-			return $?
-		fi
+	if [[ -n "$current_branch" && -n "$default_branch" ]] &&
+		_todo_branch_requires_planning_pr "$repo_path" "$default_branch"; then
+		printf '%s\n' "[todo_commit_push] Default branch ${default_branch} requires PR publication for planning files" >>"$log_target"
+		_todo_create_planning_pr "$repo_path" "$commit_msg" "$files" "$current_branch" "$default_branch" "$log_target"
+		return $?
 	fi
 
 	current_branch=$(_todo_current_branch "$repo_path")

--- a/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
+++ b/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
@@ -102,6 +102,14 @@ export AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE=1
 # shellcheck source=../shared-constants.sh
 source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true
 
+_gh_collaborator_permission_lookup() {
+	local _repo_slug="$1"
+	local _username="$2"
+	local out_var="$3"
+	printf -v "$out_var" '%s' "write"
+	return 0
+}
+
 # Re-override print_info AFTER sourcing to restore our capturing stub.
 # shellcheck disable=SC2317
 print_info() { printf '[INFO] %s\n' "$*" >>"${GH_INFO_OUTPUT}"; return 0; }
@@ -143,6 +151,10 @@ gh() {
 	# User endpoint — for _gh_wrapper_auto_assignee
 	if [[ "$1" == "api" && "$2" == "user" ]]; then
 		printf '"testuser"\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "$2" == "repos/owner/repo" ]]; then
+		printf 'false\n'
 		return 0
 	fi
 
@@ -194,6 +206,25 @@ if grep -qE '^api.*-X POST.*/repos/owner/repo/issues' "$GH_CALLS" 2>/dev/null; t
 else
 	fail "gh_create_issue routes to REST when GraphQL exhausted (issue create path)" \
 		"expected 'api -X POST /repos/owner/repo/issues' in GH_CALLS; got: $(cat "$GH_CALLS")"
+fi
+
+# The pre-creation ownership policy is transport-independent: the REST fallback
+# must not add an assignee when pending publication hides auto-dispatch.
+: >"$GH_CALLS"
+AIDEVOPS_SESSION_ORIGIN=interactive AIDEVOPS_GH_SKIP_AUTO_ASSIGNMENT=1 \
+	STUB_PRIMARY_FAIL=1 STUB_RATE_LIMIT_REMAINING=0 _GH_SHOULD_FALLBACK_OVERRIDE=1 \
+	gh_create_issue \
+		--repo "owner/repo" \
+		--title "t9991: pending rest-routing test" \
+		--body "test body" \
+		--label "bug,publication:pending" >/dev/null 2>&1 || true
+
+if grep -qE '^api.*-X POST.*/repos/owner/repo/issues' "$GH_CALLS" 2>/dev/null &&
+	! grep -q -- 'issue edit .*--add-assignee' "$GH_CALLS" 2>/dev/null; then
+	pass "REST fallback preserves explicit no-assignment ownership policy"
+else
+	fail "REST fallback preserves explicit no-assignment ownership policy" \
+		"expected REST creation without post-create assignment"
 fi
 
 # Test 2: gh_create_issue does NOT call REST when primary succeeds

--- a/.agents/scripts/tests/test-claim-task-id-status-default.sh
+++ b/.agents/scripts/tests/test-claim-task-id-status-default.sh
@@ -21,6 +21,8 @@ FAIL=0
 ERRORS=""
 STUB_DIR=""
 CREATE_ARGS_FILE=""
+CANONICAL_LABELS_FILE=""
+SKIP_ASSIGNMENT_FILE=""
 
 pass() {
 	local name="$1"
@@ -74,6 +76,8 @@ _setup() {
 	mkdir -p "${STUB_DIR}/repo" "${STUB_DIR}/home/.aidevops/logs"
 	export HOME="${STUB_DIR}/home"
 	CREATE_ARGS_FILE="${STUB_DIR}/create-args.txt"
+	CANONICAL_LABELS_FILE="${STUB_DIR}/canonical-labels.txt"
+	SKIP_ASSIGNMENT_FILE="${STUB_DIR}/skip-assignment.txt"
 
 	# shellcheck disable=SC1090
 	if ! source "$CLAIM_SCRIPT" >/dev/null 2>&1; then
@@ -104,7 +108,18 @@ _setup() {
 	gh_create_issue() {
 		local args="$*"
 		printf '%s\n' "$args" >"$CREATE_ARGS_FILE"
+		printf '%s\n' "${AIDEVOPS_GH_SKIP_AUTO_ASSIGNMENT:-0}" >"$SKIP_ASSIGNMENT_FILE"
 		printf '%s\n' 'https://github.com/owner/repo/issues/12345'
+		return 0
+	}
+
+	_converge_created_issue_ref() {
+		local _task_id="$1"
+		local _issue_num="$2"
+		local _title="$3"
+		local labels="$4"
+		local _repo_path="$5"
+		printf '%s\n' "$labels" >"$CANONICAL_LABELS_FILE"
 		return 0
 	}
 
@@ -144,6 +159,8 @@ run_create() {
 	local state="${2:-pending}"
 	TASK_PUBLICATION_STATE="$state"
 	: >"$CREATE_ARGS_FILE"
+	: >"$CANONICAL_LABELS_FILE"
+	: >"$SKIP_ASSIGNMENT_FILE"
 	create_github_issue "t2789: test default status label" "body" "$labels" "${STUB_DIR}/repo" >/dev/null
 	local create_args=""
 	create_args=$(<"$CREATE_ARGS_FILE")
@@ -157,6 +174,11 @@ args_default=$(run_create 'auto-dispatch,tier:standard,bug')
 assert_contains "pending_blocker_added" "$args_default" '--label tier:standard,bug,publication:pending'
 assert_not_contains "pending_auto_dispatch_withheld" "$args_default" 'auto-dispatch'
 assert_not_contains "pending_status_available_withheld" "$args_default" 'status:available'
+canonical_labels=$(<"$CANONICAL_LABELS_FILE")
+assert_contains "pending_canonical_auto_dispatch_preserved" "$canonical_labels" 'auto-dispatch'
+assert_not_contains "pending_canonical_blocker_not_persisted" "$canonical_labels" 'publication:pending'
+skip_assignment=$(<"$SKIP_ASSIGNMENT_FILE")
+assert_contains "pending_worker_intent_skips_wrapper_assignment" "$skip_assignment" '1'
 
 args_empty=$(run_create '')
 assert_contains "empty_labels_pending_blocker_added" "$args_empty" '--label publication:pending'

--- a/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
+++ b/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
@@ -193,6 +193,22 @@ else
 		"expected issue edit --add-assignee after an unassigned create"
 fi
 
+# Pending publication deliberately withholds auto-dispatch from the issue but
+# passes the original worker-owned policy out of band (GH#30325).
+: >"$GH_CALLS"
+AIDEVOPS_GH_SKIP_AUTO_ASSIGNMENT=1 gh_create_issue \
+	--repo "owner/repo" \
+	--title "t9992: pending worker task" \
+	--body "test body" \
+	--label "bug,publication:pending" >/dev/null 2>&1 || true
+
+if ! grep -q -- "issue edit .*--add-assignee" "$GH_CALLS" 2>/dev/null; then
+	pass "explicit worker ownership policy skips post-create assignment"
+else
+	fail "explicit worker ownership policy skips post-create assignment" \
+		"unexpected assignment call when pending labels hide auto-dispatch"
+fi
+
 # =============================================================================
 # Test 3 — auto-dispatch in labels → [INFO] skip message emitted
 # =============================================================================

--- a/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
@@ -49,6 +49,7 @@ fail() {
 setup_repo() {
 	local tmpdir="$1"
 	local protected_default="$2"
+	local work_branch="${3:-fixture-default}"
 	local bare_dir="${tmpdir}/remote.git"
 	local local_dir="${tmpdir}/local.git"
 	local work_dir="${tmpdir}/work"
@@ -69,6 +70,9 @@ setup_repo() {
 	git -C "$work_dir" push origin fixture-default >/dev/null 2>&1 || return 1
 	git -C "$work_dir" fetch origin fixture-default >/dev/null 2>&1 || return 1
 	git -C "$work_dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/fixture-default >/dev/null 2>&1 || return 1
+	if [[ "$work_branch" != "fixture-default" ]]; then
+		git -C "$work_dir" switch -c "$work_branch" >/dev/null 2>&1 || return 1
+	fi
 
 	if [[ "$protected_default" == "true" ]]; then
 		mkdir -p "${bare_dir}/hooks" || return 1
@@ -105,6 +109,11 @@ set -u
 } >>"${GH_STUB_LOG:?}"
 
 if [[ "${1:-}" == "label" && "${2:-}" == "create" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/example/repo" ]]; then
+	printf 'false\n'
 	exit 0
 fi
 
@@ -295,6 +304,108 @@ test_unprotected_default_keeps_direct_push() {
 	return 0
 }
 
+test_protected_default_from_linked_branch_creates_planning_pr() {
+	local name="protected default from linked branch creates planning PR"
+	local tmpdir fake_bin work_dir log_file output rc head_branch remote_todo
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	fake_bin="${tmpdir}/bin"
+	log_file="${tmpdir}/gh.log"
+	: >"$log_file"
+	write_fake_gh "$fake_bin" || {
+		fail "$name" "fake gh setup failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" true fixture-linked) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t1002" || {
+		fail "$name" "planning change failed"
+		return 0
+	}
+
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="$log_file" GH_STUB_BODY="${tmpdir}/body" GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: add t1002 linked protected planning" 2>&1) || rc=$?
+	if [[ $rc -ne 0 || "$output" != *"AIDEVOPS_PLANNING_COMMIT_RESULT=pr"* ]]; then
+		fail "$name" "helper failed or omitted PR result rc=$rc output=$output"
+		return 0
+	fi
+	head_branch=$(<"${tmpdir}/head")
+	if [[ "$head_branch" != planning/* ]]; then
+		fail "$name" "unexpected PR head: ${head_branch:-<empty>}"
+		return 0
+	fi
+	remote_todo=$(git -C "$work_dir" show "origin/fixture-default:TODO.md" 2>/dev/null || true)
+	if [[ "$remote_todo" == *"t1002"* ]]; then
+		fail "$name" "protected default branch was updated directly"
+		return 0
+	fi
+	if git -C "$work_dir" show-ref --verify --quiet refs/remotes/origin/fixture-linked; then
+		fail "$name" "linked source branch was published instead of a planning PR"
+		return 0
+	fi
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_unprotected_default_from_linked_branch_publishes_default() {
+	local name="unprotected default from linked branch publishes canonical default"
+	local tmpdir fake_bin work_dir log_file output rc status remote_todo
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	fake_bin="${tmpdir}/bin"
+	log_file="${tmpdir}/gh.log"
+	: >"$log_file"
+	write_fake_gh "$fake_bin" || {
+		fail "$name" "fake gh setup failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" false fixture-linked) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t1003" || {
+		fail "$name" "planning change failed"
+		return 0
+	}
+
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="$log_file" GH_STUB_BODY="${tmpdir}/body" GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		"$PLANNING_HELPER" "plan: add t1003 linked direct planning" 2>&1) || rc=$?
+	if [[ $rc -ne 0 || "$output" != *"AIDEVOPS_PLANNING_COMMIT_RESULT=direct"* ]]; then
+		fail "$name" "helper failed or omitted direct result rc=$rc output=$output"
+		return 0
+	fi
+	status=$(git -C "$work_dir" status --short 2>/dev/null)
+	if [[ "$status" != *"TODO.md"* || "$status" != *"todo/"* ]]; then
+		fail "$name" "source planning edits were not preserved: $status"
+		return 0
+	fi
+	git -C "$work_dir" fetch origin fixture-default >/dev/null 2>&1 || true
+	remote_todo=$(git -C "$work_dir" show origin/fixture-default:TODO.md 2>/dev/null || true)
+	if [[ "$remote_todo" != *"t1003"* ]]; then
+		fail "$name" "canonical default did not receive linked planning changes"
+		return 0
+	fi
+	if git -C "$work_dir" show-ref --verify --quiet refs/remotes/origin/fixture-linked; then
+		fail "$name" "linked source branch was published instead of canonical default"
+		return 0
+	fi
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
 test_pr_unavailable_fails_before_commit() {
 	local name="PR fallback unavailable fails before local commit"
 	local tmpdir work_dir before_head after_head output rc status
@@ -347,6 +458,8 @@ main() {
 	fi
 	test_protected_default_creates_planning_pr
 	test_unprotected_default_keeps_direct_push
+	test_protected_default_from_linked_branch_creates_planning_pr
+	test_unprotected_default_from_linked_branch_publishes_default
 	test_pr_unavailable_fails_before_commit
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ "$FAIL" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

- publish planning changes to the canonical default branch from linked worktrees
- route protected default branches through the planning PR fallback regardless of the caller branch
- preserve canonical dispatch labels separately from temporary publication-pending labels
- preserve worker-owned no-assignment policy through both GraphQL and REST issue creation paths

## Implementation

- `.agents/scripts/planning-commit-helper.sh` and `.agents/scripts/shared-todo-commit.sh`: default-branch publication and protected-branch routing
- `.agents/scripts/claim-task-id.sh` and `.agents/scripts/shared-gh-wrappers-create.sh`: canonical label and ownership-policy propagation
- corresponding shell regression suites cover protected/unprotected linked branches, pending labels, and REST parity

## Verification

- `.agents/scripts/linters-local.sh`
- ShellCheck on all eight changed shell files
- planning publication matrix: 6/6
- claim-task status defaults: 11 assertions
- issue assignment policy: 9/9
- REST routing: 7/7
- planning publication lifecycle/reconcile, pending issue sync, and orphan mapping suites
- `git diff --check origin/main...HEAD`

Resolves #30323
Resolves #30324
Resolves #30325

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.268 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol
