### PR TITLE
GH#30413: fix: trust Vite Dependabot review gates

### DIFF
--- a/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
@@ -14,9 +14,19 @@ HELPER_FILE="${REPO_ROOT}/.agents/scripts/review-bot-gate-helper.sh"
 STATE_DIR="$(mktemp -d)"
 trap 'rm -rf "${STATE_DIR}"' EXIT
 mkdir -p "${STATE_DIR}/bin"
+mkdir -p "${STATE_DIR}/__aidevops/.agents/scripts"
+mkdir -p "${STATE_DIR}/__aidevops/.agents/configs"
+ln -s "${REPO_ROOT}/.agents/scripts/trusted-dependabot-lib.sh" \
+	"${STATE_DIR}/__aidevops/.agents/scripts/trusted-dependabot-lib.sh"
+ln -s "${REPO_ROOT}/.agents/configs/trusted-dependabot-updates.conf" \
+	"${STATE_DIR}/__aidevops/.agents/configs/trusted-dependabot-updates.conf"
 cat >"${STATE_DIR}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "api" ]] || exit 2
+if [[ "${2:-}" == "graphql" ]]; then
+	printf '%s\n' '{"data":{"repository":{"pullRequest":{"author":{"__typename":"Bot","login":"dependabot"},"body":"Bumps [vite](source) from 8.1.5 to 8.2.1.","headRefOid":"head-123","headRepository":{"nameWithOwner":"marcusquinn/aidevops"},"headRepositoryOwner":{"login":"marcusquinn"},"commits":{"pageInfo":{"hasNextPage":false},"nodes":[{"commit":{"authors":{"pageInfo":{"hasNextPage":false},"nodes":[{"user":{"login":"dependabot[bot]"}}]}}}]},"files":{"pageInfo":{"hasNextPage":false},"nodes":[{"path":"package.json"},{"path":"bun.lock"}]},"statusCheckRollup":{"contexts":{"pageInfo":{"hasNextPage":false},"nodes":[{"__typename":"CheckRun","name":"ShellCheck","conclusion":"SUCCESS","status":"COMPLETED","workflowName":"Code Quality Analysis"}]}}}},"rateLimit":{"cost":1}}}'
+	exit 0
+fi
 [[ "${2:-}" == "repos/marcusquinn/aidevops/pulls/123" ]] || exit 2
 case "${REVIEW_GATE_LIVE_TRUSTED:-false}" in
 true)
@@ -49,6 +59,11 @@ if [[ -z "${CLASSIFIER}" ]]; then
 	printf 'FAIL: review-gate trust classifier extraction was empty\n' >&2
 	exit 1
 fi
