### PR TITLE
GH#30396: bound interactive update-branch conflicts

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -110,6 +110,8 @@ pw-skip-parent-close|pulse-wrapper.sh|1152|Deterministic merge: skipping close o
 pw-skip-dup-closing-comment|pulse-wrapper.sh|1162|Deterministic merge: skipped duplicate closing comment|Skipped duplicate closing comment on linked issue
 pw-update-branch-ok|pulse-wrapper.sh|679|Merge pass: PR #.*update-branch succeeded|Update-branch succeeded (synced PR with base)
 pw-update-branch-fail|pulse-wrapper.sh|686|Merge pass: PR #.*update-branch failed|Update-branch failed — falling through to conflict handling
+pw-update-branch-cooldown|pulse-merge-process.sh|640|Merge pass: PR #.*semantic conflict cooldown active|Update-branch skipped — unchanged interactive head is in semantic-conflict cooldown
+pw-update-branch-cooldown-recorded|pulse-merge-process.sh|130|Merge pass: PR #.*recorded semantic update-branch conflict cooldown|Recorded semantic-conflict cooldown for the current PR head
 pw-skip-conflicting-nmr|pulse-wrapper.sh|1289|Merge pass: skipping CONFLICTING-close.*needs-maintainer-review|Skipped CONFLICTING-close — linked issue has NMR
 pw-update-branch-refetch|pulse-wrapper.sh|1307|Merge pass: PR #.*update-branch succeeded, refetched|Update-branch succeeded on CONFLICTING PR, refetched mergeable state
 pw-approve-self|pulse-wrapper.sh|332|approve_collaborator_pr: PR #.*is self-authored.*skipping approval|Skipped PR approval — self-authored PR

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -57,6 +57,91 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
 : "${PULSE_MERGE_CHECKPOINT_FILE:=${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 : "${PULSE_MERGE_PR_CURSOR_FILE:=${PULSE_MERGE_CHECKPOINT_FILE}.pr-cursor}"
