### PR TITLE
GH#30361: chore(deps): bump @fontsource/dm-mono to 5.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
       "dependencies": {
         "@aidevops/gui-shared": "workspace:*",
         "@fontsource/courier-prime": "5.2.8",
-        "@fontsource/dm-mono": "5.2.7",
+        "@fontsource/dm-mono": "5.3.0",
         "@fontsource/dm-sans": "5.2.8",
         "@fontsource/fredoka": "5.2.10",
         "@fontsource/ibm-plex-mono": "5.2.7",
@@ -134,7 +134,7 @@
 
     "@fontsource/courier-prime": ["@fontsource/courier-prime@5.2.8", "", {}, "sha512-M3xOCcXnGuFi9TcGCrz4hm5yeWg4Sn35MALRLPnqNoHhawTFvhyi2KSI2+5RyFtDNJrb58bPh8LLipgiI9KA0w=="],
 
-    "@fontsource/dm-mono": ["@fontsource/dm-mono@5.2.7", "", {}, "sha512-Ma1az2atTVgQWuOWwjuxx26p/6A6CU9HBNKq1CFV6YKpKhpswnf9ry9Ql4+T6bTZzkdtSfS6tjJvqZOljVzIFQ=="],
+    "@fontsource/dm-mono": ["@fontsource/dm-mono@5.3.0", "", {}, "sha512-OINjI8C1S/wpchhQxl7njZdMn4+hnDCpQ4YtvvOpKNARo+0J8O1x1IcrChxNjHOhfVv1by8C/FQoy3hXK+C1Ug=="],
 
     "@fontsource/dm-sans": ["@fontsource/dm-sans@5.2.8", "", {}, "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aidevops/gui-shared": "workspace:*",
     "@fontsource/courier-prime": "5.2.8",
-    "@fontsource/dm-mono": "5.2.7",
+    "@fontsource/dm-mono": "5.3.0",
     "@fontsource/dm-sans": "5.2.8",
     "@fontsource/fredoka": "5.2.10",
     "@fontsource/ibm-plex-mono": "5.2.7",


### PR DESCRIPTION
Resolves #30361

Reapplies the trusted Dependabot update for `@fontsource/dm-mono` 5.3.0 from PR #30036 after its only terminal failure was the unavailable review-bot gate.

Files: `packages/gui-web/package.json`, `bun.lock`.

Verification in progress: Bun lockfile install, GUI web tests, and dependency audit.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.270 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 118,163 tokens on this as a headless worker.
