### PR TITLE
GH#30328: fix: recover stale worker sessions after DB seed failures

### DIFF
--- a/.agents/scripts/headless-runtime-invoke.sh
+++ b/.agents/scripts/headless-runtime-invoke.sh
@@ -96,6 +96,35 @@ _invoke_opencode_copy_isolated_auth() {
 }
 
 # Export isolated runtime paths and prepare continuation state.
+_invoke_opencode_discard_failed_continuation() {
+	local arg=""
+	local skip_session_value=0
+	local -a fresh_cmd=()
+
+	for arg in "${cmd[@]}"; do
+		if [[ "$skip_session_value" -eq 1 ]]; then
+			skip_session_value=0
+			continue
+		fi
+		case "$arg" in
+		--session)
+			skip_session_value=1
+			;;
+		--continue)
+			;;
+		*)
+			fresh_cmd+=("$arg")
+			;;
+		esac
+	done
+	cmd=("${fresh_cmd[@]}")
+	clear_session_id "${_invoke_provider:-}" "${_invoke_session_key:-}"
+	persisted_session=""
+	_invoke_persisted_session=""
+	_WORKER_PERSISTED_SESSION_ID=""
+	return 0
+}
+
 _invoke_opencode_export_isolation() {
 	[[ -n "$isolated_data_dir" ]] || return 0
 	export XDG_DATA_HOME="$isolated_data_dir"
@@ -134,6 +163,8 @@ _invoke_opencode_export_isolation() {
 			print_info "[lifecycle] db_seeded session=$_invoke_persisted_session pid=$$"
 		else
 			print_warning "[lifecycle] db_seed_failed session=$_invoke_persisted_session pid=$$"
+			_invoke_opencode_discard_failed_continuation
+			print_info "[lifecycle] db_seed_failed_fresh_session pid=$$"
 		fi
 	fi
 	if [[ -f "${isolated_data_dir}/opencode/auth.json" ]]; then

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -270,6 +270,7 @@ main() {
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_stale_session_retry_clears_continuation_state
+	test_db_seed_failure_starts_fresh_opencode_session
 	test_provider_sessions_scope_issue_keys_by_repo_slug
 	test_provider_sessions_keep_pulse_unscoped
 	test_blocked_completion_records_blocked_label

--- a/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
@@ -94,6 +94,39 @@ test_stale_session_retry_clears_continuation_state() {
 	return 0
 }
 
+test_db_seed_failure_starts_fresh_opencode_session() {
+	local state=""
+	state=$(
+		local persisted_session="ses_stale"
+		local _invoke_persisted_session="ses_stale" _WORKER_PERSISTED_SESSION_ID="ses_stale"
+		local _invoke_provider="openai" _invoke_session_key="issue-30328"
+		local cleared_provider="" cleared_key=""
+		local isolated_data_dir="${TEST_ROOT}/failed-seed-isolation"
+		local runtime_role="worker" public_triage=0 private_workload=0
+		local -a cmd=(opencode run prompt --session ses_stale --continue --title title)
+		clear_session_id() {
+			cleared_provider="$1"
+			cleared_key="$2"
+			return 0
+		}
+		_headless_run_is_ephemeral() { return 0; }
+		_sync_worker_db_migration_metadata() { return 0; }
+		_seed_worker_db_session_context() { return 1; }
+		print_info() { return 0; }
+		print_warning() { return 0; }
+		_invoke_opencode_export_isolation >/dev/null
+		printf '%s|%s|%s|%s|%s' "${cmd[*]}" "$persisted_session" "$_invoke_persisted_session" \
+			"$_WORKER_PERSISTED_SESSION_ID" "${cleared_provider}:${cleared_key}"
+	)
+
+	if [[ "$state" == "opencode run prompt --title title||||openai:issue-30328" ]]; then
+		print_result "DB seed failure removes stale continuation command state" 0
+		return 0
+	fi
+	print_result "DB seed failure removes stale continuation command state" 1 "state=${state:-<empty>}"
+	return 0
+}
+
 test_provider_sessions_scope_issue_keys_by_repo_slug() {
 	local provider="openai"
 	local model="openai/gpt-5.5"


### PR DESCRIPTION
## Summary

Clears the persisted session record and strips continuation flags when isolated OpenCode DB seeding fails, then launches a fresh session. Adds regression coverage for the seed-failure path.

## Files Changed

.agents/scripts/headless-runtime-invoke.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-headless-runtime-provider-tests.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with the isolated DB-seed failure fixture; shellcheck .agents/scripts/headless-runtime-invoke.sh .agents/scripts/tests/test-headless-runtime-provider-tests.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #30328


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 11m and 112,697 tokens on this as a headless worker.