### PR TITLE
GH#30382: fix: route Dependabot with paginated checks

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -256,6 +256,32 @@ test_typescript_is_maintainer_allowlisted() {
 	return 0
 }
 
+test_worker_intake_authenticates_paginated_checks() {
+	local graphql_calls=""
+	local fixture_tmp="${TEST_ROOT}/graphql-paginated.json"
+
+	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	jq '.data.repository.pullRequest.statusCheckRollup.contexts.pageInfo.hasNextPage = true' \
+		"${TEST_ROOT}/graphql.json" >"$fixture_tmp"
+	mv "$fixture_tmp" "${TEST_ROOT}/graphql.json"
+	_TRUSTED_DEPENDABOT_LAST_PR_JSON=""
+	_TRUSTED_DEPENDABOT_LAST_REPO=""
+	_TRUSTED_DEPENDABOT_LAST_PR=""
+	_TRUSTED_DEPENDABOT_LAST_HEAD=""
+	: >"$GH_LOG"
+	if ! _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current" \
+		&& _is_authentic_dependabot_pr "24473" "owner/repo" "dependabot[bot]" "head-current"; then
+		graphql_calls=$(grep -cF 'gh api graphql' "$GH_LOG" 2>/dev/null) || graphql_calls=0
+		if [[ "$graphql_calls" -eq 2 ]] \
+			&& grep -qF '1|trusted-dependabot-auth-exact-cost|gh api graphql' "$GH_LOG"; then
+			print_result "worker intake authenticates independently of paginated checks" 0
+			return 0
+		fi
+	fi
+	print_result "worker intake authenticates independently of paginated checks" 1 "gh log: $(<"$GH_LOG")"
+	return 0
+}
+
 test_trusted_dependabot_binds_expected_head() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current" \
@@ -478,6 +504,7 @@ main() {
 	test_trusted_dependabot_uses_response_metered_graphql
 	test_worker_intake_reuses_trusted_snapshot
 	test_typescript_is_maintainer_allowlisted
+	test_worker_intake_authenticates_paginated_checks
 	test_trusted_dependabot_binds_expected_head
 	test_standard_dependabot_body_parser
 	test_quoted_dependabot_dependency_names

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -150,21 +150,64 @@ _trusted_dependabot_project_pr_json() {
 	return $?
 }
 
+_trusted_dependabot_project_auth_json() {
+	local response="$1"
+
+	printf '%s' "$response" | jq -ce '
+		def string_type: "string";
+		def array_type: "array";
+		(if ((.errors // []) | length) > 0
+		 then error("GraphQL returned errors")
+		 else .data.repository.pullRequest end) as $pr
+		| if $pr == null then error("pull request unavailable")
+		  elif (($pr.author.__typename | type) != string_type or ($pr.author.__typename | length) == 0
+			or ($pr.author.login | type) != string_type or ($pr.author.login | length) == 0
+			or ($pr.headRefOid | type) != string_type or ($pr.headRefOid | length) == 0
+			or ($pr.headRepository.nameWithOwner | type) != string_type or ($pr.headRepository.nameWithOwner | length) == 0
+			or ($pr.headRepositoryOwner.login | type) != string_type or ($pr.headRepositoryOwner.login | length) == 0
+			or ($pr.commits.nodes | type) != array_type or ($pr.commits.nodes | length) == 0
+			or ([$pr.commits.nodes[] | select((.commit.authors.nodes | type) != array_type or (.commit.authors.nodes | length) == 0)] | length) > 0)
+		  then error("Dependabot authentication snapshot is incomplete")
+		  elif (($pr.commits.pageInfo.hasNextPage // false)
+			or ([$pr.commits.nodes[]?.commit.authors.pageInfo.hasNextPage // false] | any))
+		  then error("Dependabot authentication snapshot is paginated")
+		  else {
+			author: $pr.author,
+			headRefOid: $pr.headRefOid,
+			headRepository: $pr.headRepository,
+			headRepositoryOwner: $pr.headRepositoryOwner,
+			commits: [$pr.commits.nodes[] | {
+				authors: [.commit.authors.nodes[] | {login: (.user.login // "")}]
+			}]
+		  } end
+	' 2>/dev/null
+	return $?
+}
+
 _trusted_dependabot_pr_json_graphql() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local snapshot_mode="${3:-full}"
 	local owner="${repo_slug%%/*}"
 	local name="${repo_slug##*/}"
 	local response=""
 	local reported_cost=""
 	local pr_json=""
+	local route_decision="trusted-dependabot-exact-cost"
 
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" ]] || return 1
-	#aidevops:trust-boundary — this fixed snapshot binds bot identity, exact head,
-	# repository ownership, commit authors, files, and checks in one API response.
+	case "$snapshot_mode" in
+	full) ;;
+	auth)
+		route_decision="trusted-dependabot-auth-exact-cost"
+		;;
+	*) return 1 ;;
+	esac
+	#aidevops:trust-boundary — both modes bind bot identity, exact head, repository
+	# ownership, and commit authors; full mode additionally binds files and checks.
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
-		AIDEVOPS_GH_ROUTE_DECISION="trusted-dependabot-exact-cost" \
+		AIDEVOPS_GH_ROUTE_DECISION="$route_decision" \
 		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
 		query($owner: String!, $name: String!, $pr: Int!) {
 			repository(owner: $owner, name: $name) {
@@ -207,7 +250,11 @@ _trusted_dependabot_pr_json_graphql() {
 		}' 2>/dev/null) || return 1
 	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 1
 	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
-	pr_json=$(_trusted_dependabot_project_pr_json "$response") || return 1
+	if [[ "$snapshot_mode" == "auth" ]]; then
+		pr_json=$(_trusted_dependabot_project_auth_json "$response") || return 1
+	else
+		pr_json=$(_trusted_dependabot_project_pr_json "$response") || return 1
+	fi
 	[[ -n "$pr_json" ]] || return 1
 	printf '%s\n' "$pr_json"
 	return 0
@@ -261,7 +308,7 @@ _is_authentic_dependabot_pr() {
 		&& -n "$_TRUSTED_DEPENDABOT_LAST_PR_JSON" ]]; then
 		pr_json="$_TRUSTED_DEPENDABOT_LAST_PR_JSON"
 	else
-		pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug") || return 1
+		pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug" auth) || return 1
 		_TRUSTED_DEPENDABOT_LAST_PR_JSON="$pr_json"
 		_TRUSTED_DEPENDABOT_LAST_REPO="$repo_slug"
 		_TRUSTED_DEPENDABOT_LAST_PR="$pr_number"


### PR DESCRIPTION
## Summary

Add an exact-head authentication-only fallback for worker intake while keeping full automatic-merge snapshots fail-closed

## Files Changed

.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified against live PR #30039: full merge trust rejected its 109-check paginated rollup while the exact-head Bot/repository/commit authentication fallback passed; trusted Dependabot and intake suites plus ShellCheck and local linters passed

Resolves #30382


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.271 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 2h 21m and 844,382 tokens on this with the user in an interactive session.