### PR TITLE
GH#30351: Route stalled Dependabot PRs to worker intake

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-dependabot-intake.sh — idempotent worker intake for stalled bot PRs.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_PULSE_DEPENDABOT_INTAKE_LOADED:-}" ]] && return 0
+_PULSE_DEPENDABOT_INTAKE_LOADED=1
+
+: "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
+
+_pulse_dependabot_intake_marker() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	printf '<!-- aidevops:dependabot-pr-intake repo=%s pr=%s -->' "$repo_slug" "$pr_number"
+	return 0
+}
+
+_pulse_dependabot_existing_intake_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local issues_json="[]"
+
+	issues_json=$(gh_issue_list --repo "$repo_slug" --state open \
+		--search "Dependabot PR #${pr_number} in:title" --limit 20 \
+		--json number,body,url 2>/dev/null) || return 1
+	printf '%s' "$issues_json" | jq -r --arg marker "$marker" \
+		'[.[] | select((.body // "") | contains($marker))][0].url // ""' 2>/dev/null
+	return $?
+}
+
+_pulse_dependabot_intake_body() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local head_sha="$3"
+	local reason="$4"
+	local marker="$5"
+
+	cat <<-EOF
+		## Dependabot PR worker intake
+
+		Pulse verified GitHub's live Dependabot Bot identity, same-repository head ownership,
+		the exact observed head, and Dependabot commit authorship. Automated merge did not
+		proceed because: **${reason}**.
+
+		Source PR: https://github.com/${repo_slug}/pull/${pr_number}
+		Observed head: \`${head_sha}\`
+
+		### Worker objective
+
+		Inspect the dependency update and terminal checks, reproduce relevant failures, and
+		deliver the smallest safe replacement or repair PR. If the source PR is safe but only
+		outside the maintained trust policy, update the narrow policy with evidence. If the
+		update is unsafe or intentionally deferred, apply an explicit maintainer-review hold
+		with rationale. Close or supersede the source PR only after preserving this evidence.
+
+		### Files and patterns
+
+		Start from the source PR diff. Dependency manifests, lockfiles, workflow references,
+		and exact failing test paths are intentionally unknown until inspection. Follow the
+		trusted boundary in \`.agents/scripts/trusted-dependabot-lib.sh\` and the repair-routing
+		pattern in \`.agents/scripts/pulse-merge-process.sh::_route_pr_to_fix_worker\`.
+
+		### Verification
+
+		Run the dependency ecosystem's targeted install, typecheck, tests, and security checks;
+		then run repository-required checks for changed files. Verify the source PR is merged,
+		closed as superseded, or explicitly held before completing this issue.
+
+		${marker}
+	EOF
+	return 0
+}
+
+_pulse_route_dependabot_pr_to_worker_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="$3"
+	local expected_head_sha="$4"
+	local reason="${5:-policy-ineligible}"
+	local marker=""
+	local existing_url=""
+	local temp_dir=""
+	local body_file=""
+	local issue_output=""
+
+	case "$reason" in
+	policy-ineligible | terminal-ci-failure | merge-conflict) ;;
+	*) reason="policy-ineligible" ;;
+	esac
+	declare -F _is_authentic_dependabot_pr >/dev/null 2>&1 || return 1
+	declare -F gh_create_issue >/dev/null 2>&1 || return 1
+	declare -F gh_issue_list >/dev/null 2>&1 || return 1
+	marker=$(_pulse_dependabot_intake_marker "$repo_slug" "$pr_number") || return 1
+	existing_url=$(_pulse_dependabot_existing_intake_issue "$pr_number" "$repo_slug" "$marker") || return 1
+	if [[ -n "$existing_url" ]]; then
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: existing worker issue ${existing_url}" >>"$LOGFILE"
+		return 0
+	fi
+	_is_authentic_dependabot_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" || return 1
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-dependabot-intake] DRY-RUN: authentic PR #${pr_number} in ${repo_slug} would route ${reason} to a worker issue" >>"$LOGFILE"
+		return 0
+	fi
+
+	temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	mkdir -p "$temp_dir" 2>/dev/null || return 1
+	body_file=$(mktemp "${temp_dir}/dependabot-intake.XXXXXX") || return 1
+	_pulse_dependabot_intake_body "$pr_number" "$repo_slug" "$expected_head_sha" "$reason" "$marker" >"$body_file" || {
+		rm -f "$body_file"
+		return 1
+	}
+	issue_output=$(gh_create_issue --repo "$repo_slug" \
+		--title "Dependabot PR #${pr_number} requires worker resolution" \
+		--body-file "$body_file" \
+		--label "auto-dispatch,origin:worker,tier:standard,dependencies" 2>&1) || {
+		local create_rc=$?
+		rm -f "$body_file"
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: worker issue creation failed" >>"$LOGFILE"
+		return "$create_rc"
+	}
+	rm -f "$body_file"
+	echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: routed ${reason} to ${issue_output}" >>"$LOGFILE"
+	return 0
+}

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -263,6 +263,12 @@ source "${_PULSE_MERGE_DIR}/pulse-merge-author-checks.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
 source "${_PULSE_MERGE_DIR}/pulse-merge-gates.sh"
 
+# Source fail-closed Dependabot worker intake for bot PRs that cannot use the
+# narrow automatic merge policy or the linked worker-issue feedback router.
+# shellcheck source=./pulse-dependabot-intake.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
+source "${_PULSE_MERGE_DIR}/pulse-dependabot-intake.sh"
+
 # Source merge processing helpers (GH#21301 — extracted to bring
 # pulse-merge.sh below the 1500-line file-size-debt threshold).
 # shellcheck source=./pulse-merge-process.sh
@@ -469,6 +475,9 @@ _check_pr_merge_gates() {
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
+		elif _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "policy-ineligible"; then
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR is outside automatic merge policy; routed to worker intake (GH#30351)" >>"$LOGFILE"
+			return 1
 		else
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
 			return 1
@@ -1500,6 +1509,11 @@ _process_single_ready_pr() {
 					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 					return 1
 				fi
+				if _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "merge-conflict"; then
+					echo "[pulse-wrapper] Merge pass: preserving authentic Dependabot PR #${pr_number} in ${repo_slug} after routing its merge conflict to worker intake (GH#30351)" >>"$LOGFILE"
+					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+					return 1
+				fi
 
 			# GH#23371: some PRs are already known to be protected from
 			# automated close handling from the PR list metadata (draft,
@@ -1645,6 +1659,10 @@ _process_single_ready_pr() {
 			# CI failure: route to fix worker if applicable (t2203: consolidated).
 			local _ci_route_rc=0
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || _ci_route_rc=$?
+			if [[ "$_ci_route_rc" -eq 1 ]] \
+				&& _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "terminal-ci-failure"; then
+				echo "[pulse-wrapper] Merge pass: authentic Dependabot PR #${pr_number} in ${repo_slug} has terminal CI failures; routed to worker intake (GH#30351)" >>"$LOGFILE"
+			fi
 			if [[ "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
 				|| "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
 				echo "[pulse-wrapper] Merge pass: CI feedback route for PR #${pr_number} in ${repo_slug} remains partial; preserving the PR for retry or maintainer review" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+INTAKE_SCRIPT="${SCRIPT_DIR}/../pulse-dependabot-intake.sh"
+TEST_ROOT=""
+ISSUES_JSON="[]"
+AUTHENTIC=1
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	mkdir -p "$AIDEVOPS_TEMP_DIR"
+	: >"$LOGFILE"
+	export TEST_ROOT
+	return 0
+}
+
+teardown_test_env() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+_is_authentic_dependabot_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="$3"
+	local expected_head_sha="$4"
+	[[ "$AUTHENTIC" -eq 1 && "$pr_number" == "30038" && "$repo_slug" == "owner/repo" \
+		&& "$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]
+	return $?
+}
+
+gh_issue_list() {
+	printf '%s\n' "$ISSUES_JSON"
+	return 0
+}
+
+gh_create_issue() {
+	local arg=""
+	local body_file=""
+	local args_file="${TEST_ROOT}/create-args"
+	printf '%s\n' "$@" >"$args_file"
+	while [[ "$#" -gt 0 ]]; do
+		arg="$1"
+		shift
+		if [[ "$arg" == "--body-file" && "$#" -gt 0 ]]; then
+			body_file="$1"
+			shift
+		fi
+	done
+	[[ -n "$body_file" && -f "$body_file" ]] || return 1
+	cp "$body_file" "${TEST_ROOT}/created-body"
+	printf 'https://github.com/owner/repo/issues/42\n'
+	return 0
+}
+
+assert_file_contains() {
+	local description="$1"
+	local file_path="$2"
+	local expected="$3"
+	if grep -qF -- "$expected" "$file_path"; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$description" >&2
+	return 1
+}
+
+test_creates_worker_ready_issue() {
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/created-body"
+	ISSUES_JSON="[]"
+	AUTHENTIC=1
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"
+	[[ -f "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "worker issue has auto-dispatch ownership" "${TEST_ROOT}/create-args" "auto-dispatch,origin:worker,tier:standard,dependencies"
+	assert_file_contains "worker issue cites source PR" "${TEST_ROOT}/created-body" "Source PR: https://github.com/owner/repo/pull/30038"
+	assert_file_contains "worker issue carries idempotency marker" "${TEST_ROOT}/created-body" "aidevops:dependabot-pr-intake repo=owner/repo pr=30038"
+	return 0
+}
+
+test_reuses_existing_issue() {
+	rm -f "${TEST_ROOT}/create-args"
+	ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "terminal-ci-failure"
+	[[ ! -e "${TEST_ROOT}/create-args" ]]
+	return $?
+}
+
+test_rejects_unverified_author() {
+	rm -f "${TEST_ROOT}/create-args"
+	ISSUES_JSON="[]"
+	AUTHENTIC=0
+	if _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"; then
+		return 1
+	fi
+	[[ ! -e "${TEST_ROOT}/create-args" ]]
+	return $?
+}
+
+test_dry_run_has_no_write() {
+	rm -f "${TEST_ROOT}/create-args"
+	ISSUES_JSON="[]"
+	AUTHENTIC=1
+	DRY_RUN=1 _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "merge-conflict"
+	[[ ! -e "${TEST_ROOT}/create-args" ]]
+	return $?
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	# shellcheck source=../pulse-dependabot-intake.sh
+	source "$INTAKE_SCRIPT"
+	test_creates_worker_ready_issue
+	test_reuses_existing_issue
+	printf 'PASS existing intake is idempotent\n'
+	test_rejects_unverified_author
+	printf 'PASS unverified authors fail closed\n'
+	test_dry_run_has_no_write
+	printf 'PASS dry-run performs no GitHub write\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -226,6 +226,22 @@ test_trusted_dependabot_uses_response_metered_graphql() {
 	return 0
 }
 
+test_worker_intake_reuses_trusted_snapshot() {
+	local graphql_calls=""
+	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	: >"$GH_LOG"
+	_is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current" || true
+	if _is_authentic_dependabot_pr "24473" "owner/repo" "dependabot[bot]" "head-current"; then
+		graphql_calls=$(grep -cF 'gh api graphql' "$GH_LOG" 2>/dev/null) || graphql_calls=0
+		if [[ "$graphql_calls" -eq 1 ]]; then
+			print_result "worker intake reuses the exact-head trust snapshot" 0
+			return 0
+		fi
+	fi
+	print_result "worker intake reuses the exact-head trust snapshot" 1 "gh log: $(<"$GH_LOG")"
+	return 0
+}
+
 test_trusted_dependabot_binds_expected_head() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current" \
@@ -432,6 +448,7 @@ main() {
 	define_helpers_under_test
 	test_trusted_dependabot_passes
 	test_trusted_dependabot_uses_response_metered_graphql
+	test_worker_intake_reuses_trusted_snapshot
 	test_trusted_dependabot_binds_expected_head
 	test_standard_dependabot_body_parser
 	test_quoted_dependabot_dependency_names

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -12,6 +12,10 @@ _TRUSTED_DEPENDABOT_LIB_LOADED=1
 
 _TRUSTED_DEPENDABOT_DIR="${BASH_SOURCE[0]%/*}"
 [[ "$_TRUSTED_DEPENDABOT_DIR" == "${BASH_SOURCE[0]}" ]] && _TRUSTED_DEPENDABOT_DIR="."
+_TRUSTED_DEPENDABOT_LAST_PR_JSON=""
+_TRUSTED_DEPENDABOT_LAST_REPO=""
+_TRUSTED_DEPENDABOT_LAST_PR=""
+_TRUSTED_DEPENDABOT_LAST_HEAD=""
 
 _trusted_dependabot_log() {
 	local message="$1"
@@ -209,12 +213,11 @@ _trusted_dependabot_pr_json_graphql() {
 	return 0
 }
 
-_is_trusted_dependabot_update_pr() {
-	local pr_number="$1"
+_trusted_dependabot_snapshot_is_authentic() {
+	local pr_json="$1"
 	local repo_slug="$2"
 	local pr_author="${3:-}"
 	local expected_head_sha="${4:-}"
-	local pr_json=""
 	local repo_owner="${repo_slug%%/*}"
 	local api_author=""
 	local api_author_type=""
@@ -222,6 +225,58 @@ _is_trusted_dependabot_update_pr() {
 	local head_repo=""
 	local snapshot_head=""
 	local bad_commits=""
+
+	[[ -n "$pr_json" && "$pr_json" != "null" && -n "$repo_slug" && -n "$expected_head_sha" ]] || return 1
+	case "$pr_author" in
+	dependabot\[bot\] | app/dependabot | "") ;;
+	*) return 1 ;;
+	esac
+
+	api_author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null) || return 1
+	api_author_type=$(printf '%s' "$pr_json" | jq -r '.author.__typename // ""' 2>/dev/null) || return 1
+	head_owner=$(printf '%s' "$pr_json" | jq -r '.headRepositoryOwner.login // .headRepositoryOwner.name // ""' 2>/dev/null) || return 1
+	head_repo=$(printf '%s' "$pr_json" | jq -r '.headRepository.nameWithOwner // ""' 2>/dev/null) || return 1
+	snapshot_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
+	#aidevops:trust-boundary — worker intake and merge trust share this exact-head
+	# GitHub Bot, repository ownership, and commit-authorship verification.
+	[[ "$api_author_type" == "Bot" && "$api_author" == "dependabot" ]] || return 1
+	[[ "$head_owner" == "$repo_owner" && "$head_repo" == "$repo_slug" ]] || return 1
+	[[ "$snapshot_head" == "$expected_head_sha" ]] || return 1
+	bad_commits=$(printf '%s' "$pr_json" | jq '[.commits[]? | select([.authors[]?.login] | index("dependabot[bot]") | not)] | length' 2>/dev/null) || return 1
+	[[ "$bad_commits" == "0" ]] || return 1
+	return 0
+}
+
+_is_authentic_dependabot_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="${3:-}"
+	local expected_head_sha="${4:-}"
+	local pr_json=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$_TRUSTED_DEPENDABOT_LAST_REPO" == "$repo_slug" \
+		&& "$_TRUSTED_DEPENDABOT_LAST_PR" == "$pr_number" \
+		&& "$_TRUSTED_DEPENDABOT_LAST_HEAD" == "$expected_head_sha" \
+		&& -n "$_TRUSTED_DEPENDABOT_LAST_PR_JSON" ]]; then
+		pr_json="$_TRUSTED_DEPENDABOT_LAST_PR_JSON"
+	else
+		pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug") || return 1
+		_TRUSTED_DEPENDABOT_LAST_PR_JSON="$pr_json"
+		_TRUSTED_DEPENDABOT_LAST_REPO="$repo_slug"
+		_TRUSTED_DEPENDABOT_LAST_PR="$pr_number"
+		_TRUSTED_DEPENDABOT_LAST_HEAD="$expected_head_sha"
+	fi
+	_trusted_dependabot_snapshot_is_authentic "$pr_json" "$repo_slug" "$pr_author" "$expected_head_sha"
+	return $?
+}
+
+_is_trusted_dependabot_update_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="${3:-}"
+	local expected_head_sha="${4:-}"
+	local pr_json=""
 	local bad_files=""
 	local security_failures=""
 	local body=""
@@ -238,18 +293,11 @@ _is_trusted_dependabot_update_pr() {
 	esac
 
 	pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug") || return 1
-	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
-	api_author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null) || return 1
-	api_author_type=$(printf '%s' "$pr_json" | jq -r '.author.__typename // ""' 2>/dev/null) || return 1
-	head_owner=$(printf '%s' "$pr_json" | jq -r '.headRepositoryOwner.login // .headRepositoryOwner.name // ""' 2>/dev/null) || return 1
-	head_repo=$(printf '%s' "$pr_json" | jq -r '.headRepository.nameWithOwner // ""' 2>/dev/null) || return 1
-	snapshot_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
-	[[ "$api_author_type" == "Bot" && "$api_author" == "dependabot" ]] || return 1
-	[[ "$head_owner" == "$repo_owner" && "$head_repo" == "$repo_slug" ]] || return 1
-	[[ "$snapshot_head" == "$expected_head_sha" ]] || return 1
-
-	bad_commits=$(printf '%s' "$pr_json" | jq '[.commits[]? | select([.authors[]?.login] | index("dependabot[bot]") | not)] | length' 2>/dev/null) || return 1
-	[[ "$bad_commits" == "0" ]] || return 1
+	_TRUSTED_DEPENDABOT_LAST_PR_JSON="$pr_json"
+	_TRUSTED_DEPENDABOT_LAST_REPO="$repo_slug"
+	_TRUSTED_DEPENDABOT_LAST_PR="$pr_number"
+	_TRUSTED_DEPENDABOT_LAST_HEAD="$expected_head_sha"
+	_trusted_dependabot_snapshot_is_authentic "$pr_json" "$repo_slug" "$pr_author" "$expected_head_sha" || return 1
 	bad_files=$(printf '%s' "$pr_json" | jq -r '[.files[]?.path | select(test("(^|/)(requirements(-lock)?\\.txt|requirements.*\\.txt|pyproject\\.toml|poetry\\.lock|uv\\.lock|Pipfile\\.lock|package(-lock)?\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb?|composer\\.(json|lock)|Gemfile\\.lock|go\\.(mod|sum)|Cargo\\.(toml|lock))$|^\\.github/dependabot\\.yml$"; "i") | not)] | length' 2>/dev/null) || return 1
 	[[ "$bad_files" == "0" ]] || return 1
 	security_failures=$(printf '%s' "$pr_json" | jq 'def up(v): (v // "" | ascii_upcase); [.statusCheckRollup[]? | select(((.name // .context // "") | test("security|socket|codeql|dependabot"; "i")) and (up(.conclusion) == "FAILURE" or up(.conclusion) == "ERROR" or up(.state) == "FAILURE" or up(.state) == "ERROR"))] | length' 2>/dev/null) || return 1


### PR DESCRIPTION
## Summary

Add fail-closed, idempotent worker intake for authentic Dependabot PRs that cannot progress through the narrow trusted merge path or linked-issue repair router.

## Files Changed

.agents/scripts/pulse-dependabot-intake.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-dependabot-intake.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Trusted Dependabot and intake tests; CI repair and conflict routing suites; standalone merge routine tests; Pulse canary; ShellCheck; .agents/scripts/linters-local.sh.

Resolves #30351


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 20m and 272,586 tokens on this with the user in an interactive session.