+if ! grep -Fq 'TRUSTED_DEPENDABOT_PR=false' "${WORKFLOW_FILE}" ||
+	! grep -Fq '_is_trusted_dependabot_update_pr' "${WORKFLOW_FILE}"; then
+	printf 'FAIL: review-gate classifier must delegate Dependabot trust to the shared exact-head verifier\n' >&2
+	exit 1
+fi
 
 assert_output() {
 	local output_file="$1"
@@ -67,24 +82,28 @@ run_case() {
 	local case_name="$1"
 	local expected_external="$2"
 	local expected_trusted="$3"
-	local expected_association="$4"
-	local expected_rate_limit="$5"
-	local expected_completion="$6"
-	local author_association="$7"
-	local author_login="$8"
-	local author_id="$9"
-	local author_type="${10}"
-	local head_repository="${11}"
-	local base_repository="${12}"
-	local head_ref="${13}"
-	local pr_body="${14}"
-	local live_trusted="${15:-false}"
+	local expected_dependabot="$4"
+	local expected_association="$5"
+	local expected_rate_limit="$6"
+	local expected_completion="$7"
+	local author_association="$8"
+	local author_login="$9"
+	local author_id="${10}"
+	local author_type="${11}"
+	local head_repository="${12}"
+	local base_repository="${13}"
+	local head_ref="${14}"
+	local pr_body="${15}"
+	local expected_head_sha="${16:-}"
+	local live_trusted="${17:-false}"
 	local output_file=""
 
 	CASE_INDEX=$((CASE_INDEX + 1))
 	output_file="${STATE_DIR}/case-${CASE_INDEX}.out"
 	if ! GITHUB_OUTPUT="${output_file}" \
 		HELPER="${HELPER_FILE}" \
+		GITHUB_WORKSPACE="${STATE_DIR}" \
+		DEPENDABOT_LIB="${STATE_DIR}/__aidevops/.agents/scripts/trusted-dependabot-lib.sh" \
 		PATH="${STATE_DIR}/bin:${PATH}" \
 		PR_NUMBER=123 \
 		REPO="marcusquinn/aidevops" \
@@ -97,6 +116,7 @@ run_case() {
 		REVIEW_GATE_PR_BASE_REPOSITORY="${base_repository}" \
 		REVIEW_GATE_PR_HEAD_REF="${head_ref}" \
 		REVIEW_GATE_PR_BODY="${pr_body}" \
+		REVIEW_GATE_EXPECTED_HEAD_SHA="${expected_head_sha}" \
 		REVIEW_GATE_RATE_LIMIT_BEHAVIOR=pass \
 		REVIEW_GATE_COMPLETION_BEHAVIOR=fast \
 		bash -c "${CLASSIFIER}" >/dev/null; then
@@ -106,6 +126,7 @@ run_case() {
 
 	assert_output "${output_file}" is_external_pr "${expected_external}" "${case_name}"
 	assert_output "${output_file}" trusted_issue_sync_pr "${expected_trusted}" "${case_name}"
+	assert_output "${output_file}" trusted_dependabot_pr "${expected_dependabot}" "${case_name}"
 	assert_output "${output_file}" effective_author_association "${expected_association}" "${case_name}"
 	assert_output "${output_file}" effective_rate_limit_behavior "${expected_rate_limit}" "${case_name}"
 	assert_output "${output_file}" effective_completion_behavior "${expected_completion}" "${case_name}"
@@ -117,55 +138,62 @@ MARKER='<!-- aidevops:issue-sync-todo-pr -->'
 
 run_case \
 	'official same-repository Issue Sync bot is trusted' \
-	false true COLLABORATOR pass fast \
+	false true false COLLABORATOR pass fast \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' "${MARKER}"
 
 run_case \
+	'exact same-repository Dependabot update is trusted' \
+	false false true COLLABORATOR pass fast \
+	CONTRIBUTOR 'dependabot[bot]' 49699333 Bot \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'dependabot/bun/vite-8.2.1' 'Bumps vite from 8.1.5 to 8.2.1' head-123
+
+run_case \
 	'owner association remains trusted without automation normalization' \
-	false false OWNER pass fast \
+	false false false OWNER pass fast \
 	OWNER maintainer 123 User \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'feature/example' 'ordinary pull request'
 
 run_case \
 	'issue_comment metadata omission uses the live shared classifier' \
-	false true COLLABORATOR pass fast \
+	false true false COLLABORATOR pass fast \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
-	'' '' '' "${MARKER}" true
+	'' '' '' "${MARKER}" '' true
 
 run_case \
 	'external user cannot spoof marker and deterministic branch' \
-	true false CONTRIBUTOR wait strict \
+	true false false CONTRIBUTOR wait strict \
 	CONTRIBUTOR attacker 999 User \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' "${MARKER}"
 
 run_case \
 	'lookalike bot ID remains external' \
-	true false CONTRIBUTOR wait strict \
+	true false false CONTRIBUTOR wait strict \
 	CONTRIBUTOR 'github-actions[bot]' 999 Bot \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' "${MARKER}"
 
 run_case \
 	'forked Issue Sync branch remains external' \
-	true false CONTRIBUTOR wait strict \
+	true false false CONTRIBUTOR wait strict \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
 	'attacker/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' "${MARKER}"
 
 run_case \
 	'wrong same-repository branch remains external' \
-	true false CONTRIBUTOR wait strict \
+	true false false CONTRIBUTOR wait strict \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'feature/not-issue-sync' "${MARKER}"
 
 run_case \
 	'missing generated marker remains external' \
-	true false CONTRIBUTOR wait strict \
+	true false false CONTRIBUTOR wait strict \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' 'ordinary pull request'

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -149,8 +149,10 @@ jobs:
           # same repository on both sides, fixed branch, and generated body marker.
           # Any missing or mismatched field remains external and fail-closed.
           HELPER="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/review-bot-gate-helper.sh"
+          DEPENDABOT_LIB="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/trusted-dependabot-lib.sh"
           # aidevops:review-gate-trust-start
           TRUSTED_ISSUE_SYNC_PR=false
+          TRUSTED_DEPENDABOT_PR=false
           #aidevops:trust-boundary
           if [[ "${REVIEW_GATE_PR_AUTHOR_LOGIN}" == "github-actions[bot]" ]] &&
             [[ "${REVIEW_GATE_PR_AUTHOR_ID}" == "41898282" ]] &&
@@ -176,6 +178,30 @@ jobs:
             echo "Trusted Issue Sync PR confirmed from live metadata omitted by the event"
           fi
 
+          # Dependabot reports as CONTRIBUTOR even for an exact same-repository
+          # dependency update. Reuse the live, head-bound trust gate rather than
+          # accepting event metadata alone: it verifies the GitHub bot identity,
+          # repository ownership, Dependabot-authored commits, allowed files and
+          # dependencies, and terminal security checks.
+          #aidevops:trust-boundary
+          if [[ "${REVIEW_GATE_PR_AUTHOR_LOGIN}" == "dependabot[bot]" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_ID}" == "49699333" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_TYPE}" == "Bot" ]] &&
+            [[ -f "${DEPENDABOT_LIB}" ]]; then
+            DEPENDABOT_EXPECTED_HEAD_SHA="${REVIEW_GATE_EXPECTED_HEAD_SHA}"
+            if [[ -z "${DEPENDABOT_EXPECTED_HEAD_SHA}" ]]; then
+              DEPENDABOT_EXPECTED_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+                --jq '.head.sha // ""' 2>/dev/null || true)
+            fi
+            if [[ -n "${DEPENDABOT_EXPECTED_HEAD_SHA}" ]] &&
+              source "${DEPENDABOT_LIB}" &&
+              _is_trusted_dependabot_update_pr "${PR_NUMBER}" "${REPO}" \
+                "${REVIEW_GATE_PR_AUTHOR_LOGIN}" "${DEPENDABOT_EXPECTED_HEAD_SHA}"; then
+              TRUSTED_DEPENDABOT_PR=true
+              echo "Trusted same-repository Dependabot update confirmed from live exact-head metadata"
+            fi
+          fi
+
           # Check if this is an external contributor PR using immutable event
           # evidence, so API exhaustion cannot accidentally grant trust. The
           # normalized association is exported because the fetched helper
@@ -188,10 +214,10 @@ jobs:
             IS_EXTERNAL_PR=false
             ;;
           *)
-            if [[ "${TRUSTED_ISSUE_SYNC_PR}" == "true" ]]; then
+            if [[ "${TRUSTED_ISSUE_SYNC_PR}" == "true" || "${TRUSTED_DEPENDABOT_PR}" == "true" ]]; then
               export REVIEW_GATE_AUTHOR_ASSOCIATION=COLLABORATOR
               IS_EXTERNAL_PR=false
-              echo "Trusted repository-generated Issue Sync PR detected — applying internal advisory policy"
+              echo "Trusted repository automation PR detected — applying internal advisory policy"
             else
               IS_EXTERNAL_PR=true
               echo "External contributor PR detected — advisory review bypass DISABLED"
@@ -206,6 +232,7 @@ jobs:
           export REVIEW_GATE_AUTHOR_ASSOCIATION_RESOLVED=true
           echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
           echo "trusted_issue_sync_pr=${TRUSTED_ISSUE_SYNC_PR}" >> "${GITHUB_OUTPUT}"
+          echo "trusted_dependabot_pr=${TRUSTED_DEPENDABOT_PR}" >> "${GITHUB_OUTPUT}"
           echo "effective_author_association=${REVIEW_GATE_AUTHOR_ASSOCIATION}" >> "${GITHUB_OUTPUT}"
           echo "effective_rate_limit_behavior=${REVIEW_GATE_RATE_LIMIT_BEHAVIOR}" >> "${GITHUB_OUTPUT}"
           echo "effective_completion_behavior=${REVIEW_GATE_COMPLETION_BEHAVIOR}" >> "${GITHUB_OUTPUT}"

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "elysia": "1.4.27",
         "file-type": "21.3.2",
         "hono": "4.13.0",
-        "vite": "8.1.5",
+        "vite": "8.2.1",
       },
       "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "11.7.1",
