### PR TITLE
GH#30339: fix: stop approval batches on shared outages

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -83,6 +83,10 @@ readonly _APPROVAL_GITHUB_ACTIONS_BOT_ID="41898282"
 readonly _APPROVAL_MISSING_FIELD="__missing__"
 readonly _APPROVAL_GH_INVALID_TOKEN="invalid-token"
 readonly _APPROVAL_BATCH_MODE="batch"
+readonly _APPROVAL_BATCH_FAILURE_ISOLATED="isolated-target"
+readonly _APPROVAL_BATCH_FAILURE_SYSTEMIC="systemic-transport"
+readonly _APPROVAL_BATCH_FAILURE_RATE_LIMIT="shared-rate-limit"
+readonly _APPROVAL_BATCH_FAILURE_AUTH="shared-auth-failure"
 
 _APPROVAL_GH_RATE_LIMIT_RESET=""
 _APPROVAL_GH_AUTH_FAILURE=""
@@ -181,9 +185,43 @@ _approval_probe_auth_failure() {
 				printf "invalid-token"
 				exit 0
 			}
+			if (status ~ /^5[0-9][0-9]$/) {
+				printf "systemic-transport"
+				exit 0
+			}
 			exit 1
 		}'
 	return $?
+}
+
+_approval_classify_batch_failure() {
+	local probe=""
+	local failure_kind=""
+	local reset=""
+
+	if declare -F _gh_secondary_cooldown_active >/dev/null 2>&1 && _gh_secondary_cooldown_active; then
+		printf '%s' "$_APPROVAL_BATCH_FAILURE_RATE_LIMIT"
+		return 0
+	fi
+	if probe=$(_approval_probe_auth_failure); then
+		IFS=$'\t' read -r failure_kind reset <<<"$probe"
+		case "$failure_kind" in
+		authenticated) printf '%s' "$_APPROVAL_BATCH_FAILURE_ISOLATED" ;;
+		core-rate-limit) printf '%s' "$_APPROVAL_BATCH_FAILURE_RATE_LIMIT" ;;
+		"$_APPROVAL_GH_INVALID_TOKEN") printf '%s' "$_APPROVAL_BATCH_FAILURE_AUTH" ;;
+		"$_APPROVAL_BATCH_FAILURE_SYSTEMIC") printf '%s' "$_APPROVAL_BATCH_FAILURE_SYSTEMIC" ;;
+		*) printf 'unknown' ;;
+		esac
+		return 0
+	fi
+	if declare -F _gh_secondary_cooldown_active >/dev/null 2>&1 && _gh_secondary_cooldown_active; then
+		printf '%s' "$_APPROVAL_BATCH_FAILURE_RATE_LIMIT"
+	else
+		# The target operation and an independent authenticated API probe both
+		# failed, which is sufficient evidence to stop mutating untouched targets.
+		printf '%s' "$_APPROVAL_BATCH_FAILURE_SYSTEMIC"
+	fi
+	return 0
 }
 
 _approval_report_core_rate_limit() {
@@ -1228,16 +1266,37 @@ _execute_approval_batch() {
 	local target_type=""
 	local target_number=""
 	local failed=0
+	local successful=0
+	local attempted=0
+	local unattempted=0
+	local failure_class=""
+	local stopped=0
 	local target_count=$#
 
 	for target_spec in "$@"; do
+		attempted=$((attempted + 1))
 		target_type="${target_spec%%:*}"
 		target_number="${target_spec#*:}"
 		if ! _approve_target_after_confirmation "$target_type" "$target_number" "$slug" "$actual_key"; then
 			failed=$((failed + 1))
+			failure_class=$(_approval_classify_batch_failure)
+			case "$failure_class" in
+			"$_APPROVAL_BATCH_FAILURE_SYSTEMIC" | "$_APPROVAL_BATCH_FAILURE_RATE_LIMIT" | "$_APPROVAL_BATCH_FAILURE_AUTH")
+				stopped=1
+				break
+				;;
+			esac
+		else
+			successful=$((successful + 1))
 		fi
 	done
 	if [[ "$failed" -gt 0 ]]; then
+		if [[ "$stopped" -eq 1 ]]; then
+			unattempted=$((target_count - attempted))
+			_print_error "Approval batch stopped after ${failure_class}: ${successful} succeeded and remain signed, ${failed} failed, ${unattempted} unattempted"
+			_print_info "For each attempted target, run 'aidevops approve verify', then recover incomplete lifecycle state with 'aidevops approve reconcile'"
+			return 1
+		fi
 		_print_error "${failed} of ${target_count} approval(s) failed; successful targets remain signed"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-approval-helper-batch.sh
+++ b/.agents/scripts/tests/test-approval-helper-batch.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 PARENT_DIR="${SCRIPT_DIR}/.."
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/test-approval-batch-XXXXXX") || exit 1
 CALL_LOG="${TMPROOT}/calls.log"
+PROBE_LOG="${TMPROOT}/probes.log"
+FAIL_TARGET=""
+BATCH_FAILURE_CLASS="isolated-target"
 
 cleanup() {
 	local tmp_root="$TMPROOT"
@@ -23,6 +26,9 @@ run_batch() {
 	shift
 	APPROVAL_HELPER_UNDER_TEST="${PARENT_DIR}/approval-helper.sh" \
 		CALL_LOG="$CALL_LOG" \
+		PROBE_LOG="$PROBE_LOG" \
+		FAIL_TARGET="$FAIL_TARGET" \
+		BATCH_FAILURE_CLASS="$BATCH_FAILURE_CLASS" \
 		bash -c '
 			set -uo pipefail
 			# shellcheck disable=SC1090
@@ -40,10 +46,39 @@ run_batch() {
 				local slug="$3"
 				local actual_key="$4"
 				printf "%s %s %s %s\n" "$target_type" "$target_number" "$slug" "$actual_key" >>"$CALL_LOG"
+				if [[ -n "$FAIL_TARGET" && "$target_number" == "$FAIL_TARGET" ]]; then
+					return 1
+				fi
+				return 0
+			}
+			_approval_classify_batch_failure() {
+				printf "%s\n" "$BATCH_FAILURE_CLASS" >>"$PROBE_LOG"
+				printf "%s" "$BATCH_FAILURE_CLASS"
 				return 0
 			}
 			main "$@"
 		' _ "$command" "$@" <<<"$confirmation"
+	return $?
+}
+
+run_classifier() {
+	local response="$1"
+	local api_rc="$2"
+	APPROVAL_HELPER_UNDER_TEST="${PARENT_DIR}/approval-helper.sh" \
+		CLASSIFIER_RESPONSE="$response" \
+		CLASSIFIER_RC="$api_rc" \
+		bash -c '
+			set -uo pipefail
+			# shellcheck disable=SC1090
+			source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+			_gh_secondary_cooldown_preflight() { return 0; }
+			_gh_secondary_cooldown_active() { return 1; }
+			gh() {
+				printf "%s" "$CLASSIFIER_RESPONSE"
+				return "$CLASSIFIER_RC"
+			}
+			_approval_classify_batch_failure
+		' 2>/dev/null
 	return $?
 }
 
@@ -100,6 +135,89 @@ if run_batch APPROVE issue 301 301 owner/repo >/dev/null 2>&1; then
 fi
 [[ ! -s "$CALL_LOG" ]] || {
 	printf 'FAIL duplicate batch target approved targets\n' >&2
+	exit 1
+}
+
+: >"$CALL_LOG"
+: >"$PROBE_LOG"
+FAIL_TARGET="402"
+BATCH_FAILURE_CLASS="isolated-target"
+if output=$(run_batch APPROVE issue 401 402 403 owner/repo 2>&1); then
+	printf 'FAIL isolated target failure returned success\n' >&2
+	exit 1
+fi
+[[ "$(wc -l <"$CALL_LOG" | tr -d ' ')" == "3" ]] || {
+	printf 'FAIL isolated failure did not continue through later targets\n' >&2
+	exit 1
+}
+[[ "$(wc -l <"$PROBE_LOG" | tr -d ' ')" == "1" ]] || {
+	printf 'FAIL isolated failure did not classify exactly once\n' >&2
+	exit 1
+}
+[[ "$output" == *"1 of 3 approval(s) failed; successful targets remain signed"* ]] || {
+	printf 'FAIL isolated failure summary changed unexpectedly\n' >&2
+	exit 1
+}
+
+: >"$CALL_LOG"
+: >"$PROBE_LOG"
+FAIL_TARGET="502"
+BATCH_FAILURE_CLASS="systemic-transport"
+if output=$(run_batch APPROVE issue 501 502 503 504 owner/repo 2>&1); then
+	printf 'FAIL systemic transport failure returned success\n' >&2
+	exit 1
+fi
+[[ "$(wc -l <"$CALL_LOG" | tr -d ' ')" == "2" ]] || {
+	printf 'FAIL systemic transport failure touched an unattempted target\n' >&2
+	exit 1
+}
+[[ "$(wc -l <"$PROBE_LOG" | tr -d ' ')" == "1" ]] || {
+	printf 'FAIL systemic failure did not classify exactly once\n' >&2
+	exit 1
+}
+[[ "$output" == *"1 succeeded and remain signed, 1 failed, 2 unattempted"* ]] || {
+	printf 'FAIL systemic failure summary omitted outcome counts\n' >&2
+	exit 1
+}
+[[ "$output" == *"aidevops approve verify"* && "$output" == *"aidevops approve reconcile"* ]] || {
+	printf 'FAIL systemic failure summary omitted recovery guidance\n' >&2
+	exit 1
+}
+
+: >"$CALL_LOG"
+: >"$PROBE_LOG"
+FAIL_TARGET="601"
+BATCH_FAILURE_CLASS="shared-rate-limit"
+if run_batch APPROVE issue 601 602 603 owner/repo >/dev/null 2>&1; then
+	printf 'FAIL shared rate-limit failure returned success\n' >&2
+	exit 1
+fi
+[[ "$(wc -l <"$CALL_LOG" | tr -d ' ')" == "1" ]] || {
+	printf 'FAIL shared rate limit did not stop before untouched targets\n' >&2
+	exit 1
+}
+
+FAIL_TARGET=""
+BATCH_FAILURE_CLASS="isolated-target"
+
+classifier_output=$(run_classifier $'HTTP/2 200\r\n\r\n{}' 0)
+[[ "$classifier_output" == "isolated-target" ]] || {
+	printf 'FAIL authenticated probe did not classify isolated target failure\n' >&2
+	exit 1
+}
+classifier_output=$(run_classifier $'HTTP/2 503\r\n\r\n{"message":"service unavailable"}' 1)
+[[ "$classifier_output" == "systemic-transport" ]] || {
+	printf 'FAIL HTTP 503 probe did not classify systemic transport failure\n' >&2
+	exit 1
+}
+classifier_output=$(run_classifier $'HTTP/2 403\r\nx-ratelimit-remaining: 0\r\nx-ratelimit-reset: 123\r\nx-ratelimit-resource: core\r\n\r\n{}' 1)
+[[ "$classifier_output" == "shared-rate-limit" ]] || {
+	printf 'FAIL exhausted core limit did not classify shared rate-limit failure\n' >&2
+	exit 1
+}
+classifier_output=$(run_classifier "" 1)
+[[ "$classifier_output" == "systemic-transport" ]] || {
+	printf 'FAIL failed independent probe did not classify systemic transport failure\n' >&2
 	exit 1
 }
 


### PR DESCRIPTION
## Summary

Classify independent GitHub health probes after target failures and stop approval batches before untouched targets on systemic transport, shared rate-limit, or shared-auth failures.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/tests/test-approval-helper-batch.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Batch regression matrix, 50 sudo-auth assertions, 59 lifecycle assertions, ShellCheck, changed-file lint, and runtime-verified hermetic execution all pass.

Resolves #30339


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 4h 28m and 1,060,649 tokens on this with the user in an interactive session.