### PR TITLE
GH#30435: fix: require worker PR issue linkage

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -1793,6 +1793,82 @@ _create_pr() {
 	return 0
 }
 
+# Verify that a worker-created leaf PR has the same-repository closing reference
+# needed by GitHub's closingIssuesReferences metadata and by pulse's worker
+# merge gate. A partial PR create can leave an otherwise valid PR with an empty
+# body; repair that narrow condition before the issue/PR transition to review.
+# Arguments: PR number, repository slug, expected issue number, generated body.
+_ensure_worker_pr_linkage() {
+	local pr_number="$1"
+	local repo="$2"
+	local issue_number="$3"
+	local generated_body="$4"
+	local current_body=""
+
+	if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ || "$repo" != */* || ! "$issue_number" =~ ^[1-9][0-9]*$ || -z "$generated_body" ]]; then
+		print_error "Cannot validate worker PR linkage: invalid PR, repository, issue, or generated body"
+		return 1
+	fi
+
+	current_body=$(_gh_with_timeout read gh api "repos/${repo}/pulls/${pr_number}" --jq '.body // empty' 2>/dev/null) || {
+		print_error "Cannot validate worker PR #${pr_number} linkage before review transition"
+		return 1
+	}
+
+	local closing_issues=""
+	closing_issues=$(printf '%s' "$current_body" |
+		grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#[0-9]+' |
+		grep -oE '[0-9]+' | sort -u) || closing_issues=""
+	if [[ "$closing_issues" == "$issue_number" ]]; then
+		return 0
+	fi
+
+	# A qualified close reference targets another repository. Do not add a local
+	# reference to an ambiguous body: pulse must remain fail-closed for cross-repo
+	# or multi-issue relationships.
+	if [[ -n "$closing_issues" ]] || printf '%s' "$current_body" | grep -Eiq \
+		'(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+[^[:space:]]+#[0-9]+'; then
+		print_error "Worker PR #${pr_number} has ambiguous or cross-repository closing references; refusing linkage repair"
+		return 1
+	fi
+
+	local repaired_body="$generated_body"
+	if [[ -n "$current_body" ]]; then
+		repaired_body="${current_body}"$'\n\n'"Resolves #${issue_number}"
+	fi
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local repair_body_file=""
+	if ! mkdir -p "$temp_root" || ! repair_body_file=$(mktemp "${temp_root}/aidevops-worker-pr-body.XXXXXX"); then
+		print_error "Could not create worker PR linkage repair body file"
+		return 1
+	fi
+	if ! printf '%s\n' "$repaired_body" >"$repair_body_file"; then
+		rm -f "$repair_body_file"
+		print_error "Could not write worker PR linkage repair body"
+		return 1
+	fi
+	if ! gh_pr_edit_safe "$pr_number" --repo "$repo" --body-file "$repair_body_file" >/dev/null; then
+		rm -f "$repair_body_file"
+		print_error "Failed to repair missing linked issue reference on worker PR #${pr_number}"
+		return 1
+	fi
+	rm -f "$repair_body_file"
+
+	current_body=$(_gh_with_timeout read gh api "repos/${repo}/pulls/${pr_number}" --jq '.body // empty' 2>/dev/null) || {
+		print_error "Could not verify repaired linked issue reference on worker PR #${pr_number}"
+		return 1
+	}
+	closing_issues=$(printf '%s' "$current_body" |
+		grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#[0-9]+' |
+		grep -oE '[0-9]+' | sort -u) || closing_issues=""
+	if [[ "$closing_issues" != "$issue_number" ]]; then
+		print_error "Worker PR #${pr_number} linkage repair did not produce Resolves #${issue_number}"
+		return 1
+	fi
+	print_success "Repaired and verified linked issue reference on worker PR #${pr_number}"
+	return 0
+}
+
 # --- Merge Summary ---
 
 # Post the MERGE_SUMMARY comment on the PR (full-loop step 4.2.1).

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -233,6 +233,13 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 
 	local pr_number=""
 	pr_number=$(_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1
+	# A worker PR is only eligible for the worker-briefed merge path when GitHub
+	# can associate it with the issue that dispatched the worker. Creation should
+	# already preserve this body, but recover from partial GraphQL writes before
+	# marking either side in review.
+	if [[ "$origin_label" == "origin:worker" && "$closing_keyword" == "Resolves" ]]; then
+		_ensure_worker_pr_linkage "$pr_number" "$repo" "$issue_number" "$pr_body" || return 1
+	fi
 
 	_post_merge_summary "$pr_number" "$repo" "$issue_number" "$summary_what" "$files_changed" "$summary_testing" "$summary_decisions" || return 1
 	_label_issue_in_review "$issue_number" "$repo"

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -41,6 +41,8 @@ _HRW_TELEMETRY_DEFERRED="deferred"
 _HRW_STATUS_CHECKPOINTED="checkpointed"
 _HRW_REASON_DRAFT_CHECKPOINT="worker_draft_checkpoint"
 _HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
+_HRW_REASON_READY_MISSING_LINKAGE="worker_ready_missing_linkage"
+_HRW_REASON_READY_LINKAGE_HANDOFF_FAILED="worker_ready_missing_linkage_transition_failed"
 _HRW_REASON_READY_MISSING_SUMMARY="worker_ready_missing_summary"
 _HRW_REASON_READY_HANDOFF_FAILED="worker_ready_missing_summary_transition_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
@@ -538,6 +540,8 @@ _hrw_worker_base_commit_state() {
 #   "closed_unmerged"       — exact-head PR closed without merge
 #   "unverified_open_pr"    — issue-search fallback cannot prove exact head
 #   "head_mismatch"         — local HEAD is not the open PR head
+#   "ready_missing_linkage" — exact-head ready PR lacks a closing issue reference
+#   "merged_missing_linkage" — exact-head merged PR lacks a closing issue reference
 #   "ready_missing_summary" — exact-head ready PR lacks MERGE_SUMMARY
 #   "merged_missing_summary" — exact-head merged PR lacks MERGE_SUMMARY
 #   "noop"                  — no commits, no pushed branch, no PR
@@ -639,7 +643,7 @@ _worker_produced_output() {
 	pr_state="${pr_handoff%%|*}"
 	case "$pr_state" in
 		ready | merged) printf 'pr_exists'; return 0 ;;
-		draft_checkpoint | protected_draft | closed_unmerged | unverified_open_pr | head_mismatch | ready_missing_summary | merged_missing_summary)
+		draft_checkpoint | protected_draft | closed_unmerged | unverified_open_pr | head_mismatch | ready_missing_linkage | merged_missing_linkage | ready_missing_summary | merged_missing_summary)
 			printf '%s' "$pr_state"
 			return 0
 			;;
@@ -1076,7 +1080,8 @@ _recover_worker_output_on_failure() {
 			return 0
 		fi
 		if [[ "$pr_state" == "protected_draft" || "$pr_state" == "unverified_open_pr" || \
-			"$pr_state" == "head_mismatch" || "$pr_state" == "ready_missing_summary" || \
+			"$pr_state" == "head_mismatch" || "$pr_state" == "ready_missing_linkage" || \
+			"$pr_state" == "merged_missing_linkage" || "$pr_state" == "ready_missing_summary" || \
 			"$pr_state" == "merged_missing_summary" ]]; then
 			_HRW_RECOVERY_CLASSIFICATION="worker_${pr_state}"
 			print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — not completion evidence; retaining claim"
@@ -1847,6 +1852,22 @@ _hrw_preserve_ready_missing_summary_handoff() {
 	return 0
 }
 
+_hrw_preserve_ready_missing_linkage_handoff() {
+	local session_key="$1"
+	local output_class="$2"
+	_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class" \
+		"$_HRW_REASON_READY_MISSING_LINKAGE" "$_HRW_REASON_READY_LINKAGE_HANDOFF_FAILED"
+	if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_READY_MISSING_LINKAGE" ]]; then
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
+		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
+		_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_CHECKPOINTED"
+		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_READY_MISSING_LINKAGE"
+	else
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"
+	fi
+	return 0
+}
+
 _hrw_finish_success_run() {
 	local session_key="$1"
 	local work_dir="$2"
@@ -1916,6 +1937,10 @@ _hrw_finish_success_run() {
 			_hrw_preserve_ready_missing_summary_handoff "$session_key" "$output_class"
 			release_needed=0
 			;;
+		ready_missing_linkage)
+			_hrw_preserve_ready_missing_linkage_handoff "$session_key" "$output_class"
+			release_needed=0
+			;;
 		closed_unmerged)
 			print_warning "[lifecycle] ${_HRW_REASON_CLOSED_UNMERGED} session=${session_key} — closed PR is not completion evidence"
 			_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_CLOSED_UNMERGED"
@@ -1923,7 +1948,7 @@ _hrw_finish_success_run() {
 			release_needed=0
 			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_REASON_CLOSED_UNMERGED"
 			;;
-		protected_draft | unverified_open_pr | head_mismatch | merged_missing_summary)
+		protected_draft | unverified_open_pr | head_mismatch | merged_missing_linkage | merged_missing_summary)
 			local noncomplete_reason="worker_${output_class}"
 			print_warning "[lifecycle] ${noncomplete_reason} session=${session_key} — protected/inconclusive PR state is not completion evidence; retaining claim"
 			release_needed=0

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -164,8 +164,8 @@ _release_interactive_claim_on_merge() {
 #
 # Exact-head output states:
 #   ready | merged | closed_unmerged | draft_checkpoint |
-#   protected_draft | head_mismatch | ready_missing_summary |
-#   merged_missing_summary
+#   protected_draft | head_mismatch | ready_missing_linkage |
+#   merged_missing_linkage | ready_missing_summary | merged_missing_summary
 # Issue-search matches are deliberately `unverified_open_pr`: search can return
 # a sibling or stale index hit and therefore proves dedup, never completion.
 # Every state is emitted as "state|PR_NUMBER"; absent/unknown have no number.
@@ -218,6 +218,25 @@ _pr_handoff_has_merge_summary() {
 	[[ "$summary_count" =~ ^[0-9]+$ && "$summary_count" -gt 0 ]]
 }
 
+# Require a same-repository GitHub closing reference before a worker handoff is
+# treated as complete. This deliberately mirrors pulse-merge.sh's narrow body
+# matcher: parent-task For/Ref references and qualified cross-repository closes
+# are not safe evidence that this worker's issue will close.
+_pr_handoff_has_linked_issue() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local issue_number="$3"
+	local pr_body=""
+	local closing_issues=""
+
+	[[ "$repo_slug" == */* && "$pr_number" =~ ^[1-9][0-9]*$ && "$issue_number" =~ ^[1-9][0-9]*$ ]] || return 1
+	pr_body=$(gh api "repos/${repo_slug}/pulls/${pr_number}" --jq '.body // empty' 2>/dev/null) || return 1
+	closing_issues=$(printf '%s' "$pr_body" |
+		grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#[0-9]+' |
+		grep -oE '[0-9]+' | sort -u) || closing_issues=""
+	[[ "$closing_issues" == "$issue_number" ]]
+}
+
 _pr_handoff_state_for_branch_or_issue() {
 	local branch_name="$1"
 	local issue_number="$2"
@@ -248,6 +267,10 @@ _pr_handoff_state_for_branch_or_issue() {
 				if [[ "$require_merge_summary" -eq 1 ]] && \
 					_pr_handoff_state_is_completion_candidate "${pr_state%%|*}"; then
 					local pr_number="${pr_state#*|}"
+					if ! _pr_handoff_has_linked_issue "$repo_slug" "$pr_number" "$issue_number"; then
+						printf '%s_missing_linkage|%s' "${pr_state%%|*}" "$pr_number"
+						return 0
+					fi
 					if ! _pr_handoff_has_merge_summary "$repo_slug" "$pr_number"; then
 						printf '%s_missing_summary|%s' "${pr_state%%|*}" "$pr_number"
 						return 0

--- a/.agents/scripts/tests/test-full-loop-worker-pr-linkage.sh
+++ b/.agents/scripts/tests/test-full-loop-worker-pr-linkage.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#30435: workers must repair a missing generated PR
+# body before the in-review transition, while refusing ambiguous references.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+COMMIT_HELPER="${SCRIPT_DIR}/../full-loop-helper-commit.sh"
+TEST_ROOT="$(mktemp -d -t gh30435.XXXXXX)" || exit 1
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+TESTS_RUN=0
+TESTS_FAILED=0
+REMOTE_BODY=""
+EDIT_CALLS=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: %s\n' "$name" "$detail" >&2
+	return 0
+}
+
+print_error() { return 0; }
+print_success() { return 0; }
+
+_gh_with_timeout() {
+	local operation="$1"
+	shift || return 1
+	"$@"
+	return $?
+}
+
+gh() {
+	if [[ "${1:-}" == "api" ]]; then
+		printf '%s\n' "$REMOTE_BODY"
+		return 0
+	fi
+	return 1
+}
+
+gh_pr_edit_safe() {
+	local pr_number="$1"
+	local body_file=""
+	shift || return 1
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body-file)
+			body_file="${2:-}"
+			shift 2 || return 1
+			;;
+		*) shift ;;
+		esac
+	done
+	[[ "$pr_number" == "77" && -r "$body_file" ]] || return 1
+	REMOTE_BODY=$(<"$body_file")
+	EDIT_CALLS=$((EDIT_CALLS + 1))
+	return 0
+}
+
+eval "$(sed -n '/^_ensure_worker_pr_linkage() {/,/^}/p' "$COMMIT_HELPER")"
+
+test_empty_body_is_repaired() {
+	REMOTE_BODY=""
+	EDIT_CALLS=0
+	if _ensure_worker_pr_linkage 77 owner/repo 42 $'## Summary\n\nImplementation\n\nResolves #42' &&
+		[[ "$REMOTE_BODY" == *"Resolves #42"* && "$EDIT_CALLS" -eq 1 ]]; then
+		pass "empty worker PR body is repaired with generated closing reference"
+	else
+		fail "empty worker PR body is repaired with generated closing reference" "edits=${EDIT_CALLS}; body=${REMOTE_BODY}"
+	fi
+	return 0
+}
+
+test_nonclosing_body_is_preserved_and_repaired() {
+	REMOTE_BODY="## Summary\n\nWorker context survived"
+	EDIT_CALLS=0
+	if _ensure_worker_pr_linkage 77 owner/repo 42 'unused generated body' &&
+		[[ "$REMOTE_BODY" == *"Worker context survived"* && "$REMOTE_BODY" == *"Resolves #42"* && "$EDIT_CALLS" -eq 1 ]]; then
+		pass "nonclosing worker body is preserved while adding local linkage"
+	else
+		fail "nonclosing worker body is preserved while adding local linkage" "edits=${EDIT_CALLS}; body=${REMOTE_BODY}"
+	fi
+	return 0
+}
+
+test_existing_local_reference_is_accepted() {
+	REMOTE_BODY="## Summary\n\nResolves #42"
+	EDIT_CALLS=0
+	if _ensure_worker_pr_linkage 77 owner/repo 42 'unused generated body' && [[ "$EDIT_CALLS" -eq 0 ]]; then
+		pass "existing same-repository closing reference needs no repair"
+	else
+		fail "existing same-repository closing reference needs no repair" "edits=${EDIT_CALLS}"
+	fi
+	return 0
+}
+
+test_ambiguous_reference_fails_closed() {
+	REMOTE_BODY="Resolves #42 and closes #99"
+	EDIT_CALLS=0
+	local rc=0
+	_ensure_worker_pr_linkage 77 owner/repo 42 'unused generated body' || rc=$?
+	if [[ "$rc" -ne 0 && "$EDIT_CALLS" -eq 0 ]]; then
+		pass "multiple closing references fail closed without overwriting body"
+	else
+		fail "multiple closing references fail closed without overwriting body" "rc=${rc}; edits=${EDIT_CALLS}"
+	fi
+	return 0
+}
+
+test_empty_body_is_repaired
+test_nonclosing_body_is_preserved_and_repaired
+test_existing_local_reference_is_accepted
+test_ambiguous_reference_fails_closed
+
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	printf '%s/%s worker PR linkage tests failed\n' "$TESTS_FAILED" "$TESTS_RUN" >&2
+	exit 1
+fi
+printf 'All %s worker PR linkage tests passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -32,6 +32,9 @@ test_post_pr_handoff_detects_open_pending_pr() {
 		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/123/comments"* ]]; then
 			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
