### PR TITLE
GH#30441: add bounded automatic observability retention

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs
@@ -24,6 +24,7 @@ import {
 import {
   archiveRuntimeEvents,
   isProtectedRuntimeEvent,
+  maintainRuntimeEvents,
   runtimeEventRetentionInventory,
   verifyRuntimeEventArchive,
 } from "../../../scripts/runtime-events-retention.mjs";
@@ -220,6 +221,92 @@ test("synthetic high-volume cycles converge in the active partition", {
     }
     assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 3);
     assert.equal(runtimeEventRetentionInventory({ archiveDir, cutoff: CUTOFF, dbPath }).candidate_bytes, 0);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("bounded producer maintenance catches up across scheduled runs", {
+  skip: !sqliteAvailable() && "sqlite3 is unavailable",
+}, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-runtime-maintenance-"));
+  const dbPath = join(tempDir, "observability.db");
+  const archiveDir = join(tempDir, "archives");
+  try {
+    assert.equal(initialiseRuntimeEventStore(dbPath), true);
+    for (let index = 0; index < 125; index++) appendFixture(5000 + index);
+
+    const dryRun = maintainRuntimeEvents({
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxPartitions: 2,
+      maxRows: 50,
+    });
+    assert.equal(dryRun.status, "maintenance_dry_run");
+    assert.equal(dryRun.candidate_rows, 50);
+    assert.equal(dryRun.more_candidates, true);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 125);
+
+    const clockValues = [0, 0, 1001];
+    const durationBounded = maintainRuntimeEvents({
+      apply: true,
+      archiveDir,
+      clock: () => clockValues.shift() ?? 1001,
+      cutoff: CUTOFF,
+      dbPath,
+      maxDurationSeconds: 1,
+      maxPartitions: 20,
+      maxRows: 50,
+    });
+    assert.equal(durationBounded.status, "maintained");
+    assert.equal(durationBounded.stop_reason, "max_duration");
+    assert.equal(durationBounded.partitions_archived, 1);
+    assert.equal(durationBounded.source_rows_archived, 50);
+    assert.equal(durationBounded.backlog_remaining, true);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 75);
+
+    const bounded = maintainRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxPartitions: 1,
+      maxRows: 50,
+    });
+    assert.equal(bounded.status, "maintained");
+    assert.equal(bounded.stop_reason, "max_partitions");
+    assert.equal(bounded.partitions_archived, 1);
+    assert.equal(bounded.source_rows_archived, 50);
+    assert.equal(bounded.backlog_remaining, true);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 25);
+
+    const converged = maintainRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxPartitions: 2,
+      maxRows: 50,
+    });
+    assert.equal(converged.stop_reason, "no_candidates");
+    assert.equal(converged.partitions_archived, 1);
+    assert.equal(converged.source_rows_archived, 25);
+    assert.equal(converged.backlog_remaining, false);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 0);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 3);
+
+    const noOp = maintainRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxPartitions: 2,
+      maxRows: 50,
+    });
+    assert.equal(noOp.status, "no_candidates");
+    assert.equal(noOp.partitions_archived, 0);
+    assert.equal(noOp.backlog_remaining, false);
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -105,7 +105,13 @@ transaction rechecks the exact source range, temporarily suspends only the
 delete guard, restores it, and appends an immutable `runtime_event_archives`
 manifest row. A failed/corrupt archive leaves source rows intact. Interruption
 after file verification is resumable and reuses the verified partition.
-Archive deletion is not automatic.
+
+Core routine `r918` runs producer-owned maintenance daily through the shared
+Pulse scheduler. It repeatedly applies the same verified partition primitive
+until the backlog is clear or the default 20-partition/120-second run bound is
+reached; any residual backlog is reported and left for the next run. It does
+not install a dedicated launchd plist or systemd unit. The one-partition
+`retention` command remains explicit and dry-run-first.
 
 ```bash
 # Physical and classified bytes; never prints raw payloads
@@ -116,6 +122,9 @@ observability-helper.sh retention --dry-run
 
 # Explicit maintenance after reviewing the dry run
 observability-helper.sh retention --apply --max-rows 5000
+
+# Bounded catch-up used by shared-Pulse routine r918
+observability-helper.sh retention-maintenance --apply --max-partitions 20 --max-duration-seconds 120
 ```
 
 The shared storage inventory reports active, archive, protected, reclaimable,

