### PR TITLE
GH#30359: fix: resolve trusted Dependabot dm-sans intake

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -16,3 +16,4 @@ pip:pyarrow
 vite
 react
 @types/react
+@fontsource/dm-sans

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -85,7 +85,7 @@ _trusted_dependabot_dependencies_from_body() {
 			}
 			END { if (invalid || parsed == 0) exit 1 }
 		') || return 1
-		printf '%s\n' "$dependencies" | sort -u
+		printf '%s\n' "$dependencies" | LC_ALL=C sort -u
 		return 0
 	fi
 
@@ -94,7 +94,7 @@ _trusted_dependabot_dependencies_from_body() {
 	dependencies=$(printf '%s\n' "$first_line" \
 		| grep -oE '\[[^][]+\]\(' \
 		| sed -E 's/^\[//; s/\]\($//' \
-		| sort -u) || dependencies=""
+		| LC_ALL=C sort -u) || dependencies=""
 	[[ -n "$dependencies" ]] || return 1
 	printf '%s\n' "$dependencies"
 	return 0

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "aidevops-dspy-integration",
@@ -18,7 +17,7 @@
         "@types/react-dom": "19.2.3",
         "ajv": "8.20.0",
         "react": "19.2.8",
-        "react-dom": "19.1.0",
+        "react-dom": "19.2.8",
         "secretlint": "11.7.1",
         "typescript": "5.9.3",
       },
@@ -45,7 +44,7 @@
         "@aidevops/gui-shared": "workspace:*",
         "@fontsource/courier-prime": "5.2.8",
         "@fontsource/dm-mono": "5.2.7",
-        "@fontsource/dm-sans": "5.2.8",
+        "@fontsource/dm-sans": "5.3.0",
         "@fontsource/fredoka": "5.2.10",
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
@@ -61,7 +60,7 @@
         "@fontsource/ubuntu-mono": "5.2.8",
         "@fontsource/zilla-slab": "5.3.0",
         "react": "19.2.8",
-        "react-dom": "19.1.0",
+        "react-dom": "19.2.8",
         "react-icons": "5.6.0",
       },
     },
@@ -136,7 +135,7 @@
 
     "@fontsource/dm-mono": ["@fontsource/dm-mono@5.2.7", "", {}, "sha512-Ma1az2atTVgQWuOWwjuxx26p/6A6CU9HBNKq1CFV6YKpKhpswnf9ry9Ql4+T6bTZzkdtSfS6tjJvqZOljVzIFQ=="],
 
-    "@fontsource/dm-sans": ["@fontsource/dm-sans@5.2.8", "", {}, "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA=="],
+    "@fontsource/dm-sans": ["@fontsource/dm-sans@5.3.0", "", {}, "sha512-lYJtMXXO28q1z+yz+z8XKd0s4hXaa9QdkETzkyD760sidCv5heI86weYA0sx0Nc4pAMAQTUuyf4gO44cYKKS9g=="],
 
     "@fontsource/fredoka": ["@fontsource/fredoka@5.2.10", "", {}, "sha512-DyzPCmTf0PkBbAu+gNvnPzfD/dYIXlyp+Zcb76jEQyt/vmRKGZgkH8FFF9W2sICDaA5p+GLk1XGFjWh5PPX+lg=="],
 
@@ -456,7 +455,7 @@
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
-    "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
 
@@ -472,7 +471,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "secretlint": ["secretlint@11.7.1", "", { "dependencies": { "@secretlint/config-creator": "11.7.1", "@secretlint/formatter": "11.7.1", "@secretlint/node": "11.7.1", "@secretlint/profiler": "11.7.1", "@secretlint/resolver": "11.7.1", "debug": "^4.4.3", "globby": "^14.1.0", "read-pkg": "^9.0.1" }, "bin": { "secretlint": "bin/secretlint.js" } }, "sha512-igo+3xtwOisz3Ge0V1t6SzCnOLXSHjRIODZpqppUmfkb0EE0EbsEMdoUuunaacxffq3NTYSzpZcjbfrPYuO+qA=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@types/react-dom": "19.2.3",
     "ajv": "8.20.0",
     "react": "19.2.8",
-    "react-dom": "19.1.0",
+    "react-dom": "19.2.8",
     "secretlint": "11.7.1",
     "typescript": "5.9.3"
   },

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -7,7 +7,7 @@
     "@aidevops/gui-shared": "workspace:*",
     "@fontsource/courier-prime": "5.2.8",
     "@fontsource/dm-mono": "5.2.7",
-    "@fontsource/dm-sans": "5.2.8",
+    "@fontsource/dm-sans": "5.3.0",
     "@fontsource/fredoka": "5.2.10",
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",
@@ -23,7 +23,7 @@
     "@fontsource/ubuntu-mono": "5.2.8",
     "@fontsource/zilla-slab": "5.3.0",
     "react": "19.2.8",
-    "react-dom": "19.1.0",
+    "react-dom": "19.2.8",
     "react-icons": "5.6.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Reused Dependabot's dm-sans 5.3.0 update, allowlisted its exact package after validating authentic same-repository bot ownership and green non-review/security checks, and aligned react-dom 19.2.8 with React to repair the discovered GUI test failure. Made Dependabot dependency ordering locale-stable.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/trusted-dependabot-lib.sh, bun.lock, package.json, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile; bun --cwd packages/gui-web test; bun run gui:typecheck; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/trusted-dependabot-lib.sh; aidevops security supply-chain scan

Resolves #30359


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 100,173 tokens on this as a headless worker.