### PR TITLE
GH#30358: fix: trust safe types bun Dependabot updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -15,4 +15,5 @@
 pip:pyarrow
 vite
 react
+@types/bun
 @types/react

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -392,6 +392,20 @@ test_unallowlisted_dependency_fails() {
 	return 0
 }
 
+test_repository_allows_types_bun() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "" "@types/bun"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @types/bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @types/bun updates" 1
+	return 0
+}
+
 test_trusted_dependabot_can_be_approved() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	: >"$GH_LOG"
@@ -460,6 +474,7 @@ main() {
 	test_security_failure_fails
 	test_non_dependency_file_fails
 	test_unallowlisted_dependency_fails
+	test_repository_allows_types_bun
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
 	test_precomputed_status_rollup_skips_graphql


### PR DESCRIPTION
## Summary

Allow the verified same-repository Dependabot @types/bun update through the existing narrow policy and cover the repository allowlist entry with the trusted-update regression test.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun install --frozen-lockfile --ignore-scripts; bun audit

Resolves #30358


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 6m and 106,545 tokens on this as a headless worker.