--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -650,21 +650,29 @@ cmd_runtime_events() {
 	return 0
 }
 
-cmd_storage() {
+require_node() {
 	command -v node &>/dev/null || {
 		print_error "node required"
 		return 1
 	}
+	return 0
+}
+
+cmd_storage() {
+	require_node || return 1
 	node "$RUNTIME_EVENTS_RETENTION" inventory --db "${OBS_DIR}/llm-requests.db" "$@"
 	return $?
 }
 
 cmd_retention() {
-	command -v node &>/dev/null || {
-		print_error "node required"
-		return 1
-	}
+	require_node || return 1
 	node "$RUNTIME_EVENTS_RETENTION" archive --db "${OBS_DIR}/llm-requests.db" "$@"
+	return $?
+}
+
+cmd_retention_maintenance() {
+	require_node || return 1
+	node "$RUNTIME_EVENTS_RETENTION" maintain --db "${OBS_DIR}/llm-requests.db" "$@"
 	return $?
 }
 
@@ -673,7 +681,8 @@ cmd_help() {
 Observability Helper — LLM request and runtime-event evidence
 Usage: observability-helper.sh [command] [options]
 Commands: ingest | record (--model X) | rate-limits | cache-health | runtime-events [limit]
-          storage [--json] | retention [--dry-run|--apply] [--before ISO] [--max-rows N] | help
+          storage [--json] | retention [--dry-run|--apply] [--before ISO] [--max-rows N]
+          retention-maintenance [--dry-run|--apply] [--max-partitions N] [--max-duration-seconds N] | help
 
 Record options:
   --model MODEL          Model name (required)
@@ -698,7 +707,7 @@ main() {
 	local command="${1:-help}"
 	shift || true
 	case "$command" in
-	storage | retention) ;;
+	storage | storage-inventory | retention | archive | retention-maintenance | maintain-retention) ;;
 	*)
 		init_log_file
 		init_storage || return 1
@@ -711,6 +720,7 @@ main() {
 	runtime-events | runtime_events | events) cmd_runtime_events "$@" ;;
 	storage | storage-inventory) cmd_storage "$@" ;;
 	retention | archive) cmd_retention "$@" ;;
+	retention-maintenance | maintain-retention) cmd_retention_maintenance "$@" ;;
 	help | --help | -h) cmd_help ;; *)
 		print_error "Unknown: $command"
 		cmd_help

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -33,6 +33,7 @@ r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:d
 r915|x|Pulse check — worker utilisation and self-improvement recommendations|repeat:daily(@06:20)|~5m|scripts/pulse-check-helper.sh apply|script
 r916|x|Cloudron packages — check upstream releases|repeat:daily(@01:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC
 r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script
+r918|x|Observability retention — archive bounded runtime evidence|repeat:daily(@03:10)|~2m|scripts/observability-helper.sh retention-maintenance --apply --max-partitions 20 --max-duration-seconds 120|script
 ENTRIES
 	return 0
 }
@@ -139,7 +140,7 @@ EOF
 EOF
 	fi
 	cat <<'EOF'
-- `jq '.r916, .r917' ~/.aidevops/.agent-workspace/pulse/routine-state.json` — last-run state
+- `jq '.r916, .r917, .r918' ~/.aidevops/.agent-workspace/pulse/routine-state.json` — last-run state
 - `aidevops status` — framework and supervisor overview
 EOF
 	return 0
