### PR TITLE
GH#30388: fix: trust reviewed Actions Dependabot updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -11,6 +11,8 @@
 # The pulse still requires authentic GitHub Dependabot identity, same-repo
 # branch ownership, dependabot-authored commits, dependency-file-only diffs,
 # no terminal security-scan failures, and green required CI before merging.
+# Actions entries are limited to Dependabot's `actions` group and individual
+# top-level `.github/workflows/*.yml` or `.yaml` files.
 
 pip:pyarrow
 vite
@@ -20,3 +22,11 @@ hono
 @types/react
 @fontsource/dm-sans
 typescript
+actions:actions/checkout
+actions:actions/github-script
+actions:qltysh/qlty-action/install
+actions:actions/setup-node
+actions:actions/upload-artifact
+actions:github/codeql-action/upload-sarif
+actions:anomalyco/opencode/github
+actions:actions/download-artifact

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -45,13 +45,15 @@ write_pr_fixture() {
 	local changed_path="$3"
 	local security_conclusion="$4"
 	local framework_conclusion="${5:-SUCCESS}"
+	local package_manager="${6:-pip}"
+	local dependency_name="${7:-pyarrow}"
 	cat >"${TEST_ROOT}/pr.json" <<EOF
 {
   "author": {"__typename": "Bot", "login": "${author_login}"},
   "headRefOid": "head-current",
   "headRepositoryOwner": {"login": "owner"},
   "headRepository": {"nameWithOwner": "owner/repo"},
-  "body": "Bumps the pip group with 1 update in the / directory: [pyarrow](https://github.com/apache/arrow).\n\n---\nupdated-dependencies:\n- dependency-name: pyarrow\n  dependency-version: 23.0.1\n  dependency-type: direct:production\n  dependency-group: pip\n...",
+  "body": "Bumps the ${package_manager} group with 1 update in the / directory: [${dependency_name}](source).\n\n---\nupdated-dependencies:\n- dependency-name: ${dependency_name}\n  dependency-version: 23.0.1\n  dependency-type: direct:production\n  dependency-group: ${package_manager}\n...",
   "commits": [
     {"authors": [{"login": "${commit_login}"}]}
   ],
@@ -419,6 +421,19 @@ test_non_dependency_file_fails() {
 	return 0
 }
 
+test_trusted_actions_dependabot_passes() {
+	write_pr_fixture "dependabot" "dependabot[bot]" ".github/workflows/test.yml" "SUCCESS" "SUCCESS" "actions" "actions/checkout"
+	printf 'pip:pyarrow\nactions:actions/checkout\n' >"$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" "head-current"; then
+		printf 'pip:pyarrow\n' >"$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+		print_result "allowlisted Actions Dependabot workflow update passes narrow gate" 0
+		return 0
+	fi
+	printf 'pip:pyarrow\n' >"$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+	print_result "allowlisted Actions Dependabot workflow update passes narrow gate" 1 "Expected helper to trust fixture. Log: $(<"$LOGFILE")"
+	return 0
+}
+
 test_unallowlisted_dependency_fails() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	printf 'other-package\n' >"$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
@@ -457,6 +472,31 @@ test_repository_allows_hono() {
 	fi
 	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
 	print_result "repository allowlist permits hono updates" 1
+	return 0
+}
+
+test_repository_allows_trusted_actions() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+	local dependency_name=""
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	for dependency_name in \
+		actions/checkout \
+		actions/github-script \
+		qltysh/qlty-action/install \
+		actions/setup-node \
+		actions/upload-artifact \
+		github/codeql-action/upload-sarif \
+		anomalyco/opencode/github \
+		actions/download-artifact; do
+		if ! _trusted_dependabot_dependency_allowed "actions" "$dependency_name"; then
+			export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+			print_result "repository allowlist permits trusted Actions updates" 1 "Missing actions:${dependency_name}"
+			return 0
+		fi
+	done
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits trusted Actions updates" 0
 	return 0
 }
 
@@ -529,9 +569,11 @@ main() {
 	test_dependabot_login_with_user_type_fails
 	test_security_failure_fails
 	test_non_dependency_file_fails
+	test_trusted_actions_dependabot_passes
 	test_unallowlisted_dependency_fails
 	test_repository_allows_types_bun
 	test_repository_allows_hono
+	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
 	test_precomputed_status_rollup_skips_graphql

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -345,13 +345,16 @@ _is_trusted_dependabot_update_pr() {
 	_TRUSTED_DEPENDABOT_LAST_PR="$pr_number"
 	_TRUSTED_DEPENDABOT_LAST_HEAD="$expected_head_sha"
 	_trusted_dependabot_snapshot_is_authentic "$pr_json" "$repo_slug" "$pr_author" "$expected_head_sha" || return 1
-	bad_files=$(printf '%s' "$pr_json" | jq -r '[.files[]?.path | select(test("(^|/)(requirements(-lock)?\\.txt|requirements.*\\.txt|pyproject\\.toml|poetry\\.lock|uv\\.lock|Pipfile\\.lock|package(-lock)?\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb?|composer\\.(json|lock)|Gemfile\\.lock|go\\.(mod|sum)|Cargo\\.(toml|lock))$|^\\.github/dependabot\\.yml$"; "i") | not)] | length' 2>/dev/null) || return 1
-	[[ "$bad_files" == "0" ]] || return 1
-	security_failures=$(printf '%s' "$pr_json" | jq 'def up(v): (v // "" | ascii_upcase); [.statusCheckRollup[]? | select(((.name // .context // "") | test("security|socket|codeql|dependabot"; "i")) and (up(.conclusion) == "FAILURE" or up(.conclusion) == "ERROR" or up(.state) == "FAILURE" or up(.state) == "ERROR"))] | length' 2>/dev/null) || return 1
-	[[ "$security_failures" == "0" ]] || return 1
 
 	body=$(printf '%s' "$pr_json" | jq -r '.body // ""' 2>/dev/null) || body=""
 	package_manager=$(printf '%s' "$body" | sed -nE 's/^Bumps the ([A-Za-z0-9_.-]+) group.*$/\1/p' | sed -n '1p')
+	# GitHub Actions updates are dependency-only only when Dependabot's declared
+	# actions group changes a top-level workflow file. All other ecosystems retain
+	# the manifest-and-lockfile boundary below.
+	bad_files=$(printf '%s' "$pr_json" | jq -r --arg package_manager "$package_manager" '[.files[]?.path | select((test("(^|/)(requirements(-lock)?\\.txt|requirements.*\\.txt|pyproject\\.toml|poetry\\.lock|uv\\.lock|Pipfile\\.lock|package(-lock)?\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb?|composer\\.(json|lock)|Gemfile\\.lock|go\\.(mod|sum)|Cargo\\.(toml|lock))$|^\\.github/dependabot\\.yml$"; "i") or ($package_manager == "actions" and test("^\\.github/workflows/[^/]+\\.ya?ml$"; "i"))) | not)] | length' 2>/dev/null) || return 1
+	[[ "$bad_files" == "0" ]] || return 1
+	security_failures=$(printf '%s' "$pr_json" | jq 'def up(v): (v // "" | ascii_upcase); [.statusCheckRollup[]? | select(((.name // .context // "") | test("security|socket|codeql|dependabot"; "i")) and (up(.conclusion) == "FAILURE" or up(.conclusion) == "ERROR" or up(.state) == "FAILURE" or up(.state) == "ERROR"))] | length' 2>/dev/null) || return 1
+	[[ "$security_failures" == "0" ]] || return 1
 	dependencies=$(_trusted_dependabot_dependencies_from_body "$body") || return 1
 	while IFS= read -r dependency_name; do
 		[[ -n "$dependency_name" ]] || continue


### PR DESCRIPTION
## Summary

Allow the reviewed eight-package GitHub Actions Dependabot group only when every changed file is a top-level workflow and each action is explicitly allowlisted.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/trusted-dependabot-lib.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30388


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.272 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 109,469 tokens on this as a headless worker.