### PR TITLE
GH#30454: preserve signed approval across dispatch audit comments

### DIFF
--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -48,6 +48,7 @@ _approval_snapshot_v2_comments_json() {
 	local pages_json="$1"
 	local excluded_comment_id="${2:-}"
 	local source_name="${3:-conversation}"
+	local issued_at_cutoff="${4:-}"
 	local empty_string=""
 
 	# #aidevops:trust-boundary — exclude the exact approval comment whose
@@ -55,12 +56,33 @@ _approval_snapshot_v2_comments_json() {
 	# audit written after verification. Marker text is attacker-controlled:
 	# excluding arbitrary marker comments would let an external contributor hide
 	# later drift by copying the marker into an unsigned comment.
-	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg empty "$empty_string" '
+	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg cutoff "$issued_at_cutoff" --arg empty "$empty_string" '
+		def trusted_association:
+			. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
+		def aidevops_worker_footer:
+			"(?:\\n<!-- aidevops:origin:worker -->)?\\n<!-- aidevops:sig -->\\n---\\n\\[aidevops\\.sh\\]\\(https://aidevops\\.sh\\) v[A-Za-z0-9._+-]+ [^\\n]+\\n?";
+		def canonical_dispatch_audit:
+			test(
+				"^<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\\n(?:" +
+				"DISPATCH_CLAIM nonce=[A-Za-z0-9._:-]+ runner=[A-Za-z0-9._:-]+ ts=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z max_age_s=[0-9]+ version=[A-Za-z0-9._+-]+ opencode_version=[A-Za-z0-9._+-]+ lease_token=[A-Za-z0-9._:-]+ device=[A-Za-z0-9._:-]+ session=issue-[0-9]+ phase=prelaunch expires_at=[0-9]+(?: [a-z_]+=[A-Za-z0-9._:-]+)*" +
+				"|DISPATCH_LEASE phase=(?:prelaunch|ready|terminal) lease_token=[A-Za-z0-9._:-]+ device=[A-Za-z0-9._:-]+ session=issue-[0-9]+ expires_at=[0-9]+ ts=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z attempt_id=[A-Za-z0-9._:-]+" +
+				"|Dispatching worker \\(deterministic\\)\\.\\n<!-- aidevops:dispatch lease_token=[A-Za-z0-9._:-]+ device=[A-Za-z0-9._:-]+ session=issue-[0-9]+ attempt_id=[A-Za-z0-9._:-]+ claim_id=[0-9]+ -->\\n- \\*\\*Worker PID\\*\\*: [0-9]+\\n- \\*\\*Model\\*\\*: (?:[A-Za-z0-9._/+:-]+|auto-select \\(round-robin\\))\\n- \\*\\*Tier\\*\\*: [a-z]+\\n- \\*\\*Runner\\*\\*: [A-Za-z0-9._:-]+\\n- \\*\\*aidevops\\*\\*: v?[A-Za-z0-9._+-]+\\n- \\*\\*OpenCode\\*\\*: v?[A-Za-z0-9._+-]+\\n- \\*\\*Issue\\*\\*: #[0-9]+" +
+				"|CLAIM_RELEASED reason=[A-Za-z0-9._:-]+ runner=[A-Za-z0-9._:-]+ ts=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z(?: [a-z_]+=[A-Za-z0-9._:@/+:-]+)*" +
+				")\\n<!-- ops:end -->" + aidevops_worker_footer + "$"
+			);
+		def canonical_self_hosting_override:
+			test(
+				"^<!-- self-hosting-tier-override -->\\n<!-- provenance:start -->\\n## Self-Hosting Tier Override\\n\\nPre-dispatch self-hosting detector replaced lower workload-tier labels with `tier:thinking` on this issue\\.\\n\\n\\*\\*Matched pattern:\\*\\* `[A-Za-z0-9._-]+` in issue body\\n\\n\\*\\*Rationale:\\*\\* Issues modifying the dispatch path have a self-referential property — workers dispatched to fix them run through the code being fixed\\. Applying the terminal workload tier upfront avoids wasted lower-tier attempts while runtime routing retains control of the exact model and reasoning level\\.\\n\\n\\*\\*Bypass:\\*\\* `AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1`\\n\\n_Automated by `pre-dispatch-validator-helper\\.sh` \\(t2819\\)\\. This comment is posted once via the `<!-- self-hosting-tier-override -->` marker; re-runs are no-ops\\._\\n<!-- provenance:end -->" + aidevops_worker_footer + "$"
+			);
+		def canonical_no_work_escalation_skip:
+			test(
+				"^<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\\n<!-- no-work-escalation-skip -->\\n## Tier Escalation Skipped: Infrastructure Failure \\(no_work\\)\\n\\n\\*\\*Trigger:\\*\\* [0-9]+ worker failure\\(s\\) classified as `no_work` — the worker exited during setup without reading any target files\\.\\n\\*\\*Action:\\*\\* Tier escalation \\*\\*skipped\\*\\*\\. The issue stays at its current tier so the next retry can succeed cheaply once the infrastructure issue resolves\\.\\n\\*\\*Reason:\\*\\* [A-Za-z0-9._:-]+\\n\\n\\*\\*Why no cascade:\\*\\* `no_work` means the worker never produced reliable implementation evidence — it crashed during runtime setup \\(FD exhaustion, plugin init failure, branch naming race, auth refresh race\\) or stale-recovery falsely concluded no progress\\. A more expensive model cannot fix an infrastructure problem it never reached\\. Cascading to `tier:thinking` would waste capacity on a problem the mapped standard or simple model can handle once the infrastructure clears\\.\\n\\nAfter [0-9]+ consecutive `no_work` failures the per-issue no_work circuit breaker \\(t2769\\) applies `status:blocked` and files a machine-recoverable root-cause meta-issue\\.\\n\\n_Automated by `escalate_issue_tier\\(\\)` no_work skip \\(t2387\\) in worker-lifecycle-common\\.sh_\\n<!-- ops:end -->" + aidevops_worker_footer + "$"
+			);
 		[.[][]?
 		| select((.id | tostring) != $excluded)
 		| select((.user.type // $empty) != "Bot")
 		| select((
-			((.author_association // $empty) == "OWNER" or (.author_association // $empty) == "MEMBER" or (.author_association // $empty) == "COLLABORATOR")
+			((.author_association // $empty) | trusted_association)
 			and ((.body // $empty) | startswith("<!-- aidevops-signed-approval -->\n<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — "))
 			and ((.body // $empty) | contains(") -->\nAuto-approved: "))
 			and ((.body // $empty) | contains(". Stale recovery tick reset."))
@@ -70,8 +92,20 @@ _approval_snapshot_v2_comments_json() {
 			# emitted by _isc_post_claim_comment is non-scope-bearing. Keep the
 			# optional worktree qualifier bounded to its backtick-delimited basename;
 			# trusted prose or copied markers must remain approval-significant.
-			((.author_association // $empty) == "OWNER" or (.author_association // $empty) == "MEMBER" or (.author_association // $empty) == "COLLABORATOR")
+			((.author_association // $empty) | trusted_association)
 			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n(?:<!-- aidevops:origin:interactive -->\\n)?<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
+		) | not)
+		| select((
+			# #aidevops:trust-boundary — these comments are excluded only when
+			# both GitHub authority and the complete canonical writer envelope
+			# match. Partial markers, extra prose, and unknown field shapes remain
+			# content-bound so copied audit text cannot extend signed authority.
+			# Pre-approval audits also remain bound for backwards-compatible V2
+			# verification; only canonical comments posted after signing are drift.
+			((.author_association // $empty) | trusted_association)
+			and ($cutoff != $empty)
+			and ((.created_at // $empty) > $cutoff)
+			and ((.body // $empty) | canonical_dispatch_audit or canonical_self_hosting_override or canonical_no_work_escalation_skip)
 		) | not)
 		| {
 			source: $source,
@@ -280,7 +314,7 @@ approval_snapshot_v2_build() (
 	fi
 
 	comments_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/comments?per_page=100") || return 1
-	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation") || return 1
+	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation" "$issued_at_cutoff") || return 1
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
 	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages" "$issued_at_cutoff" "$source_timestamp_profile") || return 1
 	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" && "$issue_lifecycle_profile" == "$APPROVAL_SNAPSHOT_PROFILE_CURRENT" ]]; then
@@ -332,7 +366,7 @@ approval_snapshot_v2_build() (
 	pr_json=$(gh api "repos/${slug}/pulls/${target_number}" 2>/dev/null) || return 1
 	printf '%s' "$pr_json" | jq -e --arg empty "$empty_string" --arg object "$APPROVAL_JSON_OBJECT" 'type == $object and (.id != null) and (.node_id != null) and ((.head.sha // $empty) != $empty) and ((.base.ref // $empty) != $empty)' >/dev/null 2>&1 || return 1
 	review_comment_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/comments?per_page=100") || return 1
-	review_comments_json=$(_approval_snapshot_v2_comments_json "$review_comment_pages" "" "review") || return 1
+	review_comments_json=$(_approval_snapshot_v2_comments_json "$review_comment_pages" "" "review" "$issued_at_cutoff") || return 1
 	review_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/reviews?per_page=100") || return 1
 	reviews_json=$(_approval_snapshot_v2_reviews_json "$review_pages") || return 1
 	_approval_snapshot_v2_write_json_file "$temp_dir/pr.json" "$pr_json" || return 1

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -400,6 +400,124 @@ extra trusted commentary" '.[0] += [{id:4305,node_id:"IC_4305",user:{id:1,node_i
 	return 0
 }
 
+test_trusted_dispatch_audit_comments() {
+	reset_and_sign issue 41
+	local worker_footer="<!-- aidevops:origin:worker -->
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.32.275 automated scan."
+	local self_hosting_audit="<!-- self-hosting-tier-override -->
+<!-- provenance:start -->
+## Self-Hosting Tier Override
+
+Pre-dispatch self-hosting detector replaced lower workload-tier labels with \`tier:thinking\` on this issue.
+
+**Matched pattern:** \`pulse-dispatch-\` in issue body
+
+**Rationale:** Issues modifying the dispatch path have a self-referential property — workers dispatched to fix them run through the code being fixed. Applying the terminal workload tier upfront avoids wasted lower-tier attempts while runtime routing retains control of the exact model and reasoning level.
+
+**Bypass:** \`AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1\`
+
+_Automated by \`pre-dispatch-validator-helper.sh\` (t2819). This comment is posted once via the \`<!-- self-hosting-tier-override -->\` marker; re-runs are no-ops._
+<!-- provenance:end -->
+${worker_footer}"
+	local dispatch_claim_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+DISPATCH_CLAIM nonce=abc123 runner=runner-a ts=2026-01-01T00:06:00Z max_age_s=600 version=3.32.275 opencode_version=1.0.0 lease_token=abc123 device=device-a session=issue-41 phase=prelaunch expires_at=1760000000
+<!-- ops:end -->
+${worker_footer}"
+	local dispatch_lease_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+DISPATCH_LEASE phase=ready lease_token=abc123 device=device-a session=issue-41 expires_at=1760000000 ts=2026-01-01T00:06:02Z attempt_id=attempt:abc123
+<!-- ops:end -->
+${worker_footer}"
+	local dispatch_launch_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+Dispatching worker (deterministic).
+<!-- aidevops:dispatch lease_token=abc123 device=device-a session=issue-41 attempt_id=attempt:abc123 claim_id=4311 -->
+- **Worker PID**: 12345
+- **Model**: openai/gpt-5.6
+- **Tier**: thinking
+- **Runner**: runner-a
+- **aidevops**: v3.32.275
+- **OpenCode**: v1.0.0
+- **Issue**: #41
+<!-- ops:end -->
+${worker_footer}"
+	local claim_release_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=claim_only_no_worker runner=runner-a ts=2026-01-01T00:07:00Z issue=41 opencode_version=1.0.0
+<!-- ops:end -->
+${worker_footer}"
+	local no_work_skip_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- no-work-escalation-skip -->
+## Tier Escalation Skipped: Infrastructure Failure (no_work)
+
+**Trigger:** 1 worker failure(s) classified as \`no_work\` — the worker exited during setup without reading any target files.
+**Action:** Tier escalation **skipped**. The issue stays at its current tier so the next retry can succeed cheaply once the infrastructure issue resolves.
+**Reason:** worker_noop_zero_output
+
+**Why no cascade:** \`no_work\` means the worker never produced reliable implementation evidence — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would waste capacity on a problem the mapped standard or simple model can handle once the infrastructure clears.
+
+After 3 consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`status:blocked\` and files a machine-recoverable root-cause meta-issue.
+
+_Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_
+<!-- ops:end -->
+${worker_footer}"
+	local dispatch_comments=""
+	dispatch_comments=$(jq -c \
+		--arg self_hosting "$self_hosting_audit" \
+		--arg claim "$dispatch_claim_audit" \
+		--arg lease "$dispatch_lease_audit" \
+		--arg launch "$dispatch_launch_audit" \
+		--arg release "$claim_release_audit" \
+		--arg no_work "$no_work_skip_audit" '
+		.[0] += [
+			{id:4310,node_id:"IC_4310",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$self_hosting},
+			{id:4311,node_id:"IC_4311",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:01Z",updated_at:"2026-01-01T00:06:01Z",body:$claim},
+			{id:4312,node_id:"IC_4312",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:02Z",updated_at:"2026-01-01T00:06:02Z",body:$lease},
+			{id:4313,node_id:"IC_4313",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:03Z",updated_at:"2026-01-01T00:06:03Z",body:$launch},
+			{id:4314,node_id:"IC_4314",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:07:00Z",updated_at:"2026-01-01T00:07:00Z",body:$release},
+			{id:4318,node_id:"IC_4318",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:07:01Z",updated_at:"2026-01-01T00:07:01Z",body:$no_work}
+		]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	assert_verify "trusted canonical dispatch audit comments preserve issue approval" issue 41 VERIFIED 0
+
+	write_baseline_fixtures
+	dispatch_comments=$(jq -c --arg body "$dispatch_claim_audit" '.[0] += [{id:4319,node_id:"IC_4319",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:04:00Z",updated_at:"2026-01-01T00:04:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	append_signed_comment issue 41 "2026-01-01T00:05:00Z"
+	assert_verify "pre-approval canonical dispatch audit remains in the signed snapshot" issue 41 VERIFIED 0
+	dispatch_comments=$(jq -c '.[0] |= map(if .id == 4319 then .body += "\nchanged after approval" else . end)' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	assert_verify "pre-approval canonical dispatch audit drift remains stale" issue 41 STALE_APPROVAL 4
+	return 0
+}
+
+test_dispatch_audit_comments_fail_closed() {
+	local worker_footer="<!-- aidevops:origin:worker -->
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.32.275 automated scan."
+	local dispatch_claim_audit="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+DISPATCH_CLAIM nonce=abc123 runner=runner-a ts=2026-01-01T00:06:00Z max_age_s=600 version=3.32.275 opencode_version=1.0.0 lease_token=abc123 device=device-a session=issue-41 phase=prelaunch expires_at=1760000000
+<!-- ops:end -->
+${worker_footer}"
+	local dispatch_comments=""
+	reset_and_sign issue 41
+	dispatch_comments=$(jq -c --arg body "$dispatch_claim_audit" '.[0] += [{id:4315,node_id:"IC_4315",user:{id:105,node_id:"U_105",login:"external-author",type:"User"},author_association:"CONTRIBUTOR",created_at:"2026-01-01T00:08:00Z",updated_at:"2026-01-01T00:08:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	assert_verify "external canonical dispatch audit lookalike remains content-bound" issue 41 STALE_APPROVAL 4
+
+	reset_and_sign issue 41
+	dispatch_comments=$(jq -c --arg body "${dispatch_claim_audit}
+extra trusted commentary" '.[0] += [{id:4316,node_id:"IC_4316",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:08:00Z",updated_at:"2026-01-01T00:08:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	assert_verify "trusted dispatch audit with extra prose remains content-bound" issue 41 STALE_APPROVAL 4
+
+	reset_and_sign issue 41
+	dispatch_comments=$(jq -c --arg body "${dispatch_claim_audit/DISPATCH_CLAIM/DISPATCH_UNKNOWN}" '.[0] += [{id:4317,node_id:"IC_4317",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:08:00Z",updated_at:"2026-01-01T00:08:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$dispatch_comments" >"${FIXTURES}/comments-41.json"
+	assert_verify "trusted unknown dispatch audit shape remains content-bound" issue 41 STALE_APPROVAL 4
+	return 0
+}
+
 test_post_approval_linked_references() {
 	reset_and_sign issue 41
 	jq '.[0] += [(.[0][0] | .id = 420 | .node_id = "EV_420" | .created_at = "2026-01-01T00:06:00Z" | .source.issue.number = 10)]' \
@@ -627,6 +745,8 @@ main() {
 	append_signed_comment pr 42 "2026-01-01T00:06:00Z" 4300
 	assert_verify "repeat approval verifies against the newest exact snapshot" pr 42 VERIFIED 0 "$PR_HEAD"
 	test_trusted_lifecycle_comments
+	test_trusted_dispatch_audit_comments
+	test_dispatch_audit_comments_fail_closed
 	test_post_approval_linked_references
 	test_locked_issue_continuity
 	test_locked_issue_tier_backfill_continuity


### PR DESCRIPTION
## Summary

Exclude only trusted, exact canonical post-approval dispatch audit comments from V2 approval snapshots while preserving pre-approval content binding and legacy verification.

## Files Changed

.agents/scripts/approval-snapshot-v2.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: 68 approval content-binding tests passed; local lint, ShellCheck, shfmt, and live authority verification of issue #30446 passed.

Resolves #30454


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 2h 44m and 1,569,109 tokens on this with the user in an interactive session.