@@ -981,6 +982,46 @@ the version-controlled \`repeat:\` expression; r917 has no dedicated platform un
 - Audits local package files without building or executing upstream content.
 - Creates issues only after target-local deduplication and authority checks.
 - Never acknowledges a finding when GitHub/API operations fail.
+$(_pulse_diag_commands "$os")
+$(_platform_footnote "$os")
+EOF
+	return 0
+}
+
+describe_r918() {
+	local os="${1:-}"
+	[[ -n "$os" ]] || os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	cat <<EOF
+# r918: Observability retention
+
+## Overview
+
+Daily producer-owned maintenance for the append-only runtime-event store. It
+archives old rows through the existing verified partition transaction until
+the candidate backlog is clear or an explicit work bound is reached.
+
+## Schedule
+
+| Field | Value |
+|-------|-------|
+| Frequency | Daily at 03:10 |
+| Type | script |
+| Expected duration | ~2 minutes |
+| Script | \`scripts/observability-helper.sh retention-maintenance --apply --max-partitions 20 --max-duration-seconds 120\` |
+$(_scheduler_row_pulse "repeat:daily(@03:10)")
+
+Pulse reads the enabled routine from registered \`TODO.md\` files; r918 has no
+dedicated launchd plist or systemd unit.
+
+## Safety rails
+
+- Each partition is bounded, immutable, checksum-verified, and committed only
+  after the exact source range is rechecked in one immediate transaction.
+- Protected lifecycle, terminal, error, permission, security, audit, release,
+  deploy, and subagent evidence remains preserved verbatim in the archive.
+- A run stops after 20 partitions or 120 seconds and reports whether backlog
+  remains for the next scheduled run.
+- Missing stores and empty candidate sets are successful no-ops.
 $(_pulse_diag_commands "$os")
 $(_platform_footnote "$os")
 EOF

--- a/.agents/scripts/runtime-events-retention-cli.mjs
+++ b/.agents/scripts/runtime-events-retention-cli.mjs
@@ -6,6 +6,8 @@ const VALUE_OPTION_KEYS = new Map([
   ["--archive-dir", "archiveDir"],
   ["--before", "cutoff"],
   ["--db", "dbPath"],
+  ["--max-duration-seconds", "maxDurationSeconds"],
+  ["--max-partitions", "maxPartitions"],
   ["--max-rows", "maxRows"],
 ]);
 
@@ -32,7 +34,7 @@ export function runRetentionCommand(argv, actions) {
   try {
     const { command, options } = parseCli(argv);
     const action = actions[command];
-    if (typeof action !== "function") throw new TypeError("command must be inventory or archive");
+    if (typeof action !== "function") throw new TypeError("command must be inventory, archive, or maintain");
     process.stdout.write(`${JSON.stringify(action(options))}\n`);
     return 0;
   } catch (error) {

--- a/.agents/scripts/runtime-events-retention-maintenance.mjs
+++ b/.agents/scripts/runtime-events-retention-maintenance.mjs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/** Bounded orchestration around the verified runtime-event partition primitive. */
+
+function normalizedBound(value, defaultValue, maximum, label) {
+  const parsed = Number.parseInt(String(value ?? defaultValue), 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new TypeError(`${label} must be an integer from 1 to ${maximum}`);
+  }
+  return parsed;
+}
+
+function maintenanceConfig(options, dependencies) {
+  const maxPartitions = normalizedBound(
+    options.maxPartitions,
+    dependencies.maxPartitionsDefault,
+    1000,
+    "maintenance max partitions",
+  );
+  const maxDurationSeconds = normalizedBound(
+    options.maxDurationSeconds,
+    dependencies.maxDurationSecondsDefault,
+    3600,
+    "maintenance max duration seconds",
+  );
+  const clock = typeof options.clock === "function" ? options.clock : Date.now;
+  const cutoff = dependencies.normalizeCutoff(options.cutoff, options);
+  const archiveOptions = { ...options, cutoff };
+  delete archiveOptions.clock;
+  delete archiveOptions.maxDurationSeconds;
+  delete archiveOptions.maxPartitions;
+  return { archiveOptions, clock, maxDurationSeconds, maxPartitions };
+}
+
+function planMaintenance(config, archive) {
+  const planned = archive({ ...config.archiveOptions, apply: false });
+  return Object.freeze({
+    ...planned,
+    max_duration_seconds: config.maxDurationSeconds,
+    max_partitions: config.maxPartitions,
+    status: planned.status === "dry_run" ? "maintenance_dry_run" : planned.status,
+  });
+}
+
+function newTotals() {
+  return {
+    archive_bytes: 0,
+    compacted_rows: 0,
+    partition_ids: [],
+    partitions_archived: 0,
+    protected_rows: 0,
+    source_bytes_archived: 0,
+    source_rows_archived: 0,
+  };
+}
+
+function accumulatePartition(totals, result) {
+  totals.archive_bytes += Number(result.archive_bytes || 0);
+  totals.compacted_rows += Number(result.compacted_rows || 0);
+  totals.partition_ids.push(result.partition_id);
+  totals.partitions_archived += 1;
+  totals.protected_rows += Number(result.protected_rows || 0);
+  totals.source_bytes_archived += Number(result.candidate_bytes || 0);
+  totals.source_rows_archived += Number(result.candidate_rows || 0);
+}
+
+function maintenanceSummary(totals, config, stopReason, lastResult) {
+  const backlogRemaining = stopReason === "max_duration" ||
+    (stopReason === "max_partitions" && Boolean(lastResult?.more_candidates));
+  const status = totals.partitions_archived > 0
+    ? "maintained"
+    : (lastResult?.status || stopReason);
+  return Object.freeze({
+    ...totals,
+    applied: totals.partitions_archived > 0,
+    backlog_remaining: backlogRemaining,
+    max_duration_seconds: config.maxDurationSeconds,
+    max_partitions: config.maxPartitions,
+    status,
+    stop_reason: stopReason,
+  });
+}
+
+function applyMaintenance(config, archive) {
+  const startedAt = config.clock();
+  const totals = newTotals();
+  let lastResult;
+  let stopReason = "max_partitions";
+
+  while (totals.partitions_archived < config.maxPartitions) {
+    if ((config.clock() - startedAt) >= config.maxDurationSeconds * 1000) {
+      stopReason = "max_duration";
+      break;
+    }
+    const result = archive({ ...config.archiveOptions, apply: true });
+    lastResult = result;
+    if (result.status === "database_missing" || result.status === "no_candidates") {
+      stopReason = result.status;
+      break;
+    }
+    if (!result.applied || result.status !== "archived") {
+      throw new Error(`unexpected runtime-event archive result: ${result.status}`);
+    }
+    accumulatePartition(totals, result);
+    if (!result.more_candidates) {
+      stopReason = "no_candidates";
+      break;
+    }
+  }
+  return maintenanceSummary(totals, config, stopReason, lastResult);
+}
+
+export function runRuntimeEventMaintenance(options, dependencies) {
+  const config = maintenanceConfig(options, dependencies);
+  return options.apply
+    ? applyMaintenance(config, dependencies.archive)
+    : planMaintenance(config, dependencies.archive);
+}

--- a/.agents/scripts/runtime-events-retention.mjs
+++ b/.agents/scripts/runtime-events-retention.mjs
@@ -25,12 +25,15 @@ import {
 } from "./runtime-events-store.mjs";
 import { runRetentionCommand } from "./runtime-events-retention-cli.mjs";
 import { buildRuntimeEventRetentionInventory } from "./runtime-events-retention-inventory.mjs";
+import { runRuntimeEventMaintenance } from "./runtime-events-retention-maintenance.mjs";
 import { verifyArchiveArtifacts } from "./runtime-events-retention-verification.mjs";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
 export const RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION = 1;
 export const RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT = 30;
 export const RUNTIME_EVENT_ARCHIVE_MAX_ROWS_DEFAULT = 5000;
+export const RUNTIME_EVENT_MAINTENANCE_MAX_PARTITIONS_DEFAULT = 20;
+export const RUNTIME_EVENT_MAINTENANCE_MAX_DURATION_SECONDS_DEFAULT = 120;
 
 const ERROR_STATUS = new Set([
   "blocked", "cancelled", "denied", "error", "failed", "rejected", "timed_out", "timeout",
@@ -326,14 +329,28 @@ export function archiveRuntimeEvents(options = {}) {
   const cutoffAt = normalizedCutoff(options.cutoff, options);
   const maxRows = normalizedMaxRows(options.maxRows);
   if (!existsSync(dbPath)) {
-    return Object.freeze({ applied: false, candidate_bytes: 0, candidate_rows: 0, status: "database_missing" });
+    return Object.freeze({
+      applied: false,
+      candidate_bytes: 0,
+      candidate_rows: 0,
+      more_candidates: false,
+      status: "database_missing",
+    });
   }
   if (options.apply && !initialiseRuntimeEventStore(dbPath)) {
     throw new Error("runtime-event store is unavailable");
   }
-  const rows = candidateRows(dbPath, cutoffAt, maxRows, { readonly: !options.apply });
+  const selectedRows = candidateRows(dbPath, cutoffAt, maxRows + 1, { readonly: !options.apply });
+  const moreCandidates = selectedRows.length > maxRows;
+  const rows = selectedRows.slice(0, maxRows);
   if (rows.length === 0) {
-    return Object.freeze({ applied: false, candidate_bytes: 0, candidate_rows: 0, status: "no_candidates" });
+    return Object.freeze({
+      applied: false,
+      candidate_bytes: 0,
+      candidate_rows: 0,
+      more_candidates: false,
+      status: "no_candidates",
+    });
   }
   const partition = buildPartition(rows, cutoffAt, options.createdAt);
   const result = {
@@ -341,6 +358,7 @@ export function archiveRuntimeEvents(options = {}) {
     candidate_bytes: partition.header.source_logical_bytes,
     candidate_rows: partition.header.source_row_count,
     compacted_rows: partition.header.compacted_row_count,
+    more_candidates: moreCandidates,
     partition_id: partition.header.partition_id,
     protected_rows: partition.header.protected_row_count,
     status: options.apply ? "prepared" : "dry_run",
@@ -358,6 +376,16 @@ export function archiveRuntimeEvents(options = {}) {
     archive_bytes: persisted.manifest.archive_bytes,
     archive_file: persisted.manifest.archive_file,
     status: "archived",
+  });
+}
+
+/** Apply verified partitions until caught up or an explicit work bound is reached. */
+export function maintainRuntimeEvents(options = {}) {
+  return runRuntimeEventMaintenance(options, {
+    archive: archiveRuntimeEvents,
+    maxDurationSecondsDefault: RUNTIME_EVENT_MAINTENANCE_MAX_DURATION_SECONDS_DEFAULT,
+    maxPartitionsDefault: RUNTIME_EVENT_MAINTENANCE_MAX_PARTITIONS_DEFAULT,
+    normalizeCutoff: normalizedCutoff,
   });
 }
 
@@ -379,6 +407,7 @@ export function runRetentionCli(argv = process.argv.slice(2)) {
   return runRetentionCommand(argv, {
     archive: archiveRuntimeEvents,
     inventory: runtimeEventRetentionInventory,
+    maintain: maintainRuntimeEvents,
   });
 }
 

--- a/.agents/scripts/tests/test-pulse-routines-selector.sh
+++ b/.agents/scripts/tests/test-pulse-routines-selector.sh
@@ -399,6 +399,8 @@ _test_generated_routines_repository_contract() {
 	ids=$(_collect_routine_ids "${fixture_dir}/TODO.md")
 	if [[ $'\n'"$ids"$'\n' == *$'\nr916\n'* ]] &&
 		[[ $'\n'"$ids"$'\n' == *$'\nr917\n'* ]] &&
+		[[ $'\n'"$ids"$'\n' == *$'\nr918\n'* ]] &&
+		grep -Fqx -- '- [x] r918 Observability retention — archive bounded runtime evidence repeat:daily(@03:10) ~2m run:scripts/observability-helper.sh retention-maintenance --apply --max-partitions 20 --max-duration-seconds 120' "${fixture_dir}/TODO.md" &&
 		[[ $'\n'"$ids"$'\n' == *$'\nr-user-contract\n'* ]] &&
 		[[ $'\n'"$ids"$'\n' != *$'\nr-task-lookalike\n'* ]]; then
 		pass "Case 10 (GH#28957): generated repository exposes core and user routines only"


### PR DESCRIPTION
## Summary

Add producer-owned catch-up retention that repeatedly applies the existing verified archive transaction within partition and duration bounds, then register it as shared-Pulse routine r918.

## Files Changed

- `.agents/scripts/runtime-events-retention.mjs`
- `.agents/scripts/runtime-events-retention-maintenance.mjs`
- `.agents/scripts/runtime-events-retention-cli.mjs`
- `.agents/scripts/observability-helper.sh`
- `.agents/scripts/routines/core-routines.sh`
- `.agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs`
- `.agents/scripts/tests/test-pulse-routines-selector.sh`
- `.agents/reference/observability.md`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — `node --test .agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs`; `bash .agents/scripts/tests/test-pulse-routines-selector.sh`; `.agents/scripts/linters-local.sh`; `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD`; missing-store CLI smoke test

## Decisions

Reuse the immutable verified partition primitive, hold one cutoff across a run, report residual backlog, split orchestration into a focused module, and use the shared Pulse scheduler instead of a dedicated platform timer.

Resolves #30441

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 21m and 700,167 tokens on this with the user in an interactive session.