### PR TITLE
GH#30393: promote verified OpenCode 1.18.18 pin

### DIFF
--- a/.agents/plugins/opencode-aidevops/package-lock.json
+++ b/.agents/plugins/opencode-aidevops/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "@opencode-ai/plugin": "^1.3.13"
+        "@opencode-ai/plugin": "^1.18.18"
       },
       "peerDependencies": {
         "opencode-ai": ">=1.3.0"
@@ -113,13 +113,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.11.tgz",
-      "integrity": "sha512-mgn7+YO2J5tM2sWtV8pPBz6Lz6vWZswBOjUWssLvGaxKPuHR60sZ3Py4/tjI9RNl74aB4lhI0NUlanuWZS8NfA==",
+      "version": "1.18.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.18.tgz",
+      "integrity": "sha512-vqQeqJtn9c+J+tIQDzYk88xip/NVNN1hym1ATmckxo6zINHAoXoul4Sw/jgnvL00rLsfAvhja28qax4h3g/5Jg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.11",
+        "@opencode-ai/sdk": "1.18.18",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.11.tgz",
-      "integrity": "sha512-yDImmNv4PhxdMgtiHVNWQWEVwQlAm7Dr0y4XU7CT4dOIbzgO+VP+9I02lAP7Zva1FhGeyI7oKMI2tzB9RUsWaQ==",
+      "version": "1.18.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.18.tgz",
+      "integrity": "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -15,7 +15,7 @@
   "author": "Marcus Quinn",
   "license": "MIT",
   "opencode": {
-    "tracked_version": "1.3.13",
+    "tracked_version": "1.18.18",
     "repo": "anomalyco/opencode"
   },
   "peerDependencies": {
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "@opencode-ai/plugin": "^1.3.13"
+    "@opencode-ai/plugin": "^1.18.18"
   }
 }

--- a/.agents/scripts/opencode-pin-canary.sh
+++ b/.agents/scripts/opencode-pin-canary.sh
@@ -12,6 +12,7 @@ source "$SCRIPT_DIR/shared-constants.sh"
 
 _CANARY_TEMP_ROOT=""
 _CANARY_MOCK_PID=""
+_CANARY_PLUGIN_PATH=""
 
 cleanup_canary() {
 	if [[ -n "$_CANARY_MOCK_PID" ]]; then
@@ -38,6 +39,22 @@ install_isolated_opencode() {
 		npm_config_userconfig=/dev/null npm_config_cache="$isolated_cache" \
 		npm install --ignore-scripts --no-audit --no-fund --prefix "$install_root" \
 		"opencode-ai@${version}" >/dev/null
+}
+
+install_isolated_plugin() {
+	local install_root="$1"
+	local isolated_home="$2"
+	local isolated_cache="$3"
+	local source_root="$SCRIPT_DIR/../plugins/opencode-aidevops"
+	mkdir -p "$install_root" "$isolated_home" "$isolated_cache"
+	cp -R "$source_root/." "$install_root/" || return 1
+	env -i \
+		HOME="$isolated_home" PATH="$PATH" \
+		GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+		npm_config_userconfig=/dev/null npm_config_cache="$isolated_cache" \
+		npm ci --ignore-scripts --no-audit --no-fund --prefix "$install_root" >/dev/null || return 1
+	_CANARY_PLUGIN_PATH="$install_root/index.mjs"
+	return 0
 }
 
 resolve_installed_opencode_binary() {
@@ -151,35 +168,46 @@ run_isolated_probe() {
 	local request_file="$5"
 	local probe_root="$canary_root/probe-$label"
 	local output_file="$canary_root/$label.output"
-	local plugin_path="$SCRIPT_DIR/../plugins/opencode-aidevops/index.mjs"
+	local plugin_path="${_CANARY_PLUGIN_PATH:-$SCRIPT_DIR/../plugins/opencode-aidevops/index.mjs}"
 	local plugin_url=""
+	local provider_id="canary"
 	local model_id="canary"
+	local model_ref="${provider_id}/${model_id}"
 	local request_count_before=0
 	local request_count_after=0
+	local probe_timeout_seconds=120
 	mkdir -p "$probe_root/home" "$probe_root/config/opencode" "$probe_root/data" "$probe_root/cache"
 	if [[ -f "$plugin_path" ]]; then
 		plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve().as_uri())' "$plugin_path")
 	fi
-	jq -n --arg api "http://127.0.0.1:${port}/v1" --arg plugin "$plugin_url" --arg model "$model_id" \
-		'{provider:{($model):{npm:"@ai-sdk/openai-compatible",name:"Canary",api:$api,
-		options:{apiKey:"canary-local-only"},models:{($model):{name:"Canary"}}}}}
+	jq -n --arg api "http://127.0.0.1:${port}/v1" --arg plugin "$plugin_url" \
+		--arg provider "$provider_id" --arg model "$model_id" --arg model_ref "$model_ref" \
+		'{model:$model_ref,small_model:$model_ref,
+		provider:{($provider):{npm:"@ai-sdk/openai-compatible@3.0.31",name:"Canary",
+		options:{baseURL:$api,apiKey:"canary-local-only"},models:{($model):{name:"Canary"}}}}}
 		+ (if $plugin == "" then {} else {plugin:[$plugin]} end)' \
 		>"$probe_root/config/opencode/opencode.json"
