### PR TITLE
GH#30364: chore(deps-dev): bump typescript from 5.9.3 to 7.0.2

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -18,3 +18,4 @@ react
 @types/bun
 @types/react
 @fontsource/dm-sans
+typescript

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -242,6 +242,20 @@ test_worker_intake_reuses_trusted_snapshot() {
 	return 0
 }
 
+test_typescript_is_maintainer_allowlisted() {
+	local fixture_conf="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "" "typescript"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_conf"
+		print_result "TypeScript is allowlisted for trusted Dependabot updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_conf"
+	print_result "TypeScript is allowlisted for trusted Dependabot updates" 1
+	return 0
+}
+
 test_trusted_dependabot_binds_expected_head() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current" \
@@ -463,6 +477,7 @@ main() {
 	test_trusted_dependabot_passes
 	test_trusted_dependabot_uses_response_metered_graphql
 	test_worker_intake_reuses_trusted_snapshot
+	test_typescript_is_maintainer_allowlisted
 	test_trusted_dependabot_binds_expected_head
 	test_standard_dependabot_body_parser
 	test_quoted_dependabot_dependency_names

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -76,7 +76,7 @@ _trusted_dependabot_dependencies_from_body() {
 					}
 					value = substr(value, 2, length(value) - 2)
 				}
-				if (value == "" || value ~ /[[:space:]\"]/ || index(value, sq) > 0) {
+				if (value == "" || value ~ /[[:space:]"]/ || index(value, sq) > 0) {
 					invalid = 1
 					next
 				}

--- a/.opencode/server/security.test.ts
+++ b/.opencode/server/security.test.ts
@@ -38,10 +38,13 @@ async function allocateLoopbackPort(): Promise<number> {
     hostname: DEFAULT_LISTEN_HOST,
     port: 0,
     fetch: () => new Response('reserved'),
-  })
-  const port = reservation.port
-  await reservation.stop(true)
-  return port
+	})
+	const port = reservation.port
+	await reservation.stop(true)
+	if (port === undefined) {
+		throw new Error('Loopback port reservation did not return a port.')
+	}
+	return port
 }
 
 async function waitForServer(url: string, headers: HeadersInit = {}): Promise<void> {

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "secretlint": "11.7.1",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -275,6 +275,46 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -521,7 +561,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "bun run .opencode/server/api-gateway.ts",
     "dashboard": "bun run .opencode/server/mcp-dashboard.ts",
     "server:test": "bun test ./.opencode/server/security.test.ts",
-    "server:typecheck": "tsc --noEmit --skipLibCheck --target ES2022 --module ESNext --moduleResolution Bundler --types bun .opencode/server/api-gateway.ts .opencode/server/mcp-dashboard.ts .opencode/server/index.ts .opencode/server/security.ts .opencode/server/security.test.ts",
+    "server:typecheck": "tsc --ignoreConfig --noEmit --skipLibCheck --target ES2022 --module ESNext --moduleResolution Bundler --types bun .opencode/server/api-gateway.ts .opencode/server/mcp-dashboard.ts .opencode/server/index.ts .opencode/server/security.ts .opencode/server/security.test.ts",
     "server:check": "bun run server:typecheck && bun run server:test",
     "quality": "bun run .opencode/tool/parallel-quality.ts",
     "dspy:init": "dspyground init",
@@ -75,7 +75,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "secretlint": "11.7.1",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "overrides": {
     "esbuild": "0.28.1",

--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -68,12 +68,12 @@ export function createGuiApiApp() {
 
   app.post(APP_ACTION_ROUTE_MANIFEST.route, handleAppAction);
   app.get(APP_ACTION_STATUS_ROUTE_MANIFEST.route, handleAppActionStatus);
-  app.post(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.route, handlePulseWorkerAction);
-  app.get(PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.route, handlePulseWorkerActionStatus);
+	app.post(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.route, handlePulseWorkerAction);
+	app.get(PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.route, handlePulseWorkerActionStatus);
 
-  app.get(FILE_EXPLORER_ROUTE_MANIFEST.route, (context) => context.json(
-    ...fileExplorerResult(context.req.param("root"), context.req.query("path") ?? ""),
-  ));
+	app.get(FILE_EXPLORER_ROUTE_MANIFEST.route, (context) => context.json(
+		...fileExplorerResult(context.req.param("root") ?? "", context.req.query("path") ?? ""),
+	));
 
   for (const route of BANNED_ROUTE_PATTERNS) {
     app.post(route, (context) => context.json(
@@ -99,9 +99,18 @@ export function createGuiApiApp() {
 }
 
 function handleAppAction(context: Context) {
-  const appId = context.req.param("appId");
-  const action = context.req.param("action") as GuiAppActionId;
-  const command = appActionCommands[appId]?.[action];
+	const appId = context.req.param("appId");
+	const actionParam = context.req.param("action");
+	if (appId === undefined || actionParam === undefined) {
+		return context.json(createEnvelope({
+			operation_id: APP_ACTION_ROUTE_MANIFEST.operation_id,
+			source: { surface: "apps", authority: "allowlisted local command runner", path_refs: [] },
+			data: rejectedJob(appId ?? "unknown", "install", "Missing app action parameters."),
+			errors: ["action_not_allowlisted"],
+		}), 400);
+	}
+	const action = actionParam as GuiAppActionId;
+	const command = appActionCommands[appId]?.[action];
   if (command === undefined) {
     return context.json(createEnvelope({
       operation_id: APP_ACTION_ROUTE_MANIFEST.operation_id,
@@ -120,7 +129,7 @@ function handleAppAction(context: Context) {
 }
 
 function handleAppActionStatus(context: Context) {
-  const job = appActionJobs.get(context.req.param("jobId"));
+	const job = appActionJobs.get(context.req.param("jobId") ?? "");
   if (job === undefined) {
     return context.json(createEnvelope({
       operation_id: APP_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
@@ -137,16 +146,17 @@ function handleAppActionStatus(context: Context) {
 }
 
 function handlePulseWorkerAction(context: Context) {
-  const action = context.req.param("action") as GuiPulseWorkerActionId;
-  if (!Object.hasOwn(pulseWorkerActionCommands, action)) {
-    return context.json(createEnvelope({
-      operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
-      source: { surface: "pulse_workers", authority: "allowlisted local command runner", path_refs: [] },
-      data: rejectedPulseWorkerJob(action, "No allowlisted command for this Pulse & Workers action."),
-      errors: ["action_not_allowlisted"],
-    }), 400);
-  }
-  const actionCommand = pulseWorkerActionCommands[action];
+	const actionParam = context.req.param("action");
+	if (actionParam === undefined || !Object.hasOwn(pulseWorkerActionCommands, actionParam)) {
+		return context.json(createEnvelope({
+			operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
+			source: { surface: "pulse_workers", authority: "allowlisted local command runner", path_refs: [] },
+			data: rejectedPulseWorkerJob("diagnose", "No allowlisted command for this Pulse & Workers action."),
+			errors: ["action_not_allowlisted"],
+		}), 400);
+	}
+	const action = actionParam as GuiPulseWorkerActionId;
+	const actionCommand = pulseWorkerActionCommands[action];
   const job = startPulseWorkerActionJob(action, actionCommand.command, actionCommand.target_ref, actionCommand.audit_ref);
   return context.json(createEnvelope({
     operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
@@ -157,7 +167,7 @@ function handlePulseWorkerAction(context: Context) {
 }
 
 function handlePulseWorkerActionStatus(context: Context) {
-  const job = pulseWorkerActionJobs.get(context.req.param("jobId"));
+	const job = pulseWorkerActionJobs.get(context.req.param("jobId") ?? "");
   if (job === undefined) {
     return context.json(createEnvelope({
       operation_id: PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.operation_id,

--- a/packages/gui-api/src/status-inventory.ts
+++ b/packages/gui-api/src/status-inventory.ts
@@ -58,10 +58,11 @@ function isTrustedHelper(path: string): boolean {
 }
 
 function isInventory(value: unknown): value is SecretInventory {
-  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.secrets) || value.secrets.length > 512) return false;
-  if (!isRecord(value.backends) || Object.keys(value).length !== 3 || Object.keys(value.backends).length !== 2) return false;
-  if (!BACKEND_STATES.has(value.backends.gopass) || !BACKEND_STATES.has(value.backends.credentials)) return false;
-  return value.secrets.every((secret, index) => isSecretReference(secret, index === 0 ? "" : value.secrets[index - 1]?.name));
+	if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.secrets) || value.secrets.length > 512) return false;
+	if (!isRecord(value.backends) || Object.keys(value).length !== 3 || Object.keys(value.backends).length !== 2) return false;
+	if (!BACKEND_STATES.has(value.backends.gopass) || !BACKEND_STATES.has(value.backends.credentials)) return false;
+	const secrets = value.secrets;
+	return secrets.every((secret, index) => isSecretReference(secret, index === 0 ? "" : secrets[index - 1]?.name));
 }
 
 function isSecretReference(value: unknown, previousName: string | undefined): value is GuiSecretReference {

--- a/packages/gui-shared/src/notifications.ts
+++ b/packages/gui-shared/src/notifications.ts
@@ -97,7 +97,7 @@ function buildGuiStateNotifications(input: BuildNotificationInput): GuiNotificat
   const appNeedsUpdate = (input.aiApps ?? []).filter((app) => app.needs_update);
   const authErrors = (input.oauthPool?.providers ?? []).filter((provider) => provider.auth_errors > 0);
   const rateLimited = (input.oauthPool?.providers ?? []).filter((provider) => provider.rate_limited > 0);
-  const oauthPoolSourceRef = input.oauthPool?.path_ref ?? "oauth_pool";
+	const oauthPoolSourceRef = input.oauthPool?.path_ref || "oauth_pool";
   const notifications: GuiNotificationSummary[] = [];
 
   if (input.restartRequired) {

--- a/packages/gui-shared/tests/notifications.test.ts
+++ b/packages/gui-shared/tests/notifications.test.ts
@@ -47,8 +47,9 @@ describe("notification logic", () => {
     const notifications = buildStatusNotifications({
       aiApps: [],
       greetingOutput: "",
-      oauthPool: {
-        health: "present",
+		oauthPool: {
+			path_ref: "",
+			health: "present",
         providers: [{
           accounts: [],
           active_or_idle: 0,

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -42,14 +42,16 @@ export function ScreenshotCaptureNotificationHost(): ReactElement | null {
   const nextNotificationId = useRef(0);
   const [screenshotNotifications, setScreenshotNotifications] = useState<ScreenshotCapturedNotification[]>([]);
 
-  useEffect(() => {
-    const showScreenshotNotification = (event: Event) => {
-      const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
-      if (detail !== undefined && typeof detail.path === "string" && typeof detail.url === "string") {
-        nextNotificationId.current += 1;
-        setScreenshotNotifications((current) => [...current, { id: nextNotificationId.current, path: detail.path, url: detail.url }]);
-      }
-    };
+	useEffect(() => {
+		const showScreenshotNotification = (event: Event) => {
+			const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
+			const path = detail?.path;
+			const url = detail?.url;
+			if (typeof path === "string" && typeof url === "string") {
+				nextNotificationId.current += 1;
+				setScreenshotNotifications((current) => [...current, { id: nextNotificationId.current, path, url }]);
+			}
+		};
 
     window.addEventListener("aidevops:screenshot-captured", showScreenshotNotification);
     return () => window.removeEventListener("aidevops:screenshot-captured", showScreenshotNotification);

--- a/packages/gui-web/src/assets.d.ts
+++ b/packages/gui-web/src/assets.d.ts
@@ -1,0 +1,2 @@
+declare module "*.css";
+declare module "@fontsource/*";


### PR DESCRIPTION
Resolves #30364

Initial durable checkpoint for the trusted Dependabot TypeScript 7.0.2 update. The replacement reuses Dependabot commit `81e63d587a2d50dda80cef3162e2f9d63a56c297`; policy and targeted verification remain in progress.

<!-- aidevops:origin:worker -->

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.271 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
