### PR TITLE
GH#30371: fix: serialize Dependabot worker intake

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -74,6 +74,61 @@ _pulse_dependabot_intake_body() {
 	return 0
 }
 
+_pulse_dependabot_intake_lock_dir() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local lock_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/locks"
+	local repo_key="${repo_slug//[^a-zA-Z0-9_.-]/-}"
+
+	printf '%s/dependabot-intake-%s-%s.lock' "$lock_root" "$repo_key" "$pr_number"
+	return 0
+}
+
+_pulse_dependabot_acquire_intake_lock() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local output_var="$3"
+	local lock_dir=""
+	local lock_pid=""
+	local stale_dir=""
+	local attempt=0
+
+	lock_dir=$(_pulse_dependabot_intake_lock_dir "$pr_number" "$repo_slug") || return 1
+	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		lock_pid=""
+		[[ -f "${lock_dir}/pid" ]] && lock_pid=$(<"${lock_dir}/pid")
+		if [[ "$lock_pid" =~ ^[1-9][0-9]*$ ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
+			stale_dir="${lock_dir}.stale.$$"
+			if mv "$lock_dir" "$stale_dir" 2>/dev/null; then
+				rm -rf "$stale_dir"
+				continue
+			fi
+		fi
+		attempt=$((attempt + 1))
+		[[ "$attempt" -lt 300 ]] || return 1
+		sleep 0.1
+	done
+	printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || {
+		rmdir "$lock_dir" 2>/dev/null || true
+		return 1
+	}
+	printf -v "$output_var" '%s' "$lock_dir"
+	return 0
+}
+
+_pulse_dependabot_release_intake_lock() {
+	local lock_dir="$1"
+	local lock_pid=""
+
+	[[ -n "$lock_dir" && -d "$lock_dir" ]] || return 0
+	[[ -f "${lock_dir}/pid" ]] && lock_pid=$(<"${lock_dir}/pid")
+	[[ "$lock_pid" == "$$" ]] || return 1
+	rm -f "${lock_dir}/pid" 2>/dev/null || return 1
+	rmdir "$lock_dir" 2>/dev/null || return 1
+	return 0
+}
+
 _pulse_route_dependabot_pr_to_worker_issue() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -85,6 +140,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	local temp_dir=""
 	local body_file=""
 	local issue_output=""
+	local lock_dir=""
 
 	case "$reason" in
 	policy-ineligible | terminal-ci-failure | merge-conflict) ;;
@@ -104,12 +160,32 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		echo "[pulse-dependabot-intake] DRY-RUN: authentic PR #${pr_number} in ${repo_slug} would route ${reason} to a worker issue" >>"$LOGFILE"
 		return 0
 	fi
+	if ! _pulse_dependabot_acquire_intake_lock "$pr_number" "$repo_slug" lock_dir; then
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: worker intake lock unavailable" >>"$LOGFILE"
+		return 1
+	fi
+	existing_url=$(_pulse_dependabot_existing_intake_issue "$pr_number" "$repo_slug" "$marker") || {
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
+		return 1
+	}
+	if [[ -n "$existing_url" ]]; then
+		_pulse_dependabot_release_intake_lock "$lock_dir" || return 1
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: existing worker issue ${existing_url}" >>"$LOGFILE"
+		return 0
+	fi
 
 	temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
-	mkdir -p "$temp_dir" 2>/dev/null || return 1
-	body_file=$(mktemp "${temp_dir}/dependabot-intake.XXXXXX") || return 1
+	mkdir -p "$temp_dir" 2>/dev/null || {
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
+		return 1
+	}
+	body_file=$(mktemp "${temp_dir}/dependabot-intake.XXXXXX") || {
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
+		return 1
+	}
 	_pulse_dependabot_intake_body "$pr_number" "$repo_slug" "$expected_head_sha" "$reason" "$marker" >"$body_file" || {
 		rm -f "$body_file"
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
 		return 1
 	}
 	issue_output=$(gh_create_issue --repo "$repo_slug" \
@@ -118,10 +194,12 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		--label "auto-dispatch,origin:worker,tier:standard,dependencies" 2>&1) || {
 		local create_rc=$?
 		rm -f "$body_file"
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: worker issue creation failed" >>"$LOGFILE"
 		return "$create_rc"
 	}
 	rm -f "$body_file"
+	_pulse_dependabot_release_intake_lock "$lock_dir" || return 1
 	echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: routed ${reason} to ${issue_output}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -111,6 +111,69 @@ test_dry_run_has_no_write() {
 	return $?
 }
 
+test_concurrent_routes_create_once() {
+	local worker_script="${TEST_ROOT}/concurrent-worker.sh"
+	local shared_state="${TEST_ROOT}/concurrent-state"
+	local create_count="${TEST_ROOT}/concurrent-create-count"
+	local worker_one=""
+	local worker_two=""
+
+	mkdir -p "$shared_state"
+	cat >"$worker_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+INTAKE_SCRIPT="$1"
+TEST_ROOT="$2"
+SHARED_STATE="$3"
+CREATE_COUNT="$4"
+export AIDEVOPS_TEMP_DIR="${TEST_ROOT}/concurrent-tmp"
+export LOGFILE="${TEST_ROOT}/concurrent-pulse.log"
+mkdir -p "$AIDEVOPS_TEMP_DIR"
+
+_is_authentic_dependabot_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="$3"
+	local expected_head_sha="$4"
+	[[ "$pr_number" == "30038" && "$repo_slug" == "owner/repo" \
+		&& "$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]
+	return $?
+}
+
+gh_issue_list() {
+	if [[ -f "${SHARED_STATE}/created" ]]; then
+		printf '%s\n' '[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
+	else
+		printf '%s\n' '[]'
+	fi
+	return 0
+}
+
+gh_create_issue() {
+	printf '%s\n' "$$" >>"$CREATE_COUNT"
+	sleep 1
+	: >"${SHARED_STATE}/created"
+	printf '%s\n' 'https://github.com/owner/repo/issues/42'
+	return 0
+}
+
+# shellcheck source=../pulse-dependabot-intake.sh
+source "$INTAKE_SCRIPT"
+_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"
+exit 0
+EOF
+	chmod 700 "$worker_script"
+	"$worker_script" "$INTAKE_SCRIPT" "$TEST_ROOT" "$shared_state" "$create_count" &
+	worker_one=$!
+	"$worker_script" "$INTAKE_SCRIPT" "$TEST_ROOT" "$shared_state" "$create_count" &
+	worker_two=$!
+	wait "$worker_one"
+	wait "$worker_two"
+	[[ "$(wc -l <"$create_count" | tr -d ' ')" == "1" ]]
+	return $?
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
@@ -123,6 +186,8 @@ main() {
 	printf 'PASS unverified authors fail closed\n'
 	test_dry_run_has_no_write
 	printf 'PASS dry-run performs no GitHub write\n'
+	test_concurrent_routes_create_once
+	printf 'PASS concurrent routes converge on one issue\n'
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Implementation for issue #30371.

## Files Changed

.agents/scripts/pulse-dependabot-intake.sh, .agents/scripts/tests/test-pulse-dependabot-intake.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30371


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 12m and 496,682 tokens on this with the user in an interactive session.