### PR TITLE
GH#30448: harden PR origin postconditions

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -59,6 +59,9 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${PULSE_MERGE_PR_CURSOR_FILE:=${PULSE_MERGE_CHECKPOINT_FILE}.pr-cursor}"
 : "${AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_SECONDS:=3600}"
 : "${AIDEVOPS_UPDATE_BRANCH_CONFLICT_COOLDOWN_DIR:=${HOME}/.aidevops/cache/pulse-update-branch-conflicts}"
+_PMP_ORIGIN_INTERACTIVE_PATTERN=",origin:interactive,"
+_PMP_ORIGIN_WORKER_PATTERN=",origin:worker,"
+_PMP_ORIGIN_TAKEOVER_PATTERN=",origin:worker-takeover,"
 
 #######################################
 # Return the persistent state path for one interactive PR's semantic
@@ -678,11 +681,9 @@ _attempt_pr_update_branch() {
 		local _ub_labels=""
 		_ub_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
 			--jq '[.labels[]?.name] | join(",")' 2>/dev/null) || _ub_labels=""
-		case ",${_ub_labels}," in
-		*,origin:interactive,*)
+		if [[ ",${_ub_labels}," == *"$_PMP_ORIGIN_INTERACTIVE_PATTERN"* ]]; then
 			_pmp_record_update_branch_conflict_cooldown "$pr_number" "$repo_slug" "$expected_head_sha" || true
-			;;
-		esac
+		fi
 	fi
 	echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch failed, falling through to close (t2116): ${_ub_output}" >>"$LOGFILE"
 	return 1
@@ -1021,8 +1022,59 @@ _route_issue_origin_is_trusted() {
 		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} linked issue #${linked_issue} has origin:worker but PR author trust could not be confirmed" >>"$LOGFILE"
 		return 1
 	fi
-	echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} using linked issue #${linked_issue} origin:worker fallback" >>"$LOGFILE"
+	if ! declare -F set_origin_label >/dev/null 2>&1 \
+		|| ! set_origin_label "$pr_number" "$repo_slug" worker --pr >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} trusted linked issue #${linked_issue} has origin:worker, but PR origin reconciliation failed — deferring routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	local reconciled_labels=""
+	if ! reconciled_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null); then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} origin:worker reconciliation from trusted linked issue #${linked_issue} was not verified — deferring routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	local reconciled_label_list=",${reconciled_labels},"
+	if [[ "$reconciled_label_list" != *"$_PMP_ORIGIN_WORKER_PATTERN"* \
+		|| "$reconciled_label_list" == *"$_PMP_ORIGIN_INTERACTIVE_PATTERN"* \
+		|| "$reconciled_label_list" == *"$_PMP_ORIGIN_TAKEOVER_PATTERN"* ]]; then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} origin:worker reconciliation from trusted linked issue #${linked_issue} was not verified — deferring routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} restored origin:worker from trusted linked issue #${linked_issue}" >>"$LOGFILE"
 	return 0