@@ -125,12 +125,6 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
-
-    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
-
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
-
     "@fontsource/courier-prime": ["@fontsource/courier-prime@5.2.8", "", {}, "sha512-M3xOCcXnGuFi9TcGCrz4hm5yeWg4Sn35MALRLPnqNoHhawTFvhyi2KSI2+5RyFtDNJrb58bPh8LLipgiI9KA0w=="],
 
     "@fontsource/dm-mono": ["@fontsource/dm-mono@5.3.0", "", {}, "sha512-OINjI8C1S/wpchhQxl7njZdMn4+hnDCpQ4YtvvOpKNARo+0J8O1x1IcrChxNjHOhfVv1by8C/FQoy3hXK+C1Ug=="],
@@ -175,45 +169,41 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
-
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+    "@oxc-project/types": ["@oxc-project/types@0.144.0", "", {}, "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.4", "", { "os": "none", "cpu": "arm64" }, "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
-
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -254,8 +244,6 @@
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
-
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -507,7 +495,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+    "rolldown": ["rolldown@1.2.4", "", { "dependencies": { "@oxc-project/types": "=0.144.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.4", "@rolldown/binding-darwin-arm64": "1.2.4", "@rolldown/binding-darwin-x64": "1.2.4", "@rolldown/binding-freebsd-x64": "1.2.4", "@rolldown/binding-linux-arm-gnueabihf": "1.2.4", "@rolldown/binding-linux-arm64-gnu": "1.2.4", "@rolldown/binding-linux-arm64-musl": "1.2.4", "@rolldown/binding-linux-ppc64-gnu": "1.2.4", "@rolldown/binding-linux-s390x-gnu": "1.2.4", "@rolldown/binding-linux-x64-gnu": "1.2.4", "@rolldown/binding-linux-x64-musl": "1.2.4", "@rolldown/binding-openharmony-arm64": "1.2.4", "@rolldown/binding-win32-arm64-msvc": "1.2.4", "@rolldown/binding-win32-x64-msvc": "1.2.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -557,8 +545,6 @@
 
     "token-types": ["token-types@6.1.1", "", { "dependencies": { "@borewit/text-codec": "^0.1.0", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ=="],
 
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -575,7 +561,7 @@
 
     "version-range": ["version-range@4.15.0", "", {}, "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg=="],
 
-    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
+    "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "elysia": "1.4.27",
     "file-type": "21.3.2",
     "hono": "4.13.0",
-    "vite": "8.1.5"
+    "vite": "8.2.1"
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "11.7.1",


### PR DESCRIPTION
## Summary

Trusted exact-head Dependabot dependency updates now receive the internal advisory review policy after shared verification; Vite is updated to 8.2.1.

## Files Changed

.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh, .github/workflows/review-bot-gate-reusable.yml, bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun run gui:typecheck; bun run gui:build; bash .agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; ShellCheck

Resolves #30413


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 9m and 210,860 tokens on this as a headless worker.