+: "${AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_SECONDS:=3600}"
+: "${AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_DIR:=${HOME}/.aidevops/cache/pulse-update-branch-conflicts}"
+
+#######################################
+# Return the persistent state path for one interactive PR's semantic
+# update-branch conflict. The head SHA in the state file is the freshness
+# signal: a pushed head bypasses the stored cooldown immediately.
+#
+# Args: $1=pr_number, $2=repo_slug
+#######################################
+_pmp_update_branch_conflict_cooldown_file() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local state_key=""
+
+	state_key=$(printf '%s-%s' "$repo_slug" "$pr_number" | tr -c '[:alnum:]._-' '_')
+	[[ -n "$state_key" ]] || return 1
+	printf '%s/%s' "$AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_DIR" "$state_key"
+	return 0
+}
+
+#######################################
+# Check whether this exact PR head remains in a semantic-conflict cooldown.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=head_sha
+#######################################
+_pmp_update_branch_conflict_cooldown_active() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local state_file=""
+	local recorded_head_sha=""
+	local expires_at=""
+	local now=""
+
+	[[ -n "$expected_head_sha" ]] || return 1
+	state_file=$(_pmp_update_branch_conflict_cooldown_file "$pr_number" "$repo_slug") || return 1
+	[[ -f "$state_file" ]] || return 1
+	IFS=$'\t' read -r recorded_head_sha expires_at <"$state_file" || return 1
+	[[ "$recorded_head_sha" == "$expected_head_sha" ]] || return 1
+	[[ "$expires_at" =~ ^[0-9]+$ ]] || return 1
+	now=$(date +%s)
+	[[ "$now" =~ ^[0-9]+$ ]] || return 1
+	[[ "$now" -lt "$expires_at" ]] || return 1
+	return 0
+}
+
+#######################################
+# Persist a semantic-conflict cooldown for this exact interactive PR head. The
+# normal conflict path still runs after the first failed write, preserving
+# worker feedback routing and close policy. Pulse serialises merge passes, so
+# replacing this single-PR state atomically is sufficient.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=head_sha
+#######################################
+_pmp_record_update_branch_conflict_cooldown() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local state_file=""
+	local state_dir=""
+	local state_tmp=""
+	local now=""
+	local expires_at=""
+
+	[[ -n "$expected_head_sha" ]] || return 1
+	[[ "$AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_SECONDS" =~ ^[0-9]+$ ]] || return 1
+	now=$(date +%s)
+	[[ "$now" =~ ^[0-9]+$ ]] || return 1
+	expires_at=$((now + AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_SECONDS))
+	state_file=$(_pmp_update_branch_conflict_cooldown_file "$pr_number" "$repo_slug") || return 1
+	state_dir=$(dirname "$state_file")
+	mkdir -p "$state_dir" || return 1
+	state_tmp=$(mktemp "${state_file}.XXXXXX") || return 1
+	printf '%s\t%s\n' "$expected_head_sha" "$expires_at" >"$state_tmp" || {
+		rm -f "$state_tmp"
+		return 1
+	}
+	mv -f "$state_tmp" "$state_file" || {
+		rm -f "$state_tmp"
+		return 1
+	}
+	echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — recorded semantic update-branch conflict cooldown for head ${expected_head_sha:0:12} until ${expires_at} (GH#30396)" >>"$LOGFILE"
+	return 0
+}
 
 _pmp_is_protected_release_pr() {
 	local head_ref="$1"
@@ -555,8 +640,9 @@ _merge_ready_prs_for_repo() {
 # fall through to the close path).
 #
 # Rate-limit considerations: one REST update-branch call per CONFLICTING
-# PR per merge cycle. No retry — the next pulse cycle will try again if
-# appropriate.
+# PR per merge cycle. A confirmed interactive semantic conflict is persisted
+# for a bounded cooldown so later cycles do not retry an impossible write
+# until the head changes or the cooldown expires (GH#30396).
 #
 # Args: $1=pr_number, $2=repo_slug, $3=expected current head SHA
 #######################################
@@ -564,6 +650,14 @@ _attempt_pr_update_branch() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local expected_head_sha="${3:-}"
+	_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_PR=""
+	_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_REPO=""
+	_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_HEAD=""
+
+	if _pmp_update_branch_conflict_cooldown_active "$pr_number" "$repo_slug" "$expected_head_sha"; then
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — skipping update-branch; semantic conflict cooldown active for unchanged head ${expected_head_sha:0:12} (GH#30396)" >>"$LOGFILE"
+		return 1
+	fi
 
 	local _ub_output _ub_exit
 	_ub_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$expected_head_sha" 2>&1)
@@ -577,6 +671,19 @@ _attempt_pr_update_branch() {
 		return 0
 	fi
 
+	if [[ "$_ub_output" == *"HTTP 422"* ]]; then
+		_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_PR="$pr_number"
+		_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_REPO="$repo_slug"
+		_PMP_UPDATE_BRANCH_SEMANTIC_CONFLICT_HEAD="$expected_head_sha"
+		local _ub_labels=""
+		_ub_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
+			--jq '[.labels[]?.name] | join(",")' 2>/dev/null) || _ub_labels=""
+		case ",${_ub_labels}," in
+		*,origin:interactive,*)
+			_pmp_record_update_branch_conflict_cooldown "$pr_number" "$repo_slug" "$expected_head_sha" || true
+			;;
+		esac
+	fi
 	echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch failed, falling through to close (t2116): ${_ub_output}" >>"$LOGFILE"
 	return 1
 }

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -64,6 +64,8 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_DIR="${TEST_ROOT}/update-branch-conflicts"
+	export AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_SECONDS=3600
 	: >"$LOGFILE"
 	LAST_GH_ARGS_FILE="${TEST_ROOT}/gh-args.log"
 	LAST_GH_QUOTA_FILE="${TEST_ROOT}/gh-quota.log"
@@ -99,6 +101,10 @@ if [[ "${1:-}" == "api" && "${2:-}" == "--method" && "${3:-}" == "PUT" && "${4:-
 	exit "${GH_UB_EXIT:-0}"
 fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	if [[ "$*" == *"--json labels"* ]]; then
+		printf '%s\n' "${GH_PR_LABELS:-}"
+		exit 0
+	fi
 	printf '%s\n' "${GH_VIEW_MERGEABLE:-MERGEABLE}"
 	exit "${GH_VIEW_EXIT:-0}"
 fi
@@ -121,10 +127,13 @@ define_helper_under_test() {
 	# shellcheck source=/dev/null
 	source "$REST_STATE_SCRIPT"
 	helper_src=$(awk '
+		/^_pmp_update_branch_conflict_cooldown_file\(\) \{/,/^}$/ { print }
+		/^_pmp_update_branch_conflict_cooldown_active\(\) \{/,/^}$/ { print }
+		/^_pmp_record_update_branch_conflict_cooldown\(\) \{/,/^}$/ { print }
 		/^_attempt_pr_update_branch\(\) \{/,/^}$/ { print }
 		/^_resolve_pr_mergeable_status\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$helper_src" || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]] \
+	if [[ -z "$helper_src" || "$helper_src" != *"_pmp_record_update_branch_conflict_cooldown"* || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]] \
 		|| ! declare -F _pmp_update_branch_rest >/dev/null 2>&1 \
 		|| ! declare -F _pmp_refresh_unknown_mergeable_state_into >/dev/null 2>&1; then
 		printf 'ERROR: could not extract pulse-merge-process helpers from %s\n' "$PROCESS_SCRIPT" >&2
@@ -218,6 +227,50 @@ test_update_branch_http_422_records_known_cost() {
 		print_result "update-branch HTTP 422 carries explicit one-request cost" 1 \
 			"rc=${rc}; quota=$(cat "$LAST_GH_QUOTA_FILE")"
 	fi
+	return 0
+}
+
+test_semantic_conflict_cooldown_skips_duplicate_write() {
+	install_gh_stub
+	: >"$LAST_GH_ARGS_FILE"
+	: >"$LOGFILE"
+
+	local rc=0
+	GH_UB_EXIT=1 GH_UB_STATUS=422 GH_PR_LABELS=origin:interactive \
+		_attempt_pr_update_branch "19094" "marcusquinn/aidevops" "fedcba9876543210" || rc=$?
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "semantic conflict cooldown skips duplicate update-branch write" 1 \
+			"Expected semantic conflict to return 1, got ${rc}"
+		return 0
+	fi
+
+	: >"$LAST_GH_ARGS_FILE"
+	: >"$LOGFILE"
+	rc=0
+	_attempt_pr_update_branch "19094" "marcusquinn/aidevops" "fedcba9876543210" || rc=$?
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "semantic conflict cooldown skips duplicate update-branch write" 1 \
+			"Expected cooldown skip to return 1, got ${rc}"
+		return 0
+	fi
+
+	if [[ -s "$LAST_GH_ARGS_FILE" ]] || ! grep -q "semantic conflict cooldown active" "$LOGFILE"; then
+		print_result "semantic conflict cooldown skips duplicate update-branch write" 1 \
+			"Expected no gh call and a cooldown log. Calls: $(cat "$LAST_GH_ARGS_FILE"); log: $(cat "$LOGFILE")"
+		return 0
+	fi
+
+	: >"$LAST_GH_ARGS_FILE"
+	: >"$LOGFILE"
+	rc=0
+	GH_UB_EXIT=0 _attempt_pr_update_branch "19094" "marcusquinn/aidevops" "0123456789abcdef" || rc=$?
+	if [[ "$rc" -ne 0 ]] || ! grep -q "update-branch" "$LAST_GH_ARGS_FILE"; then
+		print_result "semantic conflict cooldown skips duplicate update-branch write" 1 \
+			"Expected a changed head to bypass cooldown. rc=${rc}; calls: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "semantic conflict cooldown skips duplicate update-branch write" 0
 	return 0
 }
 
@@ -598,6 +651,7 @@ main() {
 	test_update_branch_missing_head_fails_before_write
 	test_update_branch_failure_returns_one
 	test_update_branch_http_422_records_known_cost
+	test_semantic_conflict_cooldown_skips_duplicate_write
 	test_update_branch_tags_log_with_task_id
 	test_resolve_mergeable_retries_unknown
 	test_resolve_mergeable_accepts_boolean_true


### PR DESCRIPTION
## Summary

Bound repeated semantic update-branch attempts for unchanged origin:interactive PR heads and added diagnostic classifications.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/tests/test-pulse-merge-update-branch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-merge-update-branch.sh; .agents/scripts/tests/test-pulse-diagnose-helper.sh; .agents/scripts/linters-local.sh

Resolves #30396


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 12m and 188,516 tokens on this as a headless worker.