### PR TITLE
GH#30335: docs: clarify OpenCode Bash tool restrictions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -79,6 +79,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Prefer exact search first: with Bash use scoped `rg` (or `git grep` for tracked content); use the runtime Grep tool only without Bash or for bounded searches. Use targeted Read calls and model comprehension when exact search identifies likely files. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
 - Use Read for file reads. Always Read before Edit/Write existing files, re-read after modification before another edit, verify paths first, and include 3+ context lines in edits.
+- OpenCode Bash tool calls do not support shell redirections (`2>/dev/null`), pipes (`|`), output redirects (`>`), process substitutions (`<(...)`), or command substitutions (`$(...)`); use separate sequential calls or runtime file tools.
 - Put temporary artifacts that a runtime tool or agent may read under `${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}`, never host `/tmp`; shell-internal `mktemp` files are exempt.
 - Output text directly; never use Bash `echo` to communicate. Call independent tools in parallel.
 - Slash commands: read `scripts/commands/<command>.md`, then `workflows/<command>.md` fallback.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -77,9 +77,9 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 ### Tool and file discipline
 
-- Prefer exact search first: with Bash use scoped `rg` (or `git grep` for tracked content); use the runtime Grep tool only without Bash or for bounded searches. Use targeted Read calls and model comprehension when exact search identifies likely files. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
+- Prefer exact search: scoped `rg`/`git grep`, then targeted Read. With Bash, discover tracked files via `git ls-files '<pattern>'`, untracked files via `fd`, or file lists via `rg --files -g '<pattern>'`; use Glob only as a last resort.
 - Use Read for file reads. Always Read before Edit/Write existing files, re-read after modification before another edit, verify paths first, and include 3+ context lines in edits.
-- OpenCode Bash tool calls do not support shell redirections (`2>/dev/null`), pipes (`|`), output redirects (`>`), process substitutions (`<(...)`), or command substitutions (`$(...)`); use separate sequential calls or runtime file tools.
+- OpenCode Bash allows pipes but blocks redirects, dynamic expansion, grouping/subshells, background execution, and unquoted globs; use separate calls or file tools.
 - Put temporary artifacts that a runtime tool or agent may read under `${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}`, never host `/tmp`; shell-internal `mktemp` files are exempt.
 - Output text directly; never use Bash `echo` to communicate. Call independent tools in parallel.
 - Slash commands: read `scripts/commands/<command>.md`, then `workflows/<command>.md` fallback.

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -5,6 +5,10 @@
 
 Maximise output per token. Compress prose, not results.
 
+**OpenCode Bash tool calls do not support shell redirections, pipes, subshells,
+or process substitutions.** Run dependent commands as separate tool calls; use
+the runtime's file tools for file content instead of shell redirection.
+
 ## 1. Ship early, keep the audit trail intact
 
 - Start with `TodoWrite`: 3-7 subtasks, exactly one `in_progress`, last subtask `gh pr ready`.
@@ -14,40 +18,21 @@ Maximise output per token. Compress prose, not results.
 git add -A && git commit -m 'feat: <what you just did> (<task-id>)'
 ```
 
-- After the first commit, push and open a draft PR. Later commits only need `git push`; finish with `gh pr ready`.
+- After the first commit, push and open a draft PR. Later commits only need `git push`; finish with `gh pr ready`. In OpenCode, run each command separately and use the Write tool to create the PR body file.
 
 ```bash
 git push -u origin HEAD
-gh_issue=$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
-PR_BODY_FILE="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-pr-body.md"
-cat <<'EOF' > "$PR_BODY_FILE"
-WIP - incremental commits
-EOF
-[[ -n "$gh_issue" ]] && printf '\nResolves #%s\n' "$gh_issue" >> "$PR_BODY_FILE"
-~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" >> "$PR_BODY_FILE"
 ```
 
-Run the GitHub write in the next Bash tool call so the signature gate can read
-the completed body file before execution:
+Create a body file with the required `Resolves #<issue>` and signature footer,
+then run the GitHub write in the next Bash tool call so the signature gate can
+read the completed file before execution:
 
 ```bash
 gh pr create --draft --title '<task-id>: <description>' --body-file "$PR_BODY_FILE"
 ```
 
