### PR TITLE
GH#30331: report retained pulse permission blockers

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -114,6 +114,16 @@ successful `scoped_permission_granted` resume. A non-blocking grant event clears
 the prior blocker for the same worker session even though the envelope request
 ID differs from the source OpenCode request ID.
 
+For an interactive-safe live worker count, run
+`worker-activity-helper.sh live-workers`; do not source `pulse-wrapper.sh` merely
+to call `list_active_worker_processes`. When `pulse-check-helper.sh report` shows
+retained supervisor permission blockers, compare that count with `live-workers`
+and the bounded summary. A retained record with no live matching owner is
+historical evidence, not a failed or active worker. After confirming the session
+is stale, append an auditable terminal reconciliation with
+`worker-blocker-cli.mjs resolve-session` using its exact repository, session, and
+request scope. Never delete the JSONL evidence or reconcile a live owner.
+
 ## Manual Worker Launch
 
 Use `aidevops launch-worker` when an operator needs a controlled headless

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -202,6 +202,7 @@ _render_text_report() {
 		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text) + "; delivered success rate: " + (.summary.historical_delivery_success_rate | percent_text),
 		"- GraphQL/API: " + (.summary.graphql_budget_status // "unknown"),
 		"- Runner health: " + (.summary.runner_health // "unknown"),
+		"- Retained supervisor permission blockers: " + (.summary.retained_supervisor_permission_blockers | tostring) + " (advisory only; does not change runner health)",
 		"",
 		"## Findings",
 		(if (.findings | length) == 0 then "- None above thresholds" else (.findings[] | "- [" + .severity + "] " + .title + " (`" + .id + "`) — " + .recommendation) end),
@@ -210,6 +211,7 @@ _render_text_report() {
 		"- pulse-current-state-helper.sh --window " + .inputs.current_window + " --json",
 		"- worker-activity-helper.sh summary --since " + .inputs.recent_window + " --json --no-pr-check",
 		"- worker-activity-helper.sh summary --since " + .inputs.historical_window + " --json --no-pr-check",
+		"- worker-activity-helper.sh live-workers",
 		"- pulse-diagnose-helper.sh cycle-health --window 1h",
 		"",
 		"Privacy: report aggregates repos.json queue state and omits repo slugs, local paths, and issue titles."

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -44,6 +44,12 @@ end) as $max_workers |
 (if $hist_delivery.delivered_successes == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
 ($summary.metrics.failure_families // []) as $failure_families |
 ($recent_summary.metrics.failure_families // []) as $recent_failure_families |
+($summary.progress_blockers // {}) as $progress_blockers |
+([$progress_blockers.retained_unverified[]?
+  | select(((.reason // "") | contains("permission"))
+    and ((((.session_key // "") | startswith("supervisor-pulse")))
+      or (((.source // "") | contains("supervisor-pulse")))))] | length) as $bounded_retained_supervisor_permission_blockers |
+($progress_blockers.retained_supervisor_permission_total // $bounded_retained_supervisor_permission_blockers | number_or_zero) as $retained_supervisor_permission_blockers |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
 {
   generated_at: (now | todateiso8601),
@@ -77,6 +83,7 @@ end) as $max_workers |
     auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
     graphql_budget_status: ($current.graphql_budget_status // "unknown"),
     runner_health: ($runner.finding // "unknown"),
+    retained_supervisor_permission_blockers: $retained_supervisor_permission_blockers,
     recurrent_failure_families: ([$failure_families[] | select((.count // 0) >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")] | length)
   },
   queue: ($queue.aggregate // {}),
@@ -103,7 +110,14 @@ end) as $max_workers |
       pulse_stats: ($recent_summary.pulse_stats // {}),
       delivery_stages: ($recent_summary.delivery_stages // {check_state: "unavailable"})
     },
-    providers: ($providers.provider_diagnostics // {})
+    providers: ($providers.provider_diagnostics // {}),
+    progress_blockers: {
+      scope: ($progress_blockers.scope // "global"),
+      events_in_window: ($progress_blockers.event_total // 0),
+      proven_current: ($progress_blockers.active_total // 0),
+      retained_unverified: ($progress_blockers.retained_unverified_total // 0),
+      retained_supervisor_permission: $retained_supervisor_permission_blockers
+    }
   },
   failure_family_remediation: ($failure_families | map(. as $family | {
     fingerprint,
@@ -125,6 +139,20 @@ end) as $max_workers |
     cadence_api_risk: ($api.cadence_api_risk // "unknown")
   },
   findings: ([
+    if $retained_supervisor_permission_blockers > 0 then
+      finding(
+        "retained-supervisor-permission-blockers";
+        "medium";
+        "Retained supervisor permission blockers require classification";
+        [
+          ("retained_supervisor_permission_blockers=" + ($retained_supervisor_permission_blockers | tostring)),
+          ("retained_unverified_blockers_all_sources=" + (($progress_blockers.retained_unverified_total // 0) | tostring)),
+          "blocker_evidence=aggregate_redacted"
+        ];
+        "Run worker-activity-helper.sh live-workers and worker-activity-helper.sh summary --since 7d to classify retained records. Reconcile only confirmed stale sessions by appending an audited non-blocking terminal event with worker-blocker-cli.mjs resolve-session; do not delete blocker evidence or clear records that still have a live owner.";
+        false
+      )
+    else empty end,
     if $dependency_inconsistent > 0 then
       finding(
         "pulse-dependency-inconsistent-availability";

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -135,6 +135,12 @@ if [[ "$cmd" == "providers" ]]; then
 JSON
   exit 0
 fi
+if [[ "${PULSE_CHECK_BLOCKER_FIXTURE:-}" == "retained" ]]; then
+  cat <<'JSON'
+{"window":{"since":"7d"},"metrics":{"total":0,"terminal_session_total":0,"runtime_handoffs":0,"succeeded":null,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"samples":0,"avg":0,"max":0},"recent_examples":[],"failure_groups":[],"failure_families":[]},"pulse_stats":{},"progress_blockers":{"scope":"global","event_total":13,"active_total":0,"retained_unverified_total":13,"retained_supervisor_permission_total":12,"active_blockers":[],"retained_unverified":[{"reason":"permission_required","source":"opencode-permission-broker","session_key":"supervisor-pulse","repo_slug":"private/repo-one","detail":"/private/path"},{"reason":"permission_required","source":"opencode-permission-broker","session_key":"supervisor-pulse-retry","repo_slug":"private/repo-two","detail":"private title"},{"reason":"permission_required","source":"opencode-permission-broker","session_key":"manual-cli","repo_slug":"private/repo-three"}]},"delivery_stages":{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped"}}
+JSON
+  exit 0
+fi
 since="24h"
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -295,6 +301,18 @@ assert_contains "underfilled finding appears" "pulse-underfilled-auto-dispatch-q
 assert_contains "launch accounting finding appears" "pulse-launch-accounting-gap" "$OUT"
 assert_not_contains "text report omits private slug" "private/repo-one" "$OUT"
 assert_not_contains "text report omits issue titles" "secret one" "$OUT"
+
+BLOCKER_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_BLOCKER_FIXTURE=retained" "$HELPER" report --since 7d 2>&1)
+assert_contains "healthy idle report exposes retained supervisor blocker advisory" "retained-supervisor-permission-blockers" "$BLOCKER_OUT"
+assert_contains "retained blocker report preserves healthy runner state" "Runner health: HEALTHY" "$BLOCKER_OUT"
+assert_contains "retained blocker report shows zero active workers" "Active workers: 0 / 6" "$BLOCKER_OUT"
+assert_contains "retained blocker report gives no-source worker count command" "worker-activity-helper.sh live-workers" "$BLOCKER_OUT"
+assert_contains "retained blocker report gives audited reconciliation guidance" "worker-blocker-cli.mjs resolve-session" "$BLOCKER_OUT"
+assert_not_contains "retained blocker report omits private blocker slug" "private/repo-one" "$BLOCKER_OUT"
+assert_not_contains "retained blocker report omits private blocker path" "/private/path" "$BLOCKER_OUT"
+BLOCKER_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_BLOCKER_FIXTURE=retained" "$HELPER" json --since 7d 2>&1)
+assert_eq "json uses uncapped retained supervisor permission aggregate" "12" "$(printf '%s' "$BLOCKER_JSON" | jq -r '.summary.retained_supervisor_permission_blockers')"
+assert_not_contains "retained blocker JSON omits private blocker title" "private title" "$BLOCKER_JSON"
 
 JSON_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" json 2>&1)
 IDS=$(printf '%s' "$JSON_OUT" | jq -r '[.findings[].id] | sort | join(",")')

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -207,7 +207,7 @@ OWNER_PROCESS_START=$(_test_process_start_token "$$")
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_awaiting_approval","status":"blocked","reason":"needs_maintainer_permissions","blocking":true,"source":"test","issue_number":22,"repo_slug":"marcusquinn/aidevops","session_key":"issue-22","request_id":"perm-old"}\n' "$T_25H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-terminal","request_id":"perm-terminal"}\n' "$((T_25H_AGO - 2))"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"headless_session_terminal_reconciled","status":"resolved","reason":"success","blocking":false,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-terminal","request_id":"perm-terminal"}\n' "$((T_25H_AGO - 1))"
-	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-retained","request_id":"perm-retained"}\n' "$T_25H_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"opencode-permission-broker","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"supervisor-pulse","request_id":"perm-retained"}\n' "$T_25H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-live","request_id":"perm-live"}\n' "$T_25H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-pid-reuse","request_id":"perm-pid-reuse"}\n' "$T_25H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":null,"repo_slug":"marcusquinn/aidevops","session_key":"routine-legacy","request_id":"perm-legacy"}\n' "$T_25H_AGO"
@@ -217,8 +217,8 @@ OWNER_PROCESS_START=$(_test_process_start_token "$$")
 
 {
 	printf '{"session_key":"routine-live","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"owner_process_start":"%s","status":"in-flight","updated_at":"2026-07-26T01:00:00Z"}\n' "$$" "$OWNER_PROCESS_START"
-	printf '{"session_key":"routine-retained","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"owner_process_start":"%s","status":"in-flight","updated_at":"2026-07-26T01:00:01Z"}\n' "$$" "$OWNER_PROCESS_START"
-	printf '{"session_key":"routine-retained","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"status":"completed","updated_at":"2026-07-26T01:00:02Z"}\n' "$$"
+	printf '{"session_key":"supervisor-pulse","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"owner_process_start":"%s","status":"in-flight","updated_at":"2026-07-26T01:00:01Z"}\n' "$$" "$OWNER_PROCESS_START"
+	printf '{"session_key":"supervisor-pulse","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"status":"completed","updated_at":"2026-07-26T01:00:02Z"}\n' "$$"
 	printf '{"session_key":"routine-pid-reuse","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"owner_process_start":"not-%s","status":"in-flight","updated_at":"2026-07-26T01:00:03Z"}\n' "$$" "$OWNER_PROCESS_START"
 	printf '{"session_key":"routine-legacy","issue_number":"","repo_slug":"marcusquinn/aidevops","pid":%d,"status":"in-flight","updated_at":"2026-07-26T01:00:04Z"}\n' "$$"
 } >"$LEDGER"
@@ -422,8 +422,10 @@ assert_eq "2t: live null-issue session remains proven current" "1" \
 	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.active_blockers[] | select(.session_key == "routine-live")] | length')"
 assert_eq "2u: unowned null-issue records remain visible but unverified" "3" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.retained_unverified_total')"
+assert_eq "2u2: retained supervisor permission blockers have an uncapped aggregate" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.retained_supervisor_permission_total')"
 assert_eq "2v: retained bucket preserves the unowned session identity" "1" \
-	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.retained_unverified[] | select(.session_key == "routine-retained")] | length')"
+	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.retained_unverified[] | select(.session_key == "supervisor-pulse")] | length')"
 assert_eq "2w: mismatched PID identity is not treated as a live owner" "1" \
 	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.retained_unverified[] | select(.session_key == "routine-pid-reuse")] | length')"
 assert_eq "2x: legacy PID-only ownership remains unverified" "1" \
@@ -546,6 +548,8 @@ assert_contains "5i: human output shows failure families" "Failure families" "$O
 assert_contains "5j: human output shows bounded blocker evidence" "worker-progress-blockers.jsonl" "$OUT"
 assert_contains "5k: human output shows proven current blocker count" "Proven current:              3" "$OUT"
 assert_contains "5l: human output separates retained blocker count" "Retained/unverified:         3" "$OUT"
+assert_contains "5l2: human output shows retained supervisor permission count" \
+	"Retained supervisor perms:   1" "$OUT"
 assert_contains "5m: human output says reporting window is not a runtime limit" \
 	"observation only, not a worker runtime limit" "$OUT"
 

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -366,7 +366,7 @@ _wah_blocker_details_json() {
 	local live_sessions_json="${4:-[]}"
 	local blocker_log="$WAH_BLOCKER_LOG_FILE"
 	if [[ ! -f "$blocker_log" ]]; then
-		printf '{"event_total":0,"active_total":0,"retained_unverified_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"retained_unverified":[],"recent_blockers":[]}'
+		printf '{"event_total":0,"active_total":0,"retained_unverified_total":0,"retained_supervisor_permission_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"retained_unverified":[],"recent_blockers":[]}'
 		return 0
 	fi
 	jq -Rsc --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg repo "$repo_slug" --arg empty '' --argjson live_sessions "$live_sessions_json" '
@@ -397,13 +397,17 @@ _wah_blocker_details_json() {
 			event_total: ($window | length),
 			active_total: ($active | length),
 			retained_unverified_total: ($retained | length),
+			retained_supervisor_permission_total: ([$retained[]
+				| select(((.reason // "") | contains("permission"))
+					and ((((.session_key // "") | startswith("supervisor-pulse")))
+						or (((.source // "") | contains("supervisor-pulse")))))] | length),
 			event_counts: (reduce $window[] as $row ({}; .[$row.event // "unknown"] += 1)),
 			reason_counts: (reduce $window[] as $row ({}; .[$row.reason // "unknown"] += 1)),
 			active_blockers: ($active | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, timestamp, issue_number, repo_slug, session_key, request_id, event, reason, status, source, permission, tool, risk_level, grantable, detail})),
 			retained_unverified: ($retained | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, timestamp, issue_number, repo_slug, session_key, request_id, event, reason, status, source})),
 			recent_blockers: ($window | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, timestamp, issue_number, repo_slug, session_key, request_id, event, reason, status, blocking, source}))
 		}' "$blocker_log" 2>/dev/null ||
-		printf '{"event_total":0,"active_total":0,"retained_unverified_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"retained_unverified":[],"recent_blockers":[]}'
+		printf '{"event_total":0,"active_total":0,"retained_unverified_total":0,"retained_supervisor_permission_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"retained_unverified":[],"recent_blockers":[]}'
 	return 0
 }
 
@@ -689,6 +693,7 @@ _wah_emit_human() {
 	printf '  Events in window:            %s\n' "$(printf '%s' "$blocker_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')"
 	printf '  Proven current:              %s\n' "$(printf '%s' "$blocker_json" | jq -r '.active_total // 0' 2>/dev/null || printf '0')"
 	printf '  Retained/unverified:         %s\n' "$(printf '%s' "$blocker_json" | jq -r '.retained_unverified_total // 0' 2>/dev/null || printf '0')"
+	printf '  Retained supervisor perms:   %s\n' "$(printf '%s' "$blocker_json" | jq -r '.retained_supervisor_permission_total // 0' 2>/dev/null || printf '0')"
 	printf '  Reasons:                     %s\n' "$(printf '%s' "$blocker_json" | jq -c '.reason_counts // {}' 2>/dev/null || printf '{}')"
 	printf '  Active blockers:             %s\n' "$(printf '%s' "$blocker_json" | jq -c '.active_blockers // []' 2>/dev/null || printf '[]')"
 	printf '  Retained blockers:           %s\n' "$(printf '%s' "$blocker_json" | jq -c '.retained_unverified // []' 2>/dev/null || printf '[]')"

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -38,9 +38,8 @@ If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep
 
 ### 1. Normalise PATH and check capacity
 
-`pulse-wrapper.sh` is a bash library. If the host tool shell is zsh, run
-wrapper-backed snippets in a bash subshell, not by sourcing the wrapper directly
-from zsh. Example: `bash -lc 'source ~/.aidevops/agents/scripts/pulse-wrapper.sh; list_active_worker_processes'`.
+Use the standalone worker activity helper for capacity checks. It is safe in
+interactive command policies and does not require sourcing `pulse-wrapper.sh`.
 
 ```bash
 export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
@@ -48,8 +47,7 @@ export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
 
 MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
 [[ "$MAX_WORKERS" =~ ^[0-9]+$ ]] || MAX_WORKERS=4
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
+WORKER_COUNT=$(~/.aidevops/agents/scripts/worker-activity-helper.sh live-workers)
 [[ "$WORKER_COUNT" =~ ^[0-9]+$ ]] || WORKER_COUNT=0
 AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
 RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
@@ -175,10 +173,9 @@ After initial dispatch, enter a monitoring loop. Each cycle:
 3. **Check capacity**:
 
    ```bash
-   source ~/.aidevops/agents/scripts/pulse-wrapper.sh
    MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
    [[ "$MAX_WORKERS" =~ ^[0-9]+$ ]] || MAX_WORKERS=4
-   WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
+   WORKER_COUNT=$(~/.aidevops/agents/scripts/worker-activity-helper.sh live-workers)
    [[ "$WORKER_COUNT" =~ ^[0-9]+$ ]] || WORKER_COUNT=0
    AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
    ```


### PR DESCRIPTION
## Summary

Surface uncapped, privacy-safe retained supervisor permission blocker aggregates without changing healthy runner status, provide audited stale-session reconciliation guidance, and use the no-source live worker count path in pulse docs.

## Files Changed

- `.agents/reference/worker-diagnostics.md`
- `.agents/scripts/pulse-check-helper.sh`
- `.agents/scripts/pulse-check-report.jq`
- `.agents/scripts/worker-activity-helper.sh`
- `.agents/scripts/tests/test-pulse-check-helper.sh`
- `.agents/scripts/tests/test-worker-activity-helper.sh`
- `.agents/workflows/pulse.md`

## Runtime Testing

- **Risk level:** Critical (conservative keyword classification)
- **Verification:** runtime-verified — both targeted suites passed; local linters and ShellCheck passed; a live pulse-check report surfaced 7 retained supervisor blockers with aggregate-only evidence while preserving runner health independently.

Resolves #30331

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 17m and 200,707 tokens on this as a headless worker.