### PR TITLE
GH#30408: fix: retain supported file-type runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@vitejs/plugin-react": "5.2.0",
         "elysia": "1.4.29",
-        "file-type": "21.3.2",
+        "file-type": "21.3.4",
         "hono": "4.13.0",
         "vite": "8.2.1",
       },
@@ -374,7 +374,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "file-type": ["file-type@21.3.2", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w=="],
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "5.2.0",
     "elysia": "1.4.29",
-    "file-type": "21.3.2",
+    "file-type": "21.3.4",
     "hono": "4.13.0",
     "vite": "8.2.1"
   },
@@ -88,7 +88,7 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
## Summary

Keeps file-type on the Node 20-compatible 21.3.4 release and preserves newer Elysia and Vite updates while resolving the stale repair.

## Files Changed

bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bunx --bun bun@1.3.11 install --frozen-lockfile --ignore-scripts; bunx --bun bun@1.3.11 test; bunx --bun bun@1.3.11 run typecheck; bunx --bun bun@1.3.11 audit

Resolves #30408


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 92,198 tokens on this as a headless worker.