### PR TITLE
GH#30357: repair trusted @types/bun dependency update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -16,3 +16,4 @@ pip:pyarrow
 vite
 react
 @types/react
+@types/bun

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -275,7 +275,8 @@ test_quoted_dependabot_dependency_names() {
 		'- dependency-name: "@types/react"' \
 		"- dependency-name: 'react'")
 	dependencies=$(_trusted_dependabot_dependencies_from_body "$body") || dependencies=""
-	if [[ "$dependencies" == $'@types/react\nreact' ]]; then
+	if [[ $'\n'"$dependencies"$'\n' == *$'\n@types/react\n'* &&
+		$'\n'"$dependencies"$'\n' == *$'\nreact\n'* ]]; then
 		print_result "quoted Dependabot YAML dependency names are normalized" 0
 		return 0
 	fi
@@ -392,6 +393,21 @@ test_unallowlisted_dependency_fails() {
 	return 0
 }
 
+test_types_bun_is_allowlisted() {
+	local policy_path="${SCRIPT_DIR}/../../configs/trusted-dependabot-updates.conf"
+	local original_policy_path="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$policy_path"
+	if _trusted_dependabot_dependency_allowed "" "@types/bun"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$original_policy_path"
+		print_result "@types/bun is allowlisted for trusted Dependabot updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$original_policy_path"
+	print_result "@types/bun is allowlisted for trusted Dependabot updates" 1
+	return 0
+}
+
 test_trusted_dependabot_can_be_approved() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	: >"$GH_LOG"
@@ -460,6 +476,7 @@ main() {
 	test_security_failure_fails
 	test_non_dependency_file_fails
 	test_unallowlisted_dependency_fails
+	test_types_bun_is_allowlisted
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
 	test_precomputed_status_rollup_skips_graphql

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "11.7.1",
-        "@types/bun": "1.3.3",
+        "@types/bun": "1.3.14",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.3",
         "ajv": "8.20.0",
@@ -266,7 +266,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
@@ -300,7 +300,7 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "11.7.1",
-    "@types/bun": "1.3.3",
+    "@types/bun": "1.3.14",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.3",
     "ajv": "8.20.0",


### PR DESCRIPTION
Resolves #30357. Draft checkpoint for the verified replacement of Dependabot PR #30038. <!-- aidevops:origin:worker --> <!-- aidevops:sig --> --- [aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 91,102 tokens on this as a headless worker.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 94,463 tokens on this as a headless worker.