### PR TITLE
GH#30443: preserve bounded recovery retention on sizing timeout

### DIFF
--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -918,6 +918,169 @@ test_automatic_maintenance_is_bounded_and_policy_bound() {
 	return 0
 }
 
+test_automatic_maintenance_checks_capacity_before_aggregate_size() {
+	local home_path="${TEST_DIR}/automatic-capacity-first-home"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local state_dir="${home_path}/maintenance-state"
+	local archive_path="" bucket_path="" output="" receipt_path=""
+	local rc=0
+
+	mkdir -p "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "${TEST_DIR}/automatic-capacity-first-repo" \
+		"${TEST_DIR}/automatic-capacity-first-worktree" "$recovery_root" \
+		"bugfix/gh30443-capacity-first") || rc=1
+	bucket_path="${archive_path%/*}"
+	install_clear_evidence_stubs
+	output=$(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		aidevops_disk_capacity_snapshot() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			AIDEVOPS_DISK_CAPACITY_TOTAL_KB=100000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=1
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=0
+			return 0
+		}
+		_worktree_recovery_maintenance_measure_store() {
+			return 1
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=0 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_RETENTION_DAYS=3650 \
+			worktree_recovery_maintenance_run
+	) || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "removed" ]] || rc=1
+	receipt_path=$(printf '%s\n' "$output" | jq -r '.receipt') || rc=1
+	jq -e '
+		.automatic_policy.pressure_active == true and
+		.automatic_policy.pressure_reason == "filesystem-free-kb-soft-limit" and
+		.automatic_policy.store_bytes == null and
+		.entries[0].maintenance.selected_reason == "pressure"
+	' "$receipt_path" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" ]] || rc=1
+	print_result "automatic_maintenance_checks_capacity_before_aggregate_size" "$rc" \
+		"Expected known low capacity to bypass aggregate sizing and retain exact candidate checks"
+	return 0
+}
+
+test_automatic_maintenance_keeps_age_retention_when_aggregate_size_times_out() {
+	local home_path="${TEST_DIR}/automatic-age-fallback-home"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local state_dir="${home_path}/maintenance-state"
+	local archive_path="" bucket_path="" output="" receipt_path=""
+	local rc=0
+
+	mkdir -p "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "${TEST_DIR}/automatic-age-fallback-repo" \
+		"${TEST_DIR}/automatic-age-fallback-worktree" "$recovery_root" \
+		"bugfix/gh30443-age-fallback") || rc=1
+	bucket_path="${archive_path%/*}"
+	install_clear_evidence_stubs
+	output=$(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		aidevops_disk_capacity_snapshot() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			AIDEVOPS_DISK_CAPACITY_TOTAL_KB=100000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=90000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=90
+			return 0
+		}
+		_worktree_recovery_maintenance_measure_store() {
+			local ignored_root="$1"
+			local aggregate_timeout="$2"
+			: "$ignored_root"
+			[[ "$aggregate_timeout" == "73" ]] || return 1
+			printf 'null|unavailable|sizing-timeout'
+			return 0
+		}
+		_worktree_recovery_maintenance_age_seconds() {
+			local ignored_entry="$1"
+			: "$ignored_entry"
+			printf '691200\n'
+			return 0
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
+			AIDEVOPS_WORKTREE_RECOVERY_AGGREGATE_SIZE_TIMEOUT_TENTHS=73 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_RETENTION_DAYS=7 \
+			worktree_recovery_maintenance_run
+	) || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "removed" ]] || rc=1
+	receipt_path=$(printf '%s\n' "$output" | jq -r '.receipt') || rc=1
+	jq -e '
+		.automatic_policy.pressure_active == false and
+		.automatic_policy.pressure_reason == "aggregate-size-unavailable" and
+		.automatic_policy.store_bytes == null and
+		.entries[0].maintenance.selected_reason == "retention"
+	' "$receipt_path" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" ]] || rc=1
+	print_result "automatic_maintenance_keeps_age_retention_when_aggregate_size_times_out" "$rc" \
+		"Expected healthy capacity and unavailable aggregate size to preserve bounded age retention"
+	return 0
+}
+
+test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable() {
+	local home_path="${TEST_DIR}/automatic-bucket-timeout-home"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local state_dir="${home_path}/maintenance-state"
+	local archive_path="" bucket_path="" output=""
+	local rc=0
+
+	mkdir -p "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "${TEST_DIR}/automatic-bucket-timeout-repo" \
+		"${TEST_DIR}/automatic-bucket-timeout-worktree" "$recovery_root" \
+		"bugfix/gh30443-bucket-timeout") || rc=1
+	bucket_path="${archive_path%/*}"
+	install_clear_evidence_stubs
+	output=$(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		aidevops_disk_capacity_snapshot() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			AIDEVOPS_DISK_CAPACITY_TOTAL_KB=100000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=90000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=90
+			return 0
+		}
+		_worktree_recovery_maintenance_measure_store() {
+			local ignored_root="$1"
+			local ignored_timeout="$2"
+			: "$ignored_root" "$ignored_timeout"
+			printf '1024|exact|'
+			return 0
+		}
+		_worktree_recovery_measure_path() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			printf 'null|unavailable|sizing-timeout'
+			return 0
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_RETENTION_DAYS=1 \
+			worktree_recovery_maintenance_run
+	) || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "no-candidates" ]] || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.policy.unknown_count')" == "1" ]] || rc=1
+	[[ -d "$bucket_path" ]] || rc=1
+	print_result "automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable" "$rc" \
+		"Expected per-bucket sizing uncertainty to remain non-destructive"
+	return 0
+}
+
 test_automatic_maintenance_resumes_interrupted_apply() {
 	local home_path="${TEST_DIR}/automatic-resume-home"
 	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
@@ -1099,6 +1262,9 @@ test_receipt_publication_owns_only_reserved_temp
 test_shared_producer_lock_fails_closed_and_reclaims_stale
 test_apply_handles_attributable_legacy_root_transaction
 test_automatic_maintenance_is_bounded_and_policy_bound
+test_automatic_maintenance_checks_capacity_before_aggregate_size
+test_automatic_maintenance_keeps_age_retention_when_aggregate_size_times_out
+test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable
 test_automatic_maintenance_resumes_interrupted_apply
 test_automatic_maintenance_rejects_symlink_cursor
 test_large_plan_avoids_json_argv_limits

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -171,6 +171,9 @@ _worktree_recovery_apply_validate_automatic_plan_shape() {
 	local placeholder="apply-sha256:0000000000000000000000000000000000000000000000000000000000000000"
 	local selected_retention="retention"
 	local selected_pressure="pressure"
+	local reason_aggregate_unavailable="aggregate-size-unavailable"
+	local reason_filesystem_kb="filesystem-free-kb-soft-limit"
+	local reason_filesystem_percent="filesystem-free-percent-soft-limit"
 
 	manual_shape=$(printf '%s\n' "$plan_json" | jq -c --arg placeholder "$placeholder" \
 		'.confirmation_token = $placeholder') || return 1
@@ -182,7 +185,10 @@ _worktree_recovery_apply_validate_automatic_plan_shape() {
 		--arg number_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER" \
 		--arg object_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT" \
 		--arg selected_retention "$selected_retention" \
-		--arg selected_pressure "$selected_pressure" '
+		--arg selected_pressure "$selected_pressure" \
+		--arg reason_aggregate_unavailable "$reason_aggregate_unavailable" \
+		--arg reason_filesystem_kb "$reason_filesystem_kb" \
+		--arg reason_filesystem_percent "$reason_filesystem_percent" '
 		.automatic_policy as $policy |
 		($policy | type == $object_type) and
 		($policy | keys | sort) == (["available_kb","available_percent","max_bytes",
@@ -193,10 +199,15 @@ _worktree_recovery_apply_validate_automatic_plan_shape() {
 		$policy.schema == $policy_schema and $policy.policy_id == $policy_id and
 		([ $policy.retention_days,$policy.max_scan,$policy.max_candidates,$policy.max_bytes,
 			$policy.max_store_bytes,$policy.pressure_min_free_kb,
-			$policy.pressure_min_free_percent,$policy.store_bytes,$policy.available_kb,
+			$policy.pressure_min_free_percent,$policy.available_kb,
 			$policy.available_percent,$policy.scanned_count,$policy.protected_count,
 			$policy.unknown_count ] |
 			all(type == $number_type and . >= 0 and . == floor)) and
+		(($policy.store_bytes | type == $number_type and . >= 0 and . == floor) or
+			($policy.store_bytes == null and
+				(if $policy.pressure_active
+				then $policy.pressure_reason | IN($reason_filesystem_kb,$reason_filesystem_percent)
+				else $policy.pressure_reason == $reason_aggregate_unavailable end))) and
 		$policy.retention_days > 0 and $policy.max_scan > 0 and
 		$policy.max_candidates > 0 and $policy.max_bytes > 0 and
 		$policy.max_store_bytes > 0 and $policy.pressure_min_free_percent <= 100 and

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -34,7 +34,7 @@ fi
 _worktree_recovery_measure_path() {
 	local path="$1"
 	local du_command="${AIDEVOPS_WORKTREE_RECOVERY_DU_COMMAND:-${AIDEVOPS_STORAGE_DU_COMMAND:-du}}"
-	local timeout_tenths="${AIDEVOPS_WORKTREE_RECOVERY_SIZE_TIMEOUT_TENTHS:-${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}}"
+	local timeout_tenths="${2:-${AIDEVOPS_WORKTREE_RECOVERY_SIZE_TIMEOUT_TENTHS:-${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}}}"
 	local output_file=""
 	local pid=""
 	local elapsed=0

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -130,30 +130,50 @@ PY
 	return $?
 }
 
+_worktree_recovery_maintenance_measure_store() {
+	local recovery_root="$1"
+	local timeout_tenths="$2"
+
+	_worktree_recovery_measure_path "$recovery_root" "$timeout_tenths"
+	return $?
+}
+
 _worktree_recovery_maintenance_pressure_json() {
 	local recovery_root="$1"
 	local max_store_bytes="$2"
 	local minimum_free_kb="$3"
 	local minimum_free_percent="$4"
+	local aggregate_timeout_tenths="$5"
 	local measured=""
-	local store_bytes=""
-	local confidence=""
+	local store_bytes="$WORKTREE_RECOVERY_PLAN_JSON_NULL"
+	local confidence="$WORKTREE_RECOVERY_UNAVAILABLE"
+	local ignored=""
 	local pressure=false
 	local reason="none"
 
-	measured=$(_worktree_recovery_measure_path "$recovery_root") || return 1
-	IFS='|' read -r store_bytes confidence _ <<<"$measured"
-	[[ "$confidence" == "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" && "$store_bytes" =~ ^[0-9]+$ ]] || return 1
 	aidevops_disk_capacity_snapshot "$recovery_root" || return 1
-	if [[ "$store_bytes" -gt "$max_store_bytes" ]]; then
-		pressure=true
-		reason="store-soft-limit"
-	elif [[ "$AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB" -lt "$minimum_free_kb" ]]; then
+	if [[ "$AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB" -lt "$minimum_free_kb" ]]; then
 		pressure=true
 		reason="filesystem-free-kb-soft-limit"
 	elif [[ $((AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB * 100)) -lt $((AIDEVOPS_DISK_CAPACITY_TOTAL_KB * minimum_free_percent)) ]]; then
 		pressure=true
 		reason="filesystem-free-percent-soft-limit"
+	fi
+	if [[ "$pressure" == "true" ]]; then
+		store_bytes="$WORKTREE_RECOVERY_PLAN_JSON_NULL"
+	else
+		measured=$(_worktree_recovery_maintenance_measure_store "$recovery_root" \
+			"$aggregate_timeout_tenths") || return 1
+		IFS='|' read -r store_bytes confidence ignored <<<"$measured"
+		if [[ "$confidence" == "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" && "$store_bytes" =~ ^[0-9]+$ ]]; then
+			if [[ "$store_bytes" -gt "$max_store_bytes" ]]; then
+				pressure=true
+				reason="store-soft-limit"
+			fi
+		else
+			store_bytes="$WORKTREE_RECOVERY_PLAN_JSON_NULL"
+			reason="aggregate-size-unavailable"
+		fi
 	fi
 	jq -cn --argjson active "$pressure" --arg reason "$reason" \
 		--argjson store_bytes "$store_bytes" \
@@ -330,6 +350,7 @@ _worktree_recovery_maintenance_limits_json() {
 	local max_store_bytes=""
 	local minimum_free_kb=""
 	local minimum_free_percent=""
+	local aggregate_timeout_tenths=""
 	local pressure_json=""
 
 	max_scan=$(_worktree_recovery_maintenance_uint "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN:-50}" 50 1 500)
@@ -340,8 +361,10 @@ _worktree_recovery_maintenance_limits_json() {
 	max_store_bytes=$(_worktree_recovery_maintenance_uint "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_STORE_BYTES:-5368709120}" 5368709120 1 1099511627776)
 	minimum_free_kb=$(_worktree_recovery_maintenance_uint "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB:-10485760}" 10485760 0 1099511627776)
 	minimum_free_percent=$(_worktree_recovery_maintenance_uint "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT:-10}" 10 0 100)
+	aggregate_timeout_tenths=$(_worktree_recovery_maintenance_uint \
+		"${AIDEVOPS_WORKTREE_RECOVERY_AGGREGATE_SIZE_TIMEOUT_TENTHS:-20}" 20 1 36000)
 	pressure_json=$(_worktree_recovery_maintenance_pressure_json "$recovery_root" "$max_store_bytes" \
-		"$minimum_free_kb" "$minimum_free_percent") || return 1
+		"$minimum_free_kb" "$minimum_free_percent" "$aggregate_timeout_tenths") || return 1
 	jq -cn --argjson max_scan "$max_scan" --argjson max_candidates "$max_candidates" \
 		--argjson max_bytes "$max_bytes" --argjson retention_days "$retention_days" \
 		--argjson max_store_bytes "$max_store_bytes" --argjson minimum_free_kb "$minimum_free_kb" \


### PR DESCRIPTION
## Summary

Evaluate filesystem capacity before aggregate recovery-store sizing, preserve bounded age retention when aggregate sizing is unavailable, and keep exact per-bucket deletion checks fail-closed.

## Files Changed

.agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-recovery-apply-helper.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh, .agents/scripts/worktree-recovery-maintenance-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified destructive maintenance paths with 23 lifecycle tests; changed-file local linters, ShellCheck, shfmt, Bash 3.2 compatibility, portability, and complexity gates pass; independent review bundle 7e41f451d705b04af1682d0d5067787c2cb0715ef15fa8c112504ccd0c997ed0 found no material defects.

Resolves #30443


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 2h 2m and 1,018,606 tokens on this with the user in an interactive session.