### PR TITLE
GH#30409: fix: trust Elysia Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -18,6 +18,7 @@ pip:pyarrow
 vite
 react
 hono
+elysia
 @types/bun
 @types/react
 @fontsource/dm-sans

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -475,6 +475,20 @@ test_repository_allows_hono() {
 	return 0
 }
 
+test_repository_allows_elysia() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "" "elysia"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits Elysia updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits Elysia updates" 1
+	return 0
+}
+
 test_repository_allows_fontsource_ubuntu() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 
@@ -587,6 +601,7 @@ main() {
 	test_unallowlisted_dependency_fails
 	test_repository_allows_types_bun
 	test_repository_allows_hono
+	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
 	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "aidevops-dspy-integration",
       "dependencies": {
         "@vitejs/plugin-react": "5.2.0",
-        "elysia": "1.4.27",
+        "elysia": "1.4.29",
         "file-type": "21.3.2",
         "hono": "4.13.0",
         "vite": "8.2.1",
@@ -352,7 +352,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.376", "", {}, "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA=="],
 
-    "elysia": ["elysia@1.4.27", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-2UlmNEjPJVA/WZVPYKy+KdsrfFwwNlqSBW1lHz6i2AHc75k7gV4Rhm01kFeotH7PDiHIX2G8X3KnRPc33SGVIg=="],
+    "elysia": ["elysia@1.4.29", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@vitejs/plugin-react": "5.2.0",
-    "elysia": "1.4.27",
+    "elysia": "1.4.29",
     "file-type": "21.3.2",
     "hono": "4.13.0",
     "vite": "8.2.1"


### PR DESCRIPTION
## Summary

Recreated the stale Elysia 1.4.29 Dependabot patch on current main, retaining subsequent allowlist entries and adding an isolated Elysia trust regression.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun run server:check; aidevops security supply-chain scan. Bun 1.2.11 has no bun audit subcommand.

Resolves #30409


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 82,692 tokens on this as a headless worker.