-- **ShellCheck before push for `.sh` files (t234).** Do not push violations. If `shellcheck` is missing, skip and note it in the PR body.
-
-```bash
-if command -v shellcheck &>/dev/null; then
-  sc_errors=0
-  while IFS= read -r f; do
-    [[ -z "$f" ]] && continue
-    shellcheck -x -S warning -- "$f" || sc_errors=$((sc_errors + 1))
-  done < <(git diff --name-only origin/HEAD..HEAD 2>/dev/null | grep '\.sh$' || true)
-  [[ "$sc_errors" -gt 0 ]] && echo "ShellCheck: $sc_errors file(s) failed — fix before pushing" && exit 1
-else
-  echo "shellcheck not installed — skipping (note in PR body)"
-fi
-```
+- **ShellCheck before push for `.sh` files (t234).** Do not push violations. In OpenCode, first run `command -v shellcheck`, then list changed files with `git diff --name-only origin/HEAD..HEAD`, and run ShellCheck separately for each changed `.sh` file. If ShellCheck is unavailable, skip and note it in the PR body.
 
 - **PR titles must include the task ID (t318.2).** Use `<task-id>: <description>`.
   - `tNNN` for TODO tasks, e.g. `t318.2: Verify supervisor worker PRs include task ID`
@@ -116,6 +101,6 @@ Before `FULL_LOOP_COMPLETE`, verify:
 2. Verification run: tests, ShellCheck on changed `.sh` files, lint/typecheck if configured, expected output files exist.
 3. Generalization check: replace hardcoded values that should be parameterized.
 4. Minimal state changes: only requested files changed; no extra side effects.
