### PR TITLE
GH#30389: fix: preserve Dependabot maintainer holds

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -31,6 +31,20 @@ _pulse_dependabot_existing_intake_issue() {
 	return $?
 }
 
+# Return 0 when the source PR carries an explicit maintainer-review hold,
+# 1 when it does not, and 2 when the live label state cannot be verified.
+_pulse_dependabot_pr_has_maintainer_hold() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local labels=""
+
+	declare -F gh_pr_view >/dev/null 2>&1 || return 2
+	labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
+		--jq '[.labels[].name] | join(",")' 2>/dev/null) || return 2
+	[[ ",${labels}," == *",needs-maintainer-review,"* ]]
+	return $?
+}
+
 _pulse_dependabot_intake_body() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -141,6 +155,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	local body_file=""
 	local issue_output=""
 	local lock_dir=""
+	local hold_rc=0
 
 	case "$reason" in
 	policy-ineligible | terminal-ci-failure | merge-conflict) ;;
@@ -149,6 +164,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	declare -F _is_authentic_dependabot_pr >/dev/null 2>&1 || return 1
 	declare -F gh_create_issue >/dev/null 2>&1 || return 1
 	declare -F gh_issue_list >/dev/null 2>&1 || return 1
+	declare -F gh_pr_view >/dev/null 2>&1 || return 1
 	marker=$(_pulse_dependabot_intake_marker "$repo_slug" "$pr_number") || return 1
 	existing_url=$(_pulse_dependabot_existing_intake_issue "$pr_number" "$repo_slug" "$marker") || return 1
 	if [[ -n "$existing_url" ]]; then
@@ -156,6 +172,18 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		return 0
 	fi
 	_is_authentic_dependabot_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" || return 1
+	_pulse_dependabot_pr_has_maintainer_hold "$pr_number" "$repo_slug" || hold_rc=$?
+	case "$hold_rc" in
+	0)
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: preserving explicit needs-maintainer-review hold; no worker issue created" >>"$LOGFILE"
+		return 3
+		;;
+	1) ;;
+	*)
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: live maintainer-review hold state unavailable; failing closed" >>"$LOGFILE"
+		return 1
+		;;
+	esac
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
 		echo "[pulse-dependabot-intake] DRY-RUN: authentic PR #${pr_number} in ${repo_slug} would route ${reason} to a worker issue" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -403,6 +403,7 @@ _check_pr_merge_gates() {
 	local review_gate_mode="${8:-merge}"
 	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
 	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local _dependabot_intake_rc=0
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 	if [[ -n "$linked_issue" ]] &&
 		_interactive_claim_fence_blocks_merge "$linked_issue" "$repo_slug" "$expected_head_sha"; then
@@ -475,11 +476,19 @@ _check_pr_merge_gates() {
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
-		elif _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "policy-ineligible"; then
-			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR is outside automatic merge policy; routed to worker intake (GH#30351)" >>"$LOGFILE"
-			return 1
 		else
-			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
+			_pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "policy-ineligible" || _dependabot_intake_rc=$?
+			case "$_dependabot_intake_rc" in
+			0)
+				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR is outside automatic merge policy; routed to worker intake (GH#30351)" >>"$LOGFILE"
+				;;
+			3)
+				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR has an explicit maintainer-review hold; preserving it without worker intake (GH#30389)" >>"$LOGFILE"
+				;;
+			*)
+				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
+				;;
+			esac
 			return 1
 		fi
 	fi

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -9,6 +9,8 @@ INTAKE_SCRIPT="${SCRIPT_DIR}/../pulse-dependabot-intake.sh"
 TEST_ROOT=""
 ISSUES_JSON="[]"
 AUTHENTIC=1
+PR_LABELS=""
+PR_VIEW_FAIL=0
 
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
@@ -37,6 +39,12 @@ _is_authentic_dependabot_pr() {
 
 gh_issue_list() {
 	printf '%s\n' "$ISSUES_JSON"
+	return 0
+}
+
+gh_pr_view() {
+	[[ "$PR_VIEW_FAIL" -eq 0 ]] || return 1
+	printf '%s\n' "$PR_LABELS"
 	return 0
 }
 
@@ -75,6 +83,8 @@ test_creates_worker_ready_issue() {
 	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/created-body"
 	ISSUES_JSON="[]"
 	AUTHENTIC=1
+	PR_LABELS=""
+	PR_VIEW_FAIL=0
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"
 	[[ -f "${TEST_ROOT}/create-args" ]] || return 1
 	assert_file_contains "worker issue has auto-dispatch ownership" "${TEST_ROOT}/create-args" "auto-dispatch,origin:worker,tier:standard,dependencies"
@@ -100,6 +110,38 @@ test_rejects_unverified_author() {
 	fi
 	[[ ! -e "${TEST_ROOT}/create-args" ]]
 	return $?
+}
+
+test_preserves_explicit_maintainer_hold() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args"
+	ISSUES_JSON="[]"
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	PR_VIEW_FAIL=0
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "explicit hold is preserved" "$LOGFILE" "preserving explicit needs-maintainer-review hold; no worker issue created"
+	PR_LABELS=""
+	return 0
+}
+
+test_fails_closed_when_hold_state_is_unavailable() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args"
+	ISSUES_JSON="[]"
+	AUTHENTIC=1
+	PR_LABELS=""
+	PR_VIEW_FAIL=1
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 1 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "unavailable hold state fails closed" "$LOGFILE" "live maintainer-review hold state unavailable; failing closed"
+	PR_VIEW_FAIL=0
+	return 0
 }
 
 test_dry_run_has_no_write() {
@@ -158,6 +200,11 @@ gh_create_issue() {
 	return 0
 }
 
+gh_pr_view() {
+	printf '%s\n' ''
+	return 0
+}
+
 # shellcheck source=../pulse-dependabot-intake.sh
 source "$INTAKE_SCRIPT"
 _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"
@@ -184,6 +231,8 @@ main() {
 	printf 'PASS existing intake is idempotent\n'
 	test_rejects_unverified_author
 	printf 'PASS unverified authors fail closed\n'
+	test_preserves_explicit_maintainer_hold
+	test_fails_closed_when_hold_state_is_unavailable
 	test_dry_run_has_no_write
 	printf 'PASS dry-run performs no GitHub write\n'
 	test_concurrent_routes_create_once


### PR DESCRIPTION
## Summary

- preserve authentic Dependabot PRs carrying a live `needs-maintainer-review` hold without creating replacement worker-intake issues
- fail closed when the source PR's live hold state cannot be read
- distinguish the held outcome in Pulse merge logging while preserving existing intake, concurrency, and trust behavior

## Verification

- `bash .agents/scripts/tests/test-pulse-dependabot-intake.sh`
- `bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `shellcheck .agents/scripts/pulse-dependabot-intake.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-dependabot-intake.sh`
- `.agents/scripts/linters-local.sh`

Resolves #30389

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.272 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 3h 17m and 1,068,215 tokens on this with the user in an interactive session.