### PR TITLE
GH#30452: ignore commented cross-account inherit examples

### DIFF
--- a/.agents/scripts/security-posture-helper-repo.sh
+++ b/.agents/scripts/security-posture-helper-repo.sh
@@ -1285,8 +1285,10 @@ _detect_cross_account_inherit() {
 		return 1
 	fi
 
-	# Must use secrets:inherit (the broken cross-account pattern)
-	if ! printf '%s' "$decoded" | grep -q 'secrets:[[:space:]]*inherit'; then
+	# Must use an active secrets:inherit key (the broken cross-account pattern).
+	# Explanatory comments in the canonical caller must not trigger the advisory.
+	if ! printf '%s' "$decoded" | grep -qE \
+		'^[[:space:]]*secrets:[[:space:]]*inherit([[:space:]]+#.*)?[[:space:]]*$'; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-security-posture-cross-account-inherit.sh
+++ b/.agents/scripts/tests/test-security-posture-cross-account-inherit.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for the cross-account secrets:inherit detector (GH#30452).
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+STUB_WORKFLOW_CONTENT=""
+STUB_GH_FAILURE="false"
+
+pass() {
+	local message="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL: %s — %s\n' "$message" "$detail" >&2
+	return 0
+}
+
+gh() {
+	if [[ "$STUB_GH_FAILURE" == "true" ]]; then
+		return 1
+	fi
+
+	printf '%s' "$STUB_WORKFLOW_CONTENT" | base64
+	return 0
+}
+
+# shellcheck source=../security-posture-helper-repo.sh
+source "${SCRIPTS_DIR}/security-posture-helper-repo.sh"
+
+assert_detector_result() {
+	local expected="$1"
+	local description="$2"
+	local actual=0
+
+	_detect_cross_account_inherit "consumer/repo" || actual=$?
+	if [[ "$actual" -eq "$expected" ]]; then
+		pass "$description"
+	else
+		fail "$description" "expected return $expected, got $actual"
+	fi
+	return 0
+}
+
+STUB_WORKFLOW_CONTENT="jobs:
+  sync:
+    uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main
+    # GH#20976: secrets: inherit only works within the same GitHub account/org.
+    # Cross-account callers receive no secret when using secrets: inherit.
+    secrets:
+      SYNC_PAT: \${{ secrets.SYNC_PAT }}"
+assert_detector_result 1 "canonical comments with explicit SYNC_PAT mapping are clean"
+
+STUB_WORKFLOW_CONTENT='jobs:
+  sync:
+    uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main
+    secrets: inherit'
+assert_detector_result 0 "active secrets: inherit mapping remains detected"
+
+STUB_WORKFLOW_CONTENT=""
+assert_detector_result 2 "empty workflow response remains unfetchable"
+
+STUB_GH_FAILURE="true"
+assert_detector_result 2 "failed workflow fetch remains unfetchable"
+
+printf '\nTests: %d, failures: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Anchor the Phase 8 secrets inheritance detector to active YAML keys and add focused regression coverage for canonical comments, active inheritance, and fetch failures.

## Files Changed

.agents/scripts/security-posture-helper-repo.sh, .agents/scripts/tests/test-security-posture-cross-account-inherit.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused detector test, adjacent SYNC_PAT/setup-debt suites, ShellCheck, shfmt, and changed-file local linters pass.

Resolves #30452


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 27m and 306,656 tokens on this with the user in an interactive session.