-5. Commit+PR gate (GH#5317): `git status --porcelain` is empty and `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)"` returns a PR. This is the #1 worker failure mode.
+5. Commit+PR gate (GH#5317): `git status --porcelain` is empty and `gh pr list --head <current-branch-name>` returns a PR. This is the #1 worker failure mode.
 
 `FULL_LOOP_COMPLETE` is irreversible. Extra verification is cheaper than a retry cycle.

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -5,9 +5,9 @@
 
 Maximise output per token. Compress prose, not results.
 
-**OpenCode Bash tool calls do not support shell redirections, pipes, subshells,
-or process substitutions.** Run dependent commands as separate tool calls; use
-the runtime's file tools for file content instead of shell redirection.
+**OpenCode Bash supports pipelines, but its parser rejects redirection, dynamic
+expansion, grouping/subshell syntax, background execution, and unquoted globs.**
+Split blocked operations into separate calls and use file tools for persisted content.
 
 ## 1. Ship early, keep the audit trail intact
 
@@ -18,7 +18,7 @@ the runtime's file tools for file content instead of shell redirection.
 git add -A && git commit -m 'feat: <what you just did> (<task-id>)'
 ```
 
-- After the first commit, push and open a draft PR. Later commits only need `git push`; finish with `gh pr ready`. In OpenCode, run each command separately and use the Write tool to create the PR body file.
+- After the first commit, push and open a draft PR. Later commits only need `git push`; finish with `gh pr ready`. In OpenCode, use the Write tool to create the PR body file before the GitHub call.
 
 ```bash
 git push -u origin HEAD
@@ -29,7 +29,7 @@ then run the GitHub write in the next Bash tool call so the signature gate can
 read the completed file before execution:
 
 ```bash
-gh pr create --draft --title '<task-id>: <description>' --body-file "$PR_BODY_FILE"
+gh pr create --draft --title 'GH#123: description' --body-file '/path/to/pr-body.md'
 ```
 
 - **ShellCheck before push for `.sh` files (t234).** Do not push violations. In OpenCode, first run `command -v shellcheck`, then list changed files with `git diff --name-only origin/HEAD..HEAD`, and run ShellCheck separately for each changed `.sh` file. If ShellCheck is unavailable, skip and note it in the PR body.

--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -5,6 +5,8 @@
 
 Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never assign `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI. See `AGENTS.md` → "Quality Standards".
 
+> **Shell script context only:** Code in this guide is for `.sh` files, not OpenCode Bash tool calls. OpenCode blocks redirections, pipes, subshells, and process substitutions in Bash tool calls; use separate calls and runtime file tools instead.
+
 **Incident rationale (GH#18702):** On 2026-04-09, `init-routines-helper.sh:22` had an unguarded `GREEN='\033[0;32m'`. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard` — **auto-update broken for 4 days** (cascade: GH#18693, fixed: PR #18728).
 
 ## Banned patterns
@@ -34,7 +36,7 @@ fi
 
 All-or-nothing: colors partially undefined under `set -u` when parent set some without the sentinel. Pattern B handles each independently. Migrate opportunistically.
 
-## Allowed patterns
+## Allowed shell script patterns
 
 ### A — source `shared-constants.sh` (preferred)
 

--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -5,7 +5,7 @@
 
 Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never assign `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI. See `AGENTS.md` → "Quality Standards".
 
-> **Shell script context only:** Code in this guide is for `.sh` files, not OpenCode Bash tool calls. OpenCode blocks redirections, pipes, subshells, and process substitutions in Bash tool calls; use separate calls and runtime file tools instead.
+> **Shell script context only:** Code in this guide is for `.sh` files, not OpenCode Bash tool calls. OpenCode Bash supports pipelines but rejects redirects, dynamic expansion, grouping/subshells, background execution, and unquoted globs; use separate calls or file tools for those operations.
 
 **Incident rationale (GH#18702):** On 2026-04-09, `init-routines-helper.sh:22` had an unguarded `GREEN='\033[0;32m'`. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard` — **auto-update broken for 4 days** (cascade: GH#18693, fixed: PR #18728).
 

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -205,6 +205,40 @@ PY
 	return 0
 }
 
+test_worker_protocol_bash_examples() {
+	local prompt="${SCRIPT_DIR}/../prompts/worker-efficiency-protocol.md"
+	if python3 - "$SCRIPT_DIR" "$prompt" <<'PY'; then
+import pathlib
+import sys
+
+scripts_dir = pathlib.Path(sys.argv[1])
+prompt = pathlib.Path(sys.argv[2])
+sys.path.insert(0, str(scripts_dir))
+
+from command_policy_parser import _shell_invocations
+
+commands = []
+in_bash_block = False
+for line in prompt.read_text(encoding="utf-8").splitlines():
+    if line == "```bash":
+        in_bash_block = True
+    elif in_bash_block and line == "```":
+        in_bash_block = False
+    elif in_bash_block and line.strip():
+        commands.append(line)
+
+if len(commands) < 3:
+    raise SystemExit(f"expected at least 3 Bash examples, found {len(commands)}")
+for command in commands:
+    _shell_invocations(command)
+PY
+		pass "worker protocol Bash examples satisfy command parser"
+	else
+		fail "worker protocol Bash examples satisfy command parser"
+	fi
+	return 0
+}
+
 test_account_mutation_authorization() {
 	local command_text="gh repo fork owner/source --clone=false"
 	local authorization=""
@@ -771,6 +805,7 @@ PY
 main() {
 	test_validation
 	test_evaluate_invocations_compatibility
+	test_worker_protocol_bash_examples
 	test_static_decisions
 	test_process_table_parser
 	test_process_termination_policy


### PR DESCRIPTION
## Summary

Clarified that OpenCode Bash tool calls reject shell composition syntax, removed unsafe worker prompt examples, and scoped the shell style guide to script context.

## Files Changed

.agents/AGENTS.md, .agents/prompts/worker-efficiency-protocol.md, .agents/reference/shell-style-guide.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — .agents/scripts/linters-local.sh (passed)

Resolves #30335


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 10m and 114,593 tokens on this as a headless worker.