+}
+
+_route_pr_issue_supplies_worker_origin() {
+	local label_list="$1"
+	local issue_labels="$2"
+	[[ "$label_list" != *"$_PMP_ORIGIN_WORKER_PATTERN"* \
+		&& "$label_list" != *"$_PMP_ORIGIN_TAKEOVER_PATTERN"* \
+		&& "$label_list" != *"$_PMP_ORIGIN_INTERACTIVE_PATTERN"* \
+		&& ",${issue_labels}," == *"$_PMP_ORIGIN_WORKER_PATTERN"* ]]
+}
+
+_route_pr_log_unroutable() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local kind="$4"
+	local label_list="$5"
+	if [[ "$label_list" == *"$_PMP_ORIGIN_INTERACTIVE_PATTERN"* ]]; then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} retains active origin:interactive ownership; ${kind} repair routing is not eligible" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} and linked issue #${linked_issue} have no trusted origin metadata for ${kind} repair routing" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+_route_pr_has_linked_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local kind="$4"
+	[[ -n "$linked_issue" ]] && return 0
+	echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} has no linked issue for ${kind} repair routing" >>"$LOGFILE"
+	return 1
 }
 
 _route_pr_issue_labels_for_dispatch() {
@@ -1102,12 +1154,11 @@ _route_pr_to_fix_worker() {
 	local issue_labels=""
 	local issue_has_worker_origin=0
 	local label_list=""
-	local takeover_pattern=",origin:worker-takeover,"
+	local takeover_pattern="$_PMP_ORIGIN_TAKEOVER_PATTERN"
 	local has_routed_label=0
 	local issue_labels_rc=0
 
-	# No linked issue → nothing to route to
-	[[ -z "$linked_issue" ]] && return 1
+	_route_pr_has_linked_issue "$pr_number" "$repo_slug" "$linked_issue" "$kind" || return 1
 
 	# Fetch labels if not provided by caller
 	if [[ -z "$pr_labels" ]]; then
@@ -1146,21 +1197,20 @@ _route_pr_to_fix_worker() {
 	issue_labels=$(_route_pr_issue_labels_for_dispatch "$pr_number" "$repo_slug" "$linked_issue") || issue_labels_rc=$?
 	[[ "$issue_labels_rc" -eq 0 ]] || return "$issue_labels_rc"
 
-	if [[ "$label_list" != *",origin:worker,"* \
-		&& "$label_list" != *"$takeover_pattern"* \
-		&& "$label_list" != *",origin:interactive,"* ]]; then
-		if [[ ",${issue_labels}," == *",origin:worker,"* ]]; then
-			issue_has_worker_origin=1
-		fi
+	if _route_pr_issue_supplies_worker_origin "$label_list" "$issue_labels"; then
+		issue_has_worker_origin=1
 	fi
 
 	# Worker-origin PRs: dispatch directly
 	if [[ ( -n "${_OW_LABEL_PAT:-}" && "$label_list" == *"${_OW_LABEL_PAT:-}"* ) ]] \
 		|| [[ "$label_list" == *"$takeover_pattern"* ]] \
 		|| [[ "$issue_has_worker_origin" -eq 1 ]]; then
-		[[ "$issue_has_worker_origin" -eq 0 ]] \
-			|| _route_issue_origin_is_trusted "$pr_number" "$repo_slug" "$linked_issue" \
-			|| return 1
+		if [[ "$issue_has_worker_origin" -eq 1 ]]; then
+			local origin_reconcile_rc=0
+			_route_issue_origin_is_trusted "$pr_number" "$repo_slug" "$linked_issue" \
+				|| origin_reconcile_rc=$?
+			[[ "$origin_reconcile_rc" -eq 0 ]] || return "$origin_reconcile_rc"
+		fi
 		_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
 			"$linked_issue" "$kind" "$routed_label" || return $?
 		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json"
@@ -1168,7 +1218,7 @@ _route_pr_to_fix_worker() {
 	fi
 
 	# Stale interactive PRs: handover first, then dispatch
-	if [[ "$label_list" == *",origin:interactive,"* ]] \
+	if [[ "$label_list" == *"$_PMP_ORIGIN_INTERACTIVE_PATTERN"* ]] \
 		&& _interactive_pr_is_stale "$pr_number" "$repo_slug" "$updated_at" "$head_ref_oid"; then
 		if ! _interactive_pr_trigger_handover "$pr_number" "$repo_slug"; then
 			echo "[pulse-wrapper] _route_pr_to_fix_worker: interactive handover was not confirmed for PR #${pr_number} in ${repo_slug} — refusing destructive routing" >>"$LOGFILE"
@@ -1186,7 +1236,9 @@ _route_pr_to_fix_worker() {
 		return $?
 	fi
 
-	# Not routable (no matching origin label or not stale)
+	# Not routable (no matching origin label or not stale). Keep one bounded,
+	# terminal diagnostic so a lost provenance label cannot become a silent loop.
+	_route_pr_log_unroutable "$pr_number" "$repo_slug" "$linked_issue" "$kind" "$label_list"
 	return 1
 }
 

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -820,6 +820,139 @@ _gh_create_pr_should_default_draft() {
 	return 0
 }
 
+#######################################
+# Resolve the one origin label gh_create_pr must establish.
+# Args: PR create argv
+# Output: origin:interactive|origin:worker|origin:worker-takeover
+# Returns: 0=resolved, 2=conflicting or unsupported origin labels
+#######################################
+_gh_create_pr_expected_origin_label() {
+	local expected=""
+	while [[ $# -gt 0 ]]; do
+		local cur="$1"
+		local label_val=""
+		case "$cur" in
+		--label)
+			label_val="${2:-}"
+			[[ $# -gt 1 ]] && shift
+			;;
+		--label=*) label_val="${cur#--label=}" ;;
+		esac
+		if [[ -n "$label_val" ]]; then
+			local saved_ifs="$IFS"
+			local label_part=""
+			IFS=','
+			for label_part in $label_val; do
+				case "$label_part" in
+				origin:interactive | origin:worker | origin:worker-takeover)
+					if [[ -n "$expected" && "$expected" != "$label_part" ]]; then
+						IFS="$saved_ifs"
+						printf '[aidevops][gh-wrapper][BLOCK] gh_create_pr requires exactly one origin label\n' >&2
+						return 2
+					fi
+					expected="$label_part"
+					;;
+				esac
+			done
+			IFS="$saved_ifs"
+		fi
+		shift
+	done
+	[[ -n "$expected" ]] || expected=$(session_origin_label)
+	case "$expected" in
+	origin:interactive | origin:worker | origin:worker-takeover) ;;
+	*)
+		printf '[aidevops][gh-wrapper][BLOCK] gh_create_pr resolved unsupported origin label: %s\n' "$expected" >&2
+		return 2
+		;;
+	esac
+	printf '%s\n' "$expected"
+	return 0
+}
+
+#######################################
+# Resolve a durable PR URL, repository, and number from gh create output.
+# Sets _GH_CREATE_PR_DURABLE_URL/REPO/NUMBER.
+# Args: $1=create output, remaining args=PR create argv
+# Returns: 0=durable identity resolved, 1=unavailable or inconsistent
+#######################################
+_gh_create_pr_resolve_durable_identity() {
+	local output="$1"
+	shift
+	_GH_CREATE_PR_DURABLE_URL=""
+	_GH_CREATE_PR_DURABLE_REPO=""
+	_GH_CREATE_PR_DURABLE_NUMBER=""
+	local line=""
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" =~ ^https://[^[:space:]]+/pull/[0-9]+$ ]]; then
+			_GH_CREATE_PR_DURABLE_URL="$line"
+		fi
+	done <<<"$output"
+	[[ -n "$_GH_CREATE_PR_DURABLE_URL" ]] || return 1
+
+	local url_without_scheme="${_GH_CREATE_PR_DURABLE_URL#*://}"
+	local url_path="${url_without_scheme#*/}"
+	local url_repo="${url_path%/pull/*}"
+	local repo=""
+	repo=$(_gh_extract_repo_from_args "$@")
+	[[ -n "$repo" ]] || repo="$url_repo"
+	if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ || "$repo" != "$url_repo" ]]; then
+		return 1
+	fi
+	_GH_CREATE_PR_DURABLE_REPO="$repo"
+	_GH_CREATE_PR_DURABLE_NUMBER="${_GH_CREATE_PR_DURABLE_URL##*/}"
+	return 0
+}
+
+#######################################
+# Verify that a PR has exactly the expected origin label.
+# Args: $1=repo $2=PR number $3=expected origin label
+# Returns: 0=exact postcondition, 1=missing/wrong/dual/unavailable
+#######################################
+_gh_create_pr_origin_is_exact() {
+	local repo="$1"
+	local pr_number="$2"
+	local expected_origin="$3"
+	local origin_labels=""
+	origin_labels=$(_gh_with_timeout read gh api "/repos/${repo}/issues/${pr_number}" \
+		--jq '[.labels[].name | select(startswith("origin:"))] | join(",")' 2>/dev/null) || return 1
+	[[ "$origin_labels" == "$expected_origin" ]]
+}
+
+#######################################
+# Enforce the common post-create origin invariant without recreating a PR.
+# Args: $1=create output $2=expected origin, remaining args=PR create argv
+# Returns: 0=verified/reconciled, 78=durable PR remains unverified
+#######################################
+_gh_create_pr_enforce_origin_postcondition() {
+	local output="$1"
+	local expected_origin="$2"
+	shift 2
+	if ! _gh_create_pr_resolve_durable_identity "$output" "$@"; then
+		printf '[aidevops] gh_create_pr: create returned without a verifiable durable PR identity; refusing ordinary success\n' >&2
+		return "$_GH_PR_CREATE_PARTIAL_RC"
+	fi
+	if _gh_create_pr_origin_is_exact "$_GH_CREATE_PR_DURABLE_REPO" \
+		"$_GH_CREATE_PR_DURABLE_NUMBER" "$expected_origin"; then
+		return 0
+	fi
+
+	local origin_name="${expected_origin#origin:}"
+	if declare -F set_origin_label >/dev/null 2>&1; then
+		set_origin_label "$_GH_CREATE_PR_DURABLE_NUMBER" \
+			"$_GH_CREATE_PR_DURABLE_REPO" "$origin_name" --pr >/dev/null 2>&1 || true
+	fi
+	# A transport can report failure after applying its mutation. Read back even
+	# when set_origin_label returned non-zero before classifying partial success.
+	if _gh_create_pr_origin_is_exact "$_GH_CREATE_PR_DURABLE_REPO" \
+		"$_GH_CREATE_PR_DURABLE_NUMBER" "$expected_origin"; then
+		return 0
+	fi
+	printf '[aidevops] gh_create_pr: durable PR #%s exists but exact %s provenance is unverified; not retrying creation\n' \
+		"$_GH_CREATE_PR_DURABLE_NUMBER" "$expected_origin" >&2
+	return "$_GH_PR_CREATE_PARTIAL_RC"
+}
+
 gh_create_pr() {
 	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_pr 2>/dev/null || true
@@ -833,6 +966,10 @@ gh_create_pr() {
 		_gh_edit_audit_rejection "gh pr create" "$_GH_EDIT_REJECTION_REASON" "$@"
 		return 1
 	fi
+	local expected_origin_label=""
+	expected_origin_label=$(_gh_create_pr_expected_origin_label "$@") || return $?
+	local is_help=0
+	_gh_wrapper_args_have_flag "--help" "$@" && is_help=1
 
 	# t3088: defence-in-depth — only auto-inject the session origin label when
 	# the caller has NOT already specified one. Prevents the dual-origin-label
@@ -869,7 +1006,11 @@ gh_create_pr() {
 	local pr_output rc
 	pr_output=$("${pr_cmd[@]}") # aidevops-allow: raw-gh-wrapper
 	rc=$?
-	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
+	if [[ $rc -ne 0 ]] && _gh_create_pr_resolve_durable_identity "$pr_output" "$@"; then
+		# Native gh can create the PR and fail during a follow-up mutation. The URL
+		# proves creation; never invoke another create transport for this result.
+		rc="$_GH_PR_CREATE_PARTIAL_RC"
+	elif [[ $rc -ne 0 ]] && _rest_should_fallback_write; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
 		if [[ ${#_origin_label_args[@]} -gt 0 || ${#_draft_args[@]} -gt 0 ]]; then
 			pr_output=$(_rest_pr_create "$@" "${_draft_args[@]}" "${_origin_label_args[@]}")
@@ -878,8 +1019,18 @@ gh_create_pr() {
 		fi
 		rc=$?
 	fi
+	if [[ "$is_help" -eq 0 && ( "$rc" -eq 0 || "$rc" -eq "$_GH_PR_CREATE_PARTIAL_RC" ) ]]; then
+		local postcondition_rc=0
+		_gh_create_pr_enforce_origin_postcondition "$pr_output" "$expected_origin_label" "$@" \
+			|| postcondition_rc=$?
+		if [[ "$postcondition_rc" -eq 0 ]]; then
+			rc=0
+		else
+			rc="$postcondition_rc"
+		fi
+	fi
 	printf '%s\n' "$pr_output"
-	return $rc
+	return "$rc"
 }
 
 # t2767: Partial-success recovery for gh pr create.

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -26,6 +26,11 @@
 [[ -n "${_SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 
+# A durable PR exists, but a required post-create invariant is not yet
+# verified. Callers must preserve the emitted PR URL and reconcile that PR;
+# they must not retry creation and risk a duplicate.
+_GH_PR_CREATE_PARTIAL_RC=78
+
 _gh_rest_fallback_dir="${_SHARED_GH_WRAPPERS_DIR:-}"
 if [[ -z "$_gh_rest_fallback_dir" && -n "${BASH_SOURCE[0]:-}" ]]; then
 	_gh_rest_fallback_dir="${BASH_SOURCE[0]%/*}"
@@ -355,6 +360,17 @@ _rest_should_fallback() {
 		return 0
 	fi
 	return 1
+}
+
+#######################################
+# Write-safe fallback decision. AIDEVOPS_GH_FORCE_REST_READS is intentionally
+# ignored so a read-routing optimization cannot authorize a second create
+# transport after a write failure. Explicit test override and live low-budget
+# evidence still use the shared fallback decision.
+#######################################
+_rest_should_fallback_write() {
+	AIDEVOPS_GH_FORCE_REST_READS=0 _rest_should_fallback "$@"
+	return $?
 }
 
 #######################################
@@ -1067,13 +1083,38 @@ _rest_pr_autodetect_base() {
 }
 
 #######################################
+# Verify labels after a durable REST PR creation.
+# Args: $1=repo $2=PR URL $3..=requested labels
+# Returns: 0=verified/no labels, 78=durable PR with unverified labels
+#######################################
+_rest_pr_create_label_postcondition() {
+	local repo="$1"
+	local html_url="$2"
+	shift 2
+	[[ $# -gt 0 ]] || return 0
+	local pr_number=""
+	pr_number=$(printf '%s' "$html_url" | grep -oE '[0-9]+$' || true)
+	if [[ -z "$pr_number" ]]; then
+		printf '[aidevops] _rest_pr_create: created PR but could not resolve its number to verify requested labels\n' >&2
+		return "$_GH_PR_CREATE_PARTIAL_RC"
+	fi
+	if ! _rest_apply_labels_verified "$repo" "$pr_number" "$@"; then
+		printf '[aidevops] _rest_pr_create: created PR #%s but could not verify requested labels after bounded retries; not retrying creation\n' "$pr_number" >&2
+		return "$_GH_PR_CREATE_PARTIAL_RC"
+	fi
+	return 0
+}
+
+#######################################
 # _rest_pr_create: POST /repos/{owner}/{repo}/pulls.
 # Parses gh-style args (--head, --base, --title, --body, --body-file, --draft,
 # --label) into a REST payload. Labels are applied via a separate
 # POST /repos/{owner}/{repo}/issues/{pr_number}/labels call because the
 # GitHub pulls endpoint does not accept a labels field at creation time.
-# Emits the PR html_url on stdout, mirroring `gh pr create`. Returns underlying
-# gh api exit code.
+# Emits the PR html_url on stdout, mirroring `gh pr create`. Returns the
+# underlying gh api exit code, or 78 when the PR exists but requested labels
+# could not be verified. Exit 78 is a durable partial success, never authority
+# to retry creation.
 # When --head or --base are omitted, auto-detects from git HEAD / repo
 # default branch respectively (see _rest_pr_autodetect_head/base above).
 #######################################
@@ -1163,17 +1204,10 @@ _rest_pr_create() {
 	fi
 
 	# Apply labels via the issues endpoint (PRs share it).
-	if [[ ${#labels[@]} -gt 0 ]]; then
-		local pr_number
-		pr_number=$(printf '%s' "$html_url" | grep -oE '[0-9]+$' || true)
-		if [[ -z "$pr_number" ]]; then
-			printf '[aidevops] _rest_pr_create: created PR but could not resolve its number to verify requested labels\n' >&2
-		elif ! _rest_apply_labels_verified "$repo" "$pr_number" "${labels[@]}"; then
-			printf '[aidevops] _rest_pr_create: created PR #%s but could not verify requested labels after bounded retries; not retrying creation\n' "$pr_number" >&2
-		fi
-	fi
+	local label_rc=0
+	_rest_pr_create_label_postcondition "$repo" "$html_url" "${labels[@]}" || label_rc=$?
 	printf '%s\n' "$html_url"
-	return 0
+	return "$label_rc"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -122,6 +122,12 @@ export -f print_info
 _gh_with_timeout() { shift; "$@"; return $?; }
 export -f _gh_with_timeout
 
+# Public-write privacy scanning has dedicated coverage. Keep this REST transport
+# harness focused on fallback and post-create invariants instead of requiring
+# every synthetic fixture to emulate repository visibility APIs.
+# shellcheck disable=SC2317
+_gh_guard_public_write_args() { return 0; }
+
 # Post-source stubs. Shell functions beat PATH binaries.
 _stub_jq_filter_arg() {
 	local start_index="${1:-}"
@@ -254,6 +260,10 @@ _stub_gh_api() {
 		local fixture='{"number":42,"state":"open","locked":false,"labels":[{"name":"bug"}],"assignees":[]}'
 		fixture="${STUB_ISSUE_VIEW_FIXTURE:-$fixture}"
 		jq_filter="$(_stub_jq_filter_arg 3 api "$@")"
+		if [[ "$jq_filter" == *'startswith("origin:")'* ]]; then
+			local origin_fixture='{"labels":[{"name":"origin:interactive"}]}'
+			fixture="${STUB_CREATE_ORIGIN_FIXTURE:-$origin_fixture}"
+		fi
 		_stub_print_fixture_with_jq "$fixture" "$jq_filter" -r
 		return $?
 	fi
@@ -310,6 +320,10 @@ _stub_gh_pr() {
 	if [[ "$subcommand" != "create" && "$subcommand" != "comment" && "$subcommand" != "view" && "$subcommand" != "list" ]]; then
 		return 1
 	fi
+	if [[ "$subcommand" == "create" && "${STUB_PRIMARY_PARTIAL_URL:-0}" == "1" ]]; then
+		printf 'https://github.com/owner/repo/pull/9100\n'
+		return 1
+	fi
 	if [[ "${STUB_PRIMARY_FAIL:-0}" == "1" ]]; then
 		printf 'primary stub forced failure (rate limit)\n' >&2
 		return 1
@@ -354,6 +368,21 @@ gh() {
 	return 0
 }
 export -f gh
+
+# Deterministic origin reconciliation used only by the common gh_create_pr
+# postcondition tests below. The state mutation remains inside the wrapper's
+# command-substitution shell, matching production ordering before readback.
+set_origin_label() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local origin_name="$3"
+	printf 'set-origin %s %s %s\n' "$pr_number" "$repo_slug" "$origin_name" >>"$GH_CALLS"
+	[[ "${STUB_SET_ORIGIN_FAIL:-0}" != "1" ]] || return 1
+	STUB_CREATE_ORIGIN_FIXTURE=$(jq -cn --arg name "origin:${origin_name}" '{labels: [{name: $name}]}') || return 1
+	export STUB_CREATE_ORIGIN_FIXTURE
+	return 0
+}
+export -f set_origin_label
 
 # Stub _rest_append_sig as a no-op to prevent gh-signature-helper.sh calls
 # during tests. The helper queries the OpenCode SQLite session DB which can
@@ -420,6 +449,24 @@ else
 	fail "should_fallback returns false when rate_limit unparseable (fail-safe)" \
 		"expected false but got true — would trigger unnecessary REST fallback"
 fi
+
+# A read-only routing override must not authorize a write fallback.
+export AIDEVOPS_GH_FORCE_REST_READS=1
+STUB_RATE_LIMIT_REMAINING=100
+if ! _rest_should_fallback_write; then
+	pass "write fallback ignores AIDEVOPS_GH_FORCE_REST_READS"
+else
+	fail "write fallback ignores AIDEVOPS_GH_FORCE_REST_READS" \
+		"read-only override incorrectly authorized a write transport"
+fi
+STUB_RATE_LIMIT_REMAINING=0
+if _rest_should_fallback_write; then
+	pass "write fallback still honors live low GraphQL budget"
+else
+	fail "write fallback still honors live low GraphQL budget" \
+		"live exhausted budget did not authorize REST write fallback"
+fi
+unset AIDEVOPS_GH_FORCE_REST_READS
 
 # Reset for remaining tests
 export STUB_RATE_LIMIT_REMAINING=5000
@@ -824,7 +871,7 @@ label_failure_output=$(_rest_pr_create \
 pull_create_count=$(grep -cE '^api -X POST /repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null || true)
 label_apply_count=$(grep -cE '^api -X POST /repos/owner/repo/issues/9999/labels' "$GH_CALLS" 2>/dev/null || true)
 
-if [[ $label_failure_rc -eq 0 && "$label_failure_output" == "https://github.com/owner/repo/issues/9999" &&
+if [[ $label_failure_rc -eq 78 && "$label_failure_output" == "https://github.com/owner/repo/issues/9999" &&
 	"$pull_create_count" -eq 1 && "$label_apply_count" -eq 3 ]] &&
 	grep -q 'created PR #9999 but could not verify requested labels after bounded retries; not retrying creation' "$label_failure_stderr" 2>/dev/null; then
 	pass "_rest_pr_create surfaces label failure without risking duplicate PR creation"
@@ -841,6 +888,7 @@ unset STUB_REST_FAIL_MATCH STUB_ISSUE_VIEW_FIXTURE AIDEVOPS_GH_REST_LABEL_RETRY_
 : >"$GH_INFO_OUTPUT"
 export STUB_PRIMARY_FAIL=1
 export STUB_RATE_LIMIT_REMAINING=0
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":[{"name":"origin:interactive"}],"assignees":[]}'
 
 gh_pr_comment 8888 --repo "owner/repo" --body "fallback pr comment" >/dev/null 2>&1 || true
 
@@ -860,7 +908,7 @@ else
 		"INFO log: $(cat "$GH_INFO_OUTPUT")"
 fi
 
-unset STUB_PRIMARY_FAIL
+unset STUB_PRIMARY_FAIL STUB_ISSUE_VIEW_FIXTURE
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
@@ -955,6 +1003,84 @@ else
 	fail "gh_create_pr does NOT fall back when primary succeeds" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
+
+# =============================================================================
+# Test 19b: missing origin is reconciled on the durable PR, not recreated
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_CREATE_ORIGIN_FIXTURE='{"labels":[]}'
+origin_reconcile_output=""
+origin_reconcile_rc=0
+origin_reconcile_output=$(gh_create_pr \
+	--repo "owner/repo" \
+	--title "t9997: origin reconcile" \
+	--head "feature/t9997-origin-reconcile" \
+	--base "main" \
+	--body "origin reconcile body" 2>/dev/null) || origin_reconcile_rc=$?
+origin_reconcile_create_count=$(grep -cE '^pr create' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$origin_reconcile_rc" -eq 0 \
+	&& "$origin_reconcile_output" == "https://github.com/owner/repo/pull/9100" \
+	&& "$origin_reconcile_create_count" -eq 1 ]] \
+	&& grep -qF 'set-origin 9100 owner/repo interactive' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_create_pr reconciles missing origin on the durable PR"
+else
+	fail "gh_create_pr reconciles missing origin on the durable PR" \
+		"rc=${origin_reconcile_rc}; output=${origin_reconcile_output}; calls=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 19c: failed reconciliation returns typed partial success with URL
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_CREATE_ORIGIN_FIXTURE='{"labels":[]}'
+export STUB_SET_ORIGIN_FAIL=1
+origin_partial_output=""
+origin_partial_rc=0
+origin_partial_stderr="${TMP}/pr-origin-partial.stderr"
+origin_partial_output=$(gh_create_pr \
+	--repo "owner/repo" \
+	--title "t9997: origin partial" \
+	--head "feature/t9997-origin-partial" \
+	--base "main" \
+	--body "origin partial body" 2>"$origin_partial_stderr") || origin_partial_rc=$?
+origin_partial_create_count=$(grep -cE '^pr create' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$origin_partial_rc" -eq 78 \
+	&& "$origin_partial_output" == "https://github.com/owner/repo/pull/9100" \
+	&& "$origin_partial_create_count" -eq 1 ]] \
+	&& grep -q 'durable PR #9100 exists but exact origin:interactive provenance is unverified; not retrying creation' \
+		"$origin_partial_stderr" 2>/dev/null; then
+	pass "gh_create_pr preserves URL and returns typed partial success"
+else
+	fail "gh_create_pr preserves URL and returns typed partial success" \
+		"rc=${origin_partial_rc}; output=${origin_partial_output}; calls=$(cat "$GH_CALLS"); stderr=$(cat "$origin_partial_stderr")"
+fi
+unset STUB_CREATE_ORIGIN_FIXTURE STUB_SET_ORIGIN_FAIL
+
+# =============================================================================
+# Test 19d: native partial success with URL never invokes REST create
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_PRIMARY_PARTIAL_URL=1
+native_partial_output=""
+native_partial_rc=0
+native_partial_output=$(gh_create_pr \
+	--repo "owner/repo" \
+	--title "t9997: native partial" \
+	--head "feature/t9997-native-partial" \
+	--base "main" \
+	--body "native partial body" 2>/dev/null) || native_partial_rc=$?
+native_partial_create_count=$(grep -cE '^pr create' "$GH_CALLS" 2>/dev/null || true)
+native_partial_rest_count=$(grep -cE '^api.*-X POST.*/repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$native_partial_rc" -eq 0 \
+	&& "$native_partial_output" == "https://github.com/owner/repo/pull/9100" \
+	&& "$native_partial_create_count" -eq 1 \
+	&& "$native_partial_rest_count" -eq 0 ]]; then
+	pass "gh_create_pr never recreates a native partial success with durable URL"
+else
+	fail "gh_create_pr never recreates a native partial success with durable URL" \
+		"rc=${native_partial_rc}; output=${native_partial_output}; creates=${native_partial_create_count}; rest=${native_partial_rest_count}; calls=$(cat "$GH_CALLS")"
+fi
+unset STUB_PRIMARY_PARTIAL_URL
 
 # =============================================================================
 # Test 20: gh_create_pr → does NOT fall back when primary fails but healthy

--- a/.agents/scripts/tests/test-gh-wrapper-stdin.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-stdin.sh
@@ -58,11 +58,27 @@ gh() {
 		esac
 		previous="$argument"
 	done
+	if [[ "${1:-} ${2:-}" == "api repos/test/repo" ]]; then
+		printf 'false\n'
+		return 0
+	fi
+	if [[ "${1:-} ${2:-}" == "api graphql" ]]; then
+		printf 'false\n'
+		return 0
+	fi
+	if [[ "${1:-} ${2:-}" == "api /repos/test/repo/issues/999" ]]; then
+		printf 'origin:interactive\n'
+		return 0
+	fi
 	if [[ "${STUB_CREATE_FAIL:-0}" == "1" && "${1:-} ${2:-}" == "issue create" ]]; then
 		cp "$CAPTURED_BODY" "$NATIVE_BODY"
 		return 1
 	fi
-	printf 'https://github.com/test/repo/issues/999\n'
+	if [[ "${1:-} ${2:-}" == "pr create" ]]; then
+		printf 'https://github.com/test/repo/pull/999\n'
+	else
+		printf 'https://github.com/test/repo/issues/999\n'
+	fi
 	return 0
 }
 export -f gh
@@ -166,6 +182,7 @@ cat >"${STUB_BIN}/gh" <<'STUB'
 printf '%s\n' "$*" >>"$GH_CALLS"
 case "${1:-} ${2:-}" in
 "issue view" | "pr view") printf '%s\n' '{"title":"Existing","body":"Existing","labels":[]}' ;;
+"api repos/test/repo" | "api graphql") printf '%s\n' 'false' ;;
 esac
 exit 0
 STUB

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -75,7 +75,7 @@ fi
 # pr/issue create paths print a URL on stdout for caller capture
 case "$1 $2" in
 "pr create" | "issue create")
-	echo "https://example.invalid/test/repo/pull/0"
+	echo "https://example.invalid/o/r/pull/0"
 	;;
 esac
 exit 0
@@ -112,6 +112,12 @@ _gh_wrapper_auto_sig() {
 
 # Stub _gh_validate_edit_args (always pass — body validation isn't under test)
 _gh_validate_edit_args() { return 0; }
+
+# Privacy/write-policy and durable readback have dedicated suites. This harness
+# inspects only the exact create argv emitted by the wrapper.
+_gh_guard_public_write_args() { return 0; }
+_gh_create_pr_origin_is_exact() { return 0; }
+_gh_lock_created_auto_dispatch_issue() { return 0; }
 
 # Stub _gh_should_fallback_to_rest (never fall back — REST path adds noise)
 _gh_should_fallback_to_rest() { return 1; }
@@ -380,6 +386,18 @@ else
 	print_result "B8: AIDEVOPS_PR_CREATE_READY leaves interactive PR non-draft" 0
 fi
 unset AIDEVOPS_PR_CREATE_READY GH_ARGV_RECORD_FILE
+
+# B9: conflicting caller origins are rejected before any PR create write.
+reset_recorder
+dual_origin_rc=0
+gh_create_pr --repo o/r --title "t1: conflicting origins" --body "Resolves #1" \
+	--label "origin:worker,origin:interactive" >/dev/null 2>&1 || dual_origin_rc=$?
+if [[ "$dual_origin_rc" -eq 2 ]] && ! grep -q '^pr create ' "$GH_RECORD_FILE"; then
+	print_result "B9: gh_create_pr rejects conflicting origins before create" 0
+else
+	print_result "B9: gh_create_pr rejects conflicting origins before create" 1 \
+		"rc=${dual_origin_rc}; calls=$(tr '\n' ' ' <"$GH_RECORD_FILE")"
+fi
 
 # ---------------------------------------------------------------------------
 # Layer B': gh_create_issue defence-in-depth (mirrors PR tests)

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -50,6 +50,9 @@ define_functions_under_test() {
 		/^_attempt_pr_ci_rebase_retry\(\) \{/,/^}$/ { print }
 		/^_dispatch_pr_repair_by_kind\(\) \{/,/^}$/ { print }
 		/^_route_issue_origin_is_trusted\(\) \{/,/^}$/ { print }
+		/^_route_pr_issue_supplies_worker_origin\(\) \{/,/^}$/ { print }
+		/^_route_pr_log_unroutable\(\) \{/,/^}$/ { print }
+		/^_route_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_route_pr_issue_labels_for_dispatch\(\) \{/,/^}$/ { print }
 		/^_route_pr_feedback_terminal_guard\(\) \{/,/^}$/ { print }
 		/^_route_pr_to_fix_worker\(\) \{/,/^}$/ { print }
@@ -59,6 +62,9 @@ define_functions_under_test() {
 		return 1
 	fi
 	_OW_LABEL_PAT=',origin:worker,'
+	_PMP_ORIGIN_INTERACTIVE_PATTERN=',origin:interactive,'
+	_PMP_ORIGIN_WORKER_PATTERN=',origin:worker,'
+	_PMP_ORIGIN_TAKEOVER_PATTERN=',origin:worker-takeover,'
 	eval "$fn_src"
 	return 0
 }
@@ -67,6 +73,8 @@ install_stubs() {
 	ISSUE_LABELS="origin:worker,status:in-review"
 	ISSUE_METADATA_FAIL=0
 	PR_AUTHOR="maintainer"
+	SET_ORIGIN_RC=0
+	RECONCILED_PR_LABELS="origin:worker"
 	ROUTE_GUARD_RC=0
 	COMPARE_FAIL=0
 	COMPARE_BEHIND=1
@@ -102,7 +110,7 @@ install_stubs() {
 			return 0
 		fi
 		if [[ "$args" == *"labels"* ]]; then
-			printf 'origin:worker\n'
+			printf '%s\n' "${RECONCILED_PR_LABELS:-origin:worker}"
 			return 0
 		fi
 		if [[ "$args" == *"author"* ]]; then
@@ -119,6 +127,7 @@ install_stubs() {
 	_pulse_merge_admin_safety_check() { local pr_number="$1"; local repo_slug="$2"; local expected_head_sha="${3:-}"; printf 'admin-safety %s %s %s\n' "$pr_number" "$repo_slug" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$ADMIN_SAFETY_RC"; }
 	_pmp_update_branch_rest() { local pr_number="$1"; local repo_slug="$2"; local head_oid="$3"; printf 'update-branch %s %s %s\n' "$pr_number" "$repo_slug" "$head_oid" >>"$GH_CALL_LOG"; return "$UPDATE_BRANCH_RC"; }
 	_feedback_route_guard_existing_terminal_label() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; local kind="$4"; printf 'route-guard %s %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" "$kind" >>"$GH_CALL_LOG"; return "$ROUTE_GUARD_RC"; }
+	set_origin_label() { local pr_number="$1"; local repo_slug="$2"; local origin_name="$3"; local mode="${4:-}"; printf 'set-origin %s %s %s %s\n' "$pr_number" "$repo_slug" "$origin_name" "$mode" >>"$GH_CALL_LOG"; return "$SET_ORIGIN_RC"; }
 	_interactive_pr_is_stale() { return 1; }
 	_is_collaborator_author() { local author="$1"; [[ "$author" == "maintainer" ]]; return $?; }
 	return 0
@@ -247,7 +256,8 @@ test_route_falls_back_to_linked_worker_issue_for_ci() {
 	export PR_AUTHOR="maintainer"
 	_route_pr_to_fix_worker "8614" "owner/repo" "456" "ci" "status:in-review" || true
 
-	if ! grep -q "dispatch-ci 8614 owner/repo 456" "$GH_CALL_LOG"; then
+	if ! grep -q "dispatch-ci 8614 owner/repo 456" "$GH_CALL_LOG" \
+		|| ! grep -q "set-origin 8614 owner/repo worker --pr" "$GH_CALL_LOG"; then
 		fail "fix-worker route falls back to linked worker issue for CI" "Expected CI dispatch: $(cat "$GH_CALL_LOG")"
 		return 0
 	fi
@@ -284,6 +294,43 @@ test_issue_origin_fallback_requires_collaborator_pr_author() {
 		return 0
 	fi
 	pass "issue-origin fallback requires collaborator PR author"
+	return 0
+}
+
+test_issue_origin_reconciliation_failure_is_retryable() {
+	install_stubs
+	SET_ORIGIN_RC=1
+	: >"$GH_CALL_LOG"
+	local route_rc=0
+	_route_pr_to_fix_worker "8615" "owner/repo" "456" "ci" "status:in-review" || route_rc=$?
+	if [[ "$route_rc" -ne 75 ]] || grep -q "dispatch-ci" "$GH_CALL_LOG" \
+		|| ! grep -q "set-origin 8615 owner/repo worker --pr" "$GH_CALL_LOG"; then
+		fail "issue-origin reconciliation failure is retryable" \
+			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	if ! grep -q "origin reconciliation failed — deferring routing" "$LOGFILE"; then
+		fail "issue-origin reconciliation failure is retryable" "missing bounded diagnostic"
+		return 0
+	fi
+	pass "issue-origin reconciliation failure defers without dispatch"
+	return 0
+}
+
+test_missing_origin_has_terminal_diagnostic() {
+	install_stubs
+	ISSUE_LABELS="status:in-review"
+	: >"$LOGFILE"
+	: >"$GH_CALL_LOG"
+	local route_rc=0
+	_route_pr_to_fix_worker "8616" "owner/repo" "456" "review" "status:in-review" || route_rc=$?
+	if [[ "$route_rc" -ne 1 ]] || grep -q "dispatch-review" "$GH_CALL_LOG" \
+		|| ! grep -q "have no trusted origin metadata for review repair routing" "$LOGFILE"; then
+		fail "missing origin has terminal diagnostic" \
+			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG"); log=$(tr '\n' ';' <"$LOGFILE")"
+		return 0
+	fi
+	pass "missing PR and issue origin emits bounded routing diagnostic"
 	return 0
 }
 
@@ -456,6 +503,8 @@ main() {
 	test_route_falls_back_to_linked_worker_issue_for_ci
 	test_route_falls_back_to_linked_worker_issue_for_conflict
 	test_issue_origin_fallback_requires_collaborator_pr_author
+	test_issue_origin_reconciliation_failure_is_retryable
+	test_missing_origin_has_terminal_diagnostic
 	test_fresh_interactive_pr_is_not_routed
 	test_interactive_route_requires_confirmed_handover
 	test_interactive_route_dispatches_after_confirmed_takeover


### PR DESCRIPTION
## Summary

Preserve durable PR URLs with typed partial-success status, reconcile exact origin provenance in the shared wrapper, and restore trusted worker routing with bounded diagnostics.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-gh-wrapper-stdin.sh, .agents/scripts/tests/test-origin-label-mutex-create.sh, .agents/scripts/tests/test-pulse-merge-pr-context.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local quality gates passed; focused shell suites passed 240 assertions across REST fallback, origin mutex, pulse routing, full-loop reconciliation, fix-worker dispatch, standalone sourcing, and stdin handling.

Resolves #30448


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 54m and 757,512 tokens on this with the user in an interactive session.