+	local routing_file="$probe_root/config/model-routing.json"
+	jq -n --arg model "$model_ref" \
+		'{tiers:{simple:{models:[$model]},standard:{models:[$model]},thinking:{models:[$model]}},
+		escalation_order:["simple","standard","thinking"]}' >"$routing_file"
 	[[ -f "$request_file" ]] && request_count_before=$(wc -l <"$request_file" | tr -d ' ')
 
-	local timeout_command=(timeout --kill-after=5s 60s)
+	local timeout_command=(timeout --kill-after=5s "${probe_timeout_seconds}s")
 	if ! command -v timeout >/dev/null 2>&1; then
-		timeout_command=(perl -e 'alarm 60; exec @ARGV' --)
+		timeout_command=(perl -e "alarm ${probe_timeout_seconds}; exec @ARGV" --)
 	fi
 	local probe_rc=0
 	env -i \
 		HOME="$probe_root/home" PATH="$PATH" \
 		XDG_CONFIG_HOME="$probe_root/config" XDG_DATA_HOME="$probe_root/data" \
-		XDG_CACHE_HOME="$probe_root/cache" AIDEVOPS_HEADLESS=1 \
+		XDG_CACHE_HOME="$probe_root/cache" AIDEVOPS_HEADLESS=1 AIDEVOPS_PLUGIN_DEBUG=1 \
+		AIDEVOPS_MODEL_ROUTING_TABLE="$routing_file" \
 		GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
 		"${timeout_command[@]}" "$binary" run \
 		"What is two plus two? Answer with the single word: Four" \
-		-m canary/canary --dir "$probe_root/home" --agent build \
+		-m "$model_ref" --dir "$probe_root/home" --agent build \
+		--print-logs --log-level DEBUG \
 		>"$output_file" 2>&1 || probe_rc=$?
 	[[ -f "$request_file" ]] && request_count_after=$(wc -l <"$request_file" | tr -d ' ')
 	if [[ "$probe_rc" -eq 0 && "$request_count_after" -gt "$request_count_before" ]] && grep -q 'Four' "$output_file"; then
@@ -189,6 +217,12 @@ run_isolated_probe() {
 	printf 'FAIL: %s isolated probe exited %s (provider requests: %s -> %s)\n' \
 		"$label" "$probe_rc" "$request_count_before" "$request_count_after" >&2
 	command tail -n 20 "$output_file" >&2 || true
+	local log_file
+	for log_file in "$probe_root/data/opencode/log/"*.log; do
+		[[ -f "$log_file" ]] || continue
+		printf '%s\n' "OpenCode log: $log_file" >&2
+		command tail -n 80 "$log_file" >&2 || true
+	done
 	return 1
 }
 
