### PR TITLE
GH#30334: classify shared command policy failures

### DIFF
--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -192,6 +192,7 @@ def compress_steerage(chunks_dir: Path) -> dict:
 
 
 _SEVERITY_RANK = {
+    "command_policy": "high",
     "permission": "high",
     "not_read_first": "high",
     "edit_stale_read": "medium",

--- a/.agents/scripts/session-miner/extract_errors.py
+++ b/.agents/scripts/session-miner/extract_errors.py
@@ -20,6 +20,7 @@ from extract_shared import (
 
 
 ERROR_CATEGORIES = {
+    "command_policy": re.compile(r"BLOCKED\s+by\s+shared\s+command\s+policy", re.IGNORECASE),
     "workdir_not_found": re.compile(r"NotFound:\s*FileSystem\.access\s*\(", re.IGNORECASE),
     "file_not_found": re.compile(r"(file not found|no such file|ENOENT)", re.IGNORECASE),
     "edit_stale_read": re.compile(r"modified since.*(last read|was read)", re.IGNORECASE),

--- a/.agents/scripts/tests/test-session-miner-error-classification.sh
+++ b/.agents/scripts/tests/test-session-miner-error-classification.sh
@@ -9,13 +9,16 @@ SESSION_MINER_DIR="${SCRIPT_DIR}/../session-miner"
 
 python3 - "$SESSION_MINER_DIR" <<'PY'
 import sys
+from collections import Counter, defaultdict
 
 sys.path.insert(0, sys.argv[1])
 
+from compress import _build_error_patterns
 from extract_errors import classify_error
 
 
 cases = {
+    "BLOCKED by shared command policy (forbid, command.parse-error): unsupported": "command_policy",
     "NotFound: FileSystem.access ([local-worktree])": "workdir_not_found",
     "ENOENT: no such file or directory, open 'missing.txt'": "file_not_found",
     "Error: must Read before Edit": "not_read_first",
@@ -25,6 +28,15 @@ for raw_error, expected in cases.items():
     actual = classify_error(raw_error)
     if actual != expected:
         raise SystemExit(f"expected {expected!r} for {raw_error!r}, got {actual!r}")
+
+patterns = _build_error_patterns(
+    Counter({"bash:command_policy": 1}),
+    defaultdict(list),
+    defaultdict(list),
+    defaultdict(set, {"bash:command_policy": {"model-a"}}),
+)
+if patterns[0]["severity"] != "high":
+    raise SystemExit(f"expected command_policy severity 'high', got {patterns[0]['severity']!r}")
 
 print("session-miner error classification tests passed")
 PY


### PR DESCRIPTION
Resolves #30334

## Summary

- Classify deterministic shared command-policy blocks separately from unmatched Bash errors.
- Mark command-policy failures as high severity in compressed session-miner feedback.
- Cover classification and severity mapping with the focused session-miner test.

## Testing

- `bash .agents/scripts/tests/test-session-miner-error-classification.sh`
- `python3 -m py_compile .agents/scripts/session-miner/extract_errors.py .agents/scripts/session-miner/compress.py`
- `shellcheck .agents/scripts/tests/test-session-miner-error-classification.sh`

## Runtime Testing

Self-assessed: this low-risk error-classification change is covered by focused unit execution and Python compilation.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 53,230 tokens on this as a headless worker.