+		elif [[ "$args" == *"api repos/"* && "$args" == *"/pulls/123"* ]]; then
+			printf '%s' 'Resolves #99999'
+			return 0
 		fi
 		return 1
 	}
@@ -90,6 +93,9 @@ test_post_pr_handoff_treats_ci_as_monitoring_state() {
 		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/126/comments"* ]]; then
 			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
+		elif [[ "$args" == *"api repos/"* && "$args" == *"/pulls/126"* ]]; then
+			printf '%s' 'Resolves #99999'
+			return 0
 		fi
 		return 1
 	}
@@ -139,6 +145,9 @@ test_post_pr_handoff_rejects_mismatched_head_or_missing_summary() {
 			else
 				printf '%s' '[[]]'
 			fi
+			return 0
+		elif [[ "$args" == *"api repos/"* && "$args" == *"/pulls/125"* ]]; then
+			printf '%s' 'Resolves #99999'
 			return 0
 		fi
 		return 1
@@ -495,6 +504,47 @@ test_ready_missing_summary_preserves_in_review_handoff() {
 	return 0
 }
 
+test_ready_missing_linkage_preserves_in_review_handoff() {
+	local result=""
+	local transition_marker="${TEST_ROOT}/ready-missing-linkage-transition"
+	rm -f "$transition_marker"
+	result=$(
+		(
+			DISPATCH_REPO_SLUG="test-owner/test-repo"
+			_HRW_TERMINAL_OUTCOME="unset"
+			_HRW_FINAL_RUNTIME_EVENT="unset"
+			_HRW_FINAL_RUNTIME_STATUS="unset"
+			_HRW_FINAL_RUNTIME_CLASSIFICATION="unset"
+			_HRW_RECOVERY_CLASSIFICATION=""
+			_worker_produced_output() { printf 'ready_missing_linkage'; return 0; }
+			_hrff_resolve_release_runner_login() { printf 'worker-bot'; return 0; }
+			set_issue_status() { printf '%s\n' "$*" >"$transition_marker"; return 0; }
+			gh() {
+				printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"worker-bot"}]}'
+				return 0
+			}
+			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
+
+			_hrw_finish_success_run "issue-99999" "${TEST_ROOT}"
+			printf 'terminal=%s|event=%s|status=%s|classification=%s\n' \
+				"$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
+				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+		)
+	)
+	local transition=""
+	[[ -f "$transition_marker" ]] && transition=$(<"$transition_marker")
+	if [[ "$transition" == *"99999 test-owner/test-repo in-review"* &&
+		"$result" == *"release=worker_ready_missing_linkage"* &&
+		"$result" == *"terminal=deferred|event=worker.deferred|status=checkpointed|classification=worker_ready_missing_linkage"* &&
+		"$result" != *"release=worker_complete"* ]]; then
+		print_result "ready PR missing linked issue preserves an actionable in-review handoff" 0
+	else
+		print_result "ready PR missing linked issue preserves an actionable in-review handoff" 1 \
+			"result=${result} transition=${transition:-<none>}"
+	fi
+	return 0
+}
+
 test_failed_ci_ready_pr_is_durable_handoff() {
 	local pr_json result
 	pr_json='[{"number":457,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"abc123","labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"name":"tests","conclusion":"FAILURE"},{"name":"tests","conclusion":"SUCCESS"}]}]'
@@ -595,6 +645,9 @@ test_post_pr_handoff_overrides_watchdog_next_action() {
 		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/124/comments"* ]]; then
 			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
+		elif [[ "$args" == *"api repos/"* && "$args" == *"/pulls/124"* ]]; then
+			printf '%s' 'Resolves #99999'
+			return 0
 		fi
 		return 1
 	}
@@ -671,6 +724,7 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_protected_draft_is_not_mutated_or_completed
 	test_checkpoint_terminal_telemetry_is_deferred
 	test_ready_missing_summary_preserves_in_review_handoff
+	test_ready_missing_linkage_preserves_in_review_handoff
 	test_failed_ci_ready_pr_is_durable_handoff
 	test_closed_unmerged_pr_is_failed_not_completed
 	test_failed_worker_ready_pr_remains_completed_handoff

--- a/.agents/scripts/tests/test-headless-runtime-completion-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-completion-tests.sh
@@ -176,6 +176,8 @@ test_worker_produced_output_branch_with_pr_returns_pr_exists() {
 	gh() {
 		if [[ "${*}" == *"api --paginate"* && "${*}" == *"/issues/123/comments"* ]]; then
 			printf '%s\n' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
+		elif [[ "${*}" == *"api repos/"* && "${*}" == *"/pulls/123"* ]]; then
+			printf '%s\n' 'Resolves #99999'
 		else
 			return 1
 		fi

--- a/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
+++ b/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
@@ -177,6 +177,8 @@ case "${1:-}" in
 			else
 				printf '%s\n' '[[]]'
 			fi
+		elif [[ "$*" == *"/pulls/"* ]]; then
+			printf '%s\n' "${STUB_LINKED_BODY:-}"
 		else
 			printf '{}\n'
 		fi
@@ -349,6 +351,7 @@ test_case_ready_and_terminal_states_are_preserved() {
 test_case_ready_requires_exact_head_and_merge_summary() {
 	export STUB_HEAD_JSON='[{"number":331,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"remote-head","labels":[],"statusCheckRollup":[]}]'
 	export STUB_SEARCH_JSON='[]'
+	export STUB_LINKED_BODY='Resolves #27501'
 	export STUB_SUMMARY_COUNT=1
 	local got
 	got=$(_pr_handoff_state_for_branch_or_issue "feature/exact" "27501" "owner/repo" \
@@ -377,12 +380,31 @@ test_case_ready_requires_exact_head_and_merge_summary() {
 		print_result "ready handoff accepts exact head with MERGE_SUMMARY" 1 "got: '$got'"
 	fi
 	unset STUB_SUMMARY_COUNT
+	unset STUB_LINKED_BODY
+	return 0
+}
+
+test_case_ready_requires_same_repo_linkage() {
+	export STUB_HEAD_JSON='[{"number":333,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"remote-head","labels":[],"statusCheckRollup":[]}]'
+	export STUB_SEARCH_JSON='[]'
+	export STUB_SUMMARY_COUNT=1
+	export STUB_LINKED_BODY='## Summary\n\nNo closing reference survived creation.'
+	local got
+	got=$(_pr_handoff_state_for_branch_or_issue "feature/exact" "27501" "owner/repo" \
+		"head-only" "remote-head" 1)
+	if [[ "$got" == "ready_missing_linkage|333" ]]; then
+		print_result "ready handoff requires a same-repository closing reference" 0
+	else
+		print_result "ready handoff requires a same-repository closing reference" 1 "got: '$got'"
+	fi
+	unset STUB_SUMMARY_COUNT STUB_LINKED_BODY
 	return 0
 }
 
 test_case_merged_requires_exact_head_and_merge_summary() {
 	export STUB_HEAD_JSON='[{"number":332,"state":"MERGED","isDraft":false,"mergedAt":"2026-07-13T00:00:00Z","headRefOid":"merged-head","labels":[],"statusCheckRollup":[]}]'
 	export STUB_SEARCH_JSON='[]'
+	export STUB_LINKED_BODY='Resolves #27501'
 	export STUB_SUMMARY_COUNT=1
 	local got
 	got=$(_pr_handoff_state_for_branch_or_issue "feature/merged" "27501" "owner/repo" \
@@ -402,6 +424,7 @@ test_case_merged_requires_exact_head_and_merge_summary() {
 		print_result "merged handoff requires canonical MERGE_SUMMARY" 1 "got: '$got'"
 	fi
 	unset STUB_SUMMARY_COUNT
+	unset STUB_LINKED_BODY
 	return 0
 }
 
@@ -546,6 +569,7 @@ test_case_d3_failed_head_probe_is_unknown
 test_case_draft_state_is_preserved
 test_case_ready_and_terminal_states_are_preserved
 test_case_ready_requires_exact_head_and_merge_summary
+test_case_ready_requires_same_repo_linkage
 test_case_merged_requires_exact_head_and_merge_summary
 test_case_head_only_does_not_capture_unrelated_issue_draft
 test_case_active_pr_wins_over_historical_pr


### PR DESCRIPTION
## Summary

Repair missing worker PR closing references and fail closed before in-review handoff when linkage is absent or ambiguous.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/shared-claim-lifecycle.sh, .agents/scripts/tests/test-full-loop-worker-pr-linkage.sh, .agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh, .agents/scripts/tests/test-headless-runtime-completion-tests.sh, .agents/scripts/tests/test-worker-output-classification-head-vs-search.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-full-loop-worker-pr-linkage.sh; bash .agents/scripts/tests/test-worker-output-classification-head-vs-search.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh; ShellCheck clean

Resolves #30435


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 10m and 220,226 tokens on this as a headless worker.