@@ -260,6 +294,11 @@ cmd_canary() {
 	if ! install_isolated_opencode "$_CANARY_TEMP_ROOT/candidate" "$candidate" \
 		"$_CANARY_TEMP_ROOT/install-home-candidate" "$_CANARY_TEMP_ROOT/npm-cache-candidate"; then
 		printf 'RESULT=inconclusive\nINCONCLUSIVE: candidate installation failed\n' >&2
+		return 2
+	fi
+	if ! install_isolated_plugin "$_CANARY_TEMP_ROOT/plugin" \
+		"$_CANARY_TEMP_ROOT/install-home-plugin" "$_CANARY_TEMP_ROOT/npm-cache-plugin"; then
+		printf 'RESULT=inconclusive\nINCONCLUSIVE: locked plugin installation failed\n' >&2
 		return 2
 	fi
 	local baseline_bin=""

--- a/.agents/scripts/opencode-pin-canary.sh
+++ b/.agents/scripts/opencode-pin-canary.sh
@@ -170,8 +170,9 @@ run_isolated_probe() {
 	local output_file="$canary_root/$label.output"
 	local plugin_path="${_CANARY_PLUGIN_PATH:-$SCRIPT_DIR/../plugins/opencode-aidevops/index.mjs}"
 	local plugin_url=""
-	local provider_id="canary"
-	local model_id="canary"
+	local canary_id="canary"
+	local provider_id="$canary_id"
+	local model_id="$canary_id"
 	local model_ref="${provider_id}/${model_id}"
 	local request_count_before=0
 	local request_count_after=0
@@ -338,5 +339,8 @@ cmd_canary() {
 case "${1:-}" in
 status) cmd_status "${2:-}" ;;
 canary) cmd_canary "${2:-latest}" ;;
-*) usage >&2; exit 2 ;;
+*)
+	usage >&2
+	exit 2
+	;;
 esac

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -182,18 +182,19 @@ aidevops_ensure_symlink_target() {
 # GH#28766: OpenCode 1.18.7 stalled Linux headless workers while bootstrapping
 # location services with an isolated XDG_DATA_HOME. GH#28892 advanced the pin
 # after 1.18.9 passed the isolated Linux-headless canary; GH#29964 promoted
-# 1.18.16 after a credential-free same-revision baseline comparison. Keep the
-# complete compatibility decision visible and machine-readable; general
-# installs track latest because the observed failure scope is Linux headless.
-readonly OPENCODE_PINNED_VERSION="1.18.16"
+# 1.18.16 after a credential-free same-revision baseline comparison; GH#30393
+# promoted 1.18.18 after making that comparison self-contained. Keep the complete
+# compatibility decision visible and machine-readable; general installs track
+# latest because the observed failure scope is Linux headless.
+readonly OPENCODE_PINNED_VERSION="1.18.18"
 readonly OPENCODE_PIN_REASON="GH#28766 Linux headless bootstrap stalled with isolated XDG_DATA_HOME"
 readonly OPENCODE_PIN_PLATFORM="Linux"
 readonly OPENCODE_PIN_RUNTIME_MODE="headless"
 readonly OPENCODE_PIN_INTRODUCED_DATE="2026-07-30"
-readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-08-11"
-readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.16"
-readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-08-18"
-readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.16"
+readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-08-19"
+readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.18"
+readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-08-26"
+readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.18"
 
 aidevops_opencode_pin_applies() {
 	local platform="${1:-$(uname -s 2>/dev/null || printf 'unknown')}"

--- a/.agents/scripts/tests/test-opencode-pin-policy.sh
+++ b/.agents/scripts/tests/test-opencode-pin-policy.sh
@@ -19,13 +19,13 @@ assert_eq() {
 	fi
 }
 
-assert_eq "pin version is explicit" "1.18.16" "$OPENCODE_PINNED_VERSION"
+assert_eq "pin version is explicit" "1.18.18" "$OPENCODE_PINNED_VERSION"
 assert_eq "pin platform is scoped" "Linux" "$OPENCODE_PIN_PLATFORM"
 assert_eq "pin runtime is scoped" "headless" "$OPENCODE_PIN_RUNTIME_MODE"
 assert_eq "introduction date is recorded" "2026-07-30" "$OPENCODE_PIN_INTRODUCED_DATE"
-assert_eq "last canary is recorded" "2026-08-11" "$OPENCODE_PIN_LAST_CANARY_DATE"
-assert_eq "review deadline is recorded" "2026-08-18" "$OPENCODE_PIN_REVIEW_DEADLINE"
-assert_eq "plugin compatibility signal is explicit" "1.18.16" "$OPENCODE_PLUGIN_TESTED_VERSION"
+assert_eq "last canary is recorded" "2026-08-19" "$OPENCODE_PIN_LAST_CANARY_DATE"
+assert_eq "review deadline is recorded" "2026-08-26" "$OPENCODE_PIN_REVIEW_DEADLINE"
+assert_eq "plugin compatibility signal is explicit" "1.18.18" "$OPENCODE_PLUGIN_TESTED_VERSION"
 
 scope_rc=0
 aidevops_opencode_pin_applies Linux headless || scope_rc=$?
@@ -40,7 +40,7 @@ assert_eq "interactive setup is outside observed scope" "1" "$scope_rc"
 status=$(
 	PATH="/usr/bin:/bin" "$REPO_ROOT/.agents/scripts/opencode-pin-canary.sh" status
 )
-[[ "$status" == *"pinned=1.18.16"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.16"* && "$status" == *"last-canary=2026-08-11"* ]] || {
+[[ "$status" == *"pinned=1.18.18"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.18"* && "$status" == *"last-canary=2026-08-19"* ]] || {
 	printf 'FAIL: status omits compatibility evidence: %s\n' "$status" >&2
 	fail=$((fail + 1))
 }
@@ -56,7 +56,8 @@ else
 	fail=$((fail + 1))
 fi
 if grep -q 'env -i' "$canary_script" && grep -q 'GIT_CONFIG_GLOBAL=/dev/null' "$canary_script" &&
-	grep -q 'npm_config_userconfig=/dev/null' "$canary_script"; then
+	grep -q 'npm_config_userconfig=/dev/null' "$canary_script" &&
+	grep -q 'npm ci --ignore-scripts --no-audit --no-fund' "$canary_script"; then
 	printf 'PASS: package installation and candidate execution use isolated environments\n'
 else
 	printf 'FAIL: candidate execution is not explicitly isolated from user credentials/config\n' >&2
@@ -64,7 +65,8 @@ else
 fi
 if grep -q 'run_isolated_probe "baseline-' "$canary_script" &&
 	grep -q 'run_isolated_probe "candidate-' "$canary_script" &&
-	grep -q 'canary-local-only' "$canary_script" && grep -q "'^RESULT=pass\$'" "$workflow"; then
+	grep -q 'canary-local-only' "$canary_script" && grep -q 'small_model:' "$canary_script" &&
+	grep -q 'AIDEVOPS_MODEL_ROUTING_TABLE=' "$canary_script" && grep -q "'^RESULT=pass\$'" "$workflow"; then
 	printf 'PASS: promotion requires a credential-free same-revision baseline and candidate pass\n'
 else
 	printf 'FAIL: promotion lacks a credential-free same-revision comparison gate\n' >&2

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -284,7 +284,7 @@ cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 printf "1.18.18\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
-( : ) &
+(:) &
 dead_installer_pid=$!
 wait "$dead_installer_pid" || true
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock"

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -91,7 +91,7 @@ extract_function
 printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
 # shellcheck source=../shared-constants.sh
 source "$SHARED_CONSTANTS"
-assert_eq "OpenCode headless regression pin" "1.18.16" "$OPENCODE_PINNED_VERSION"
+assert_eq "OpenCode headless regression pin" "1.18.18" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 0a: routine freshness tracks registry outside Linux headless dispatch\n'
 mkdir -p "$SANDBOX/routine-freshness/bin"
@@ -212,7 +212,7 @@ assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$
 printf 'Test 4: headless guard provisions an isolated pin without changing newer general install\n'
 mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin" "$SANDBOX/version-guard/state"
 write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
-printf "1.18.17\n"'
+printf "1.18.19\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
@@ -224,7 +224,7 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.16\n"
+printf "1.18.18\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 guard_rc=0
@@ -244,10 +244,10 @@ headless_bin=""
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
 headless_bin=$(<"$SANDBOX/version-guard/headless-bin")
-assert_eq "general install remains newer" "1.18.17" "$("$SANDBOX/version-guard/runtime/opencode")"
-assert_eq "isolated headless runtime is pinned" "1.18.16" "$("$headless_bin")"
+assert_eq "general install remains newer" "1.18.19" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "isolated headless runtime is pinned" "1.18.18" "$("$headless_bin")"
 install_call=$(<"$SANDBOX/version-guard/calls")
-[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.16.install."*"/prefix opencode-ai@1.18.16" ]] && install_shape="valid" || install_shape="invalid"
+[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.18.install."*"/prefix opencode-ai@1.18.18" ]] && install_shape="valid" || install_shape="invalid"
 assert_eq "isolated install requests exact pin" "valid" "$install_shape"
 
 printf 'Test 4b: existing isolated pin is reused without package-manager mutation\n'
@@ -270,7 +270,7 @@ assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SAND
 printf 'Test 4c: stale pin repair locks are cleared after the bounded wait\n'
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes" "$SANDBOX/version-stale-lock/bin"
 write_executable "$SANDBOX/version-stale-lock/runtime-opencode" '#!/usr/bin/env bash
-printf "1.18.17\n"'
+printf "1.18.19\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-stale-lock/bin/npm" '#!/usr/bin/env bash
 prefix=""
@@ -281,14 +281,14 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.16\n"
+printf "1.18.18\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 ( : ) &
 dead_installer_pid=$!
 wait "$dead_installer_pid" || true
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock"
-mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.16.install.$dead_installer_pid"
+mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.18.install.$dead_installer_pid"
 stale_lock_rc=0
 (
 	source_extracted
@@ -306,14 +306,14 @@ stale_lock_rc=0
 ) || stale_lock_rc=$?
 assert_eq "stale lock repair status" "0" "$stale_lock_rc"
 assert_eq "stale lock is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
-assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.16.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
+assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.18.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
 stale_headless_bin=$(<"$SANDBOX/version-stale-lock/headless-bin")
-assert_eq "stale lock path provisions pinned runtime" "1.18.16" "$("$stale_headless_bin")"
+assert_eq "stale lock path provisions pinned runtime" "1.18.18" "$("$stale_headless_bin")"
 
 printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
 mkdir -p "$SANDBOX/version-install-failure/state"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.17\n"'
+printf "1.18.19\n"'
 write_executable "$SANDBOX/version-install-failure/npm" '#!/usr/bin/env bash
 exit 42'
 guard_rc=0


### PR DESCRIPTION
## Summary

Repair the isolated Linux-headless canary, lock its plugin/provider inputs, and promote the verified OpenCode pin to 1.18.18.

## Files Changed

.agents/plugins/opencode-aidevops/package-lock.json, .agents/plugins/opencode-aidevops/package.json, .agents/scripts/opencode-pin-canary.sh, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-opencode-pin-policy.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck; pin-policy and version-guard tests; 639 plugin tests; local linters; Docker Linux/amd64 baseline 1.18.17 and candidate 1.18.18 canary pass.

Resolves #30393


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 51m and 545,128 tokens on this with the user in an interactive session.