### PR TITLE
GH#30367: fix: allow trusted Hono Dependabot updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -15,6 +15,7 @@
 pip:pyarrow
 vite
 react
+hono
 @types/bun
 @types/react
 @fontsource/dm-sans

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -406,6 +406,20 @@ test_repository_allows_types_bun() {
 	return 0
 }
 
+test_repository_allows_hono() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "" "hono"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits hono updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits hono updates" 1
+	return 0
+}
+
 test_trusted_dependabot_can_be_approved() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	: >"$GH_LOG"
@@ -475,6 +489,7 @@ main() {
 	test_non_dependency_file_fails
 	test_unallowlisted_dependency_fails
 	test_repository_allows_types_bun
+	test_repository_allows_hono
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
 	test_precomputed_status_rollup_skips_graphql

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@vitejs/plugin-react": "5.2.0",
         "elysia": "1.4.27",
         "file-type": "21.3.2",
-        "hono": "4.12.34",
+        "hono": "4.13.0",
         "vite": "8.1.5",
       },
       "devDependencies": {
@@ -359,7 +359,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
+    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
 
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@vitejs/plugin-react": "5.2.0",
     "elysia": "1.4.27",
     "file-type": "21.3.2",
-    "hono": "4.12.34",
+    "hono": "4.13.0",
     "vite": "8.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Allow the verified Hono 4.13.0 Dependabot update through the narrow maintained trust policy and cover the repository allowlist entry.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun install --frozen-lockfile --ignore-scripts; bun audit; bun run server:check

Resolves #30367


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.271 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 9m and 106,243 tokens on this as a headless worker.