### PR TITLE
GH#30446: add trust-gated CI repair-only routing

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -799,8 +799,9 @@ _pr_required_checks_pass() {
 # Returns 0 if update-branch succeeded (caller should skip fix-worker
 # routing and let the next pulse cycle re-check CI on the rebased HEAD).
 # Returns 1 if the PR is already up-to-date with its base or if update-branch
-# failed. Standard callers may route a fix worker; review-repair callers must
-# preserve CHANGES_REQUESTED and return without merge or feedback routing.
+# failed. Standard callers may route a fix worker. Review-repair callers must
+# preserve CHANGES_REQUESTED; a typed caller may separately evaluate trust-gated
+# CI repair after a no-op, but must always return before merge.
 #
 # Rate-limit: one call per PR per merge cycle — same as t2116.
 #
@@ -989,6 +990,59 @@ _attempt_green_behind_update_branch() {
 	fi
 
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: green but BEHIND without native auto-merge — update-branch failed, falling through: ${_ub_output}" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
+# Keep a converged CHANGES_REQUESTED PR on a strictly non-merge path while
+# evaluating bounded branch refresh and CI repair. All caller-side trust gates
+# have already passed for the exact PR/head; the CI router independently binds
+# actionable terminal failures to the live head before dispatch.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=base_ref, $4=head_sha,
+#       $5=linked_issue, $6=pr_labels, $7=updated_at, $8=repair_mode
+# Returns: 1 always so review-blocked PRs never fall through toward merge.
+#######################################
+_handle_review_blocked_ci_repair() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local base_ref="$3"
+	local head_sha="$4"
+	local linked_issue="$5"
+	local pr_labels="$6"
+	local updated_at="$7"
+	local repair_mode="$8"
+	local ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
+	local route_rc=0
+
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} remains CHANGES_REQUESTED; would evaluate ${repair_mode}" >>"$LOGFILE"
+		return 1
+	fi
+	if _attempt_pr_ci_rebase_retry "$pr_number" "$repo_slug" "$base_ref" "$head_sha" "review-repair"; then
+		return 1
+	fi
+	if [[ "$repair_mode" == "$ci_rebase_only" ]]; then
+		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — CHANGES_REQUESTED remains blocking and strict CI-drift rebase was not eligible or did not succeed" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$repair_mode" != "$ci_repair_only" ]]; then
+		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — unknown review-blocked CI repair mode ${repair_mode}" >>"$LOGFILE"
+		return 1
+	fi
+	if _pr_required_checks_pass "$pr_number" "$repo_slug"; then
+		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — CHANGES_REQUESTED remains blocking and required checks do not need CI repair" >>"$LOGFILE"
+		return 1
+	fi
+
+	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$updated_at" "$head_sha" || route_rc=$?
+	if [[ "$route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+		echo "[pulse-wrapper] Merge pass: CI repair-only route for PR #${pr_number} in ${repo_slug} remains partial; preserving the PR for retry or maintainer review" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — CHANGES_REQUESTED remains blocking after trust-gated CI repair evaluation" >>"$LOGFILE"
+	fi
 	return 1
 }
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -81,6 +81,7 @@ PULSE_MERGE_BOOL_TRUE="true"
 _PULSE_MERGE_REMEDIATION_OUTCOME=""
 PULSE_REVIEW_DECISION_CHANGES_REQUESTED="CHANGES_REQUESTED"
 PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY="ci-rebase-only"
+PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY="ci-repair-only"
 
 # t2863: Module-level variable defaults (set -u guards).
 # When this module is sourced standalone (e.g. pulse-merge-routine.sh, test
@@ -332,7 +333,7 @@ source "${_PULSE_MERGE_DIR}/pulse-merge-required-checks.sh"
 #
 # Returns 0 if the caller may keep evaluating merge gates.
 # Returns 1 if the PR remains review-blocked. A converged remediation may also
-# set review_gate_mode_dest_var=ci-rebase-only for an explicit repair-only path.
+# set review_gate_mode_dest_var=ci-repair-only for an explicit repair-only path.
 # Args: $1=pr_number, $2=repo_slug, $3=pr_review, $4=linked_issue, $5=pr_labels (optional),
 #       $6=dismissed_dest_var (optional), $7=review_gate_mode_dest_var (optional)
 #######################################
@@ -346,7 +347,7 @@ _handle_changes_requested_review_gate() {
 	local review_gate_mode_dest_var="${7:-}"
 	local _cr_pr_labels=""
 	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
-	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
 
 	if [[ -n "$dismissed_dest_var" && "$dismissed_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
 		printf -v "$dismissed_dest_var" '%s' "0"
@@ -397,9 +398,9 @@ _handle_changes_requested_review_gate() {
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; response remediation already active/deferred, preserving PR" >>"$LOGFILE"
 		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "converged" ]]; then
 			if [[ -n "$review_gate_mode_dest_var" && "$review_gate_mode_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-				printf -v "$review_gate_mode_dest_var" '%s' "$_ci_rebase_only"
+				printf -v "$review_gate_mode_dest_var" '%s' "$_ci_repair_only"
 			fi
-			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; no matching unresolved thread remained after refresh, preserving the review block while allowing trust-gated CI-drift repair evaluation" >>"$LOGFILE"
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; no matching unresolved thread remained after refresh, preserving the review block while allowing trust-gated CI repair evaluation" >>"$LOGFILE"
 		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "maintainer_attention" ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; terminal review-thread maintainer attention pending, preserving PR" >>"$LOGFILE"
 		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "$PULSE_REVIEW_REMEDIATION_REPEAT_EXHAUSTED" ]]; then
@@ -426,11 +427,11 @@ _handle_changes_requested_review_gate() {
 #######################################
 # Run all merge-eligibility or repair-authority gate checks for a single PR.
 # Returns 0 if all gates for the requested mode pass. Only merge mode permits
-# the caller to proceed toward merge; ci-rebase-only must return after repair.
+# the caller to proceed toward merge; repair-only modes must return after repair.
 # Returns 1 if any gate fails (PR should be skipped).
 # Args: $1=pr_number, $2=repo_slug, $3=pr_author, $4=pr_review, $5=linked_issue,
 #       $6=pr_labels (optional), $7=expected_head_sha (optional),
-#       $8=review_gate_mode (optional: merge|ci-rebase-only)
+#       $8=review_gate_mode (optional: merge|ci-rebase-only|ci-repair-only)
 #######################################
 _check_pr_merge_gates() {
 	local pr_number="$1"
@@ -443,6 +444,7 @@ _check_pr_merge_gates() {
 	local review_gate_mode="${8:-merge}"
 	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
 	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
 	local _dependabot_intake_rc=0
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 	if [[ -n "$linked_issue" ]] &&
@@ -472,12 +474,12 @@ _check_pr_merge_gates() {
 			return 1
 		fi
 		;;
-	"$_ci_rebase_only")
+	"$_ci_rebase_only" | "$_ci_repair_only")
 		# The early review gate already proved remediation converged. Skip only
 		# repeated review routing so the normal non-review trust gates can run.
 		# The caller must remain on the repair-only path and return before merge.
 		if [[ "$pr_review" != "$_changes_requested" ]]; then
-			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — ci-rebase-only review mode requires CHANGES_REQUESTED" >>"$LOGFILE"
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — ${review_gate_mode} review mode requires CHANGES_REQUESTED" >>"$LOGFILE"
 			return 1
 		fi
 		;;
@@ -612,12 +614,15 @@ _check_pr_merge_gates() {
 	fi
 
 	# A converged CHANGES_REQUESTED remediation may perform a branch repair,
-	# but it cannot satisfy review. The ownership, permission, maintainer, and
-	# worker-brief trust gates above still apply; the review-bot gate remains a
-	# merge-only boundary and is re-evaluated on a later cycle after review.
+	# but it cannot satisfy review. Preserve the existing narrow rebase-only
+	# boundary; broader CI repair must also pass current-head review-bot evidence
+	# below before it receives worker-dispatch authority.
 	if [[ "$review_gate_mode" == "$_ci_rebase_only" ]]; then
-		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ci-rebase-only evaluation; CHANGES_REQUESTED remains blocking" >>"$LOGFILE"
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ${review_gate_mode} evaluation; CHANGES_REQUESTED remains blocking" >>"$LOGFILE"
 		return 0
+	fi
+	if [[ "$review_gate_mode" == "$_ci_repair_only" ]]; then
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ${review_gate_mode} evaluation; requiring current-head review-bot evidence before CI repair" >>"$LOGFILE"
 	fi
 
 	# ── Review bot gate (GH#17490) ──
@@ -1591,6 +1596,7 @@ _process_single_ready_pr() {
 	local _review_gate_mode="merge"
 	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
 	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
 	if [[ "$pr_review" == "$_changes_requested" ]]; then
 		if [[ "${DRY_RUN:-0}" == "1" ]]; then
 			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has CHANGES_REQUESTED; would evaluate review remediation or repair routing" >>"$LOGFILE"
@@ -1600,7 +1606,7 @@ _process_single_ready_pr() {
 		local _early_review_dismissed="0"
 		_early_review_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || _early_review_linked_issue=""
 		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$_early_review_linked_issue" "$pr_labels" _early_review_dismissed _review_gate_mode; then
-			if [[ "$_review_gate_mode" != "$_ci_rebase_only" ]]; then
+			if [[ "$_review_gate_mode" != "$_ci_rebase_only" && "$_review_gate_mode" != "$_ci_repair_only" ]]; then
 				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 				return 1
 			fi
@@ -1640,7 +1646,7 @@ _process_single_ready_pr() {
 
 	# Repair-only mode must reach its strict update guard without any terminal PR
 	# mutation; CHANGES_REQUESTED still owns the PR lifecycle in this cycle.
-	if [[ "$_review_gate_mode" != "$_ci_rebase_only" ]] \
+	if [[ "$_review_gate_mode" != "$_ci_rebase_only" && "$_review_gate_mode" != "$_ci_repair_only" ]] \
 		&& [[ "${DRY_RUN:-0}" != "1" ]] \
 		&& declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
 		&& _pm_close_superseded_duplicate_pr_if_issue_solved "$pr_number" "$repo_slug" "$linked_issue" "$pr_labels"; then
@@ -1648,21 +1654,13 @@ _process_single_ready_pr() {
 	fi
 
 	# A converged response-remediation cycle does not clear CHANGES_REQUESTED.
-	# It authorizes one narrowly bounded repair attempt only: all normal trust
-	# gates above must pass, the current head must have settled terminal-failure
-	# evidence, and the branch must be explicitly behind. Always return here so
-	# passing or indeterminate CI can never turn this mode into a merge bypass.
-	if [[ "$_review_gate_mode" == "$_ci_rebase_only" ]]; then
-		if [[ "${DRY_RUN:-0}" == "1" ]]; then
-			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} remains CHANGES_REQUESTED; would evaluate strict CI-drift rebase only" >>"$LOGFILE"
-			return 1
-		fi
+	# It authorizes only the typed, non-merge repair path selected above. Always
+	# return after that evaluation so green, pending, or indeterminate CI can
+	# never turn review remediation into a merge bypass.
+	if [[ "$_review_gate_mode" == "$_ci_rebase_only" || "$_review_gate_mode" == "$_ci_repair_only" ]]; then
 		[[ -n "$timing_prefix" ]] && _branch_protection_start=$(_pmp_now_epoch)
-		if _attempt_pr_ci_rebase_retry "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid" "review-repair"; then
-			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
-			return 1
-		fi
-		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — CHANGES_REQUESTED remains blocking and strict CI-drift rebase was not eligible or did not succeed" >>"$LOGFILE"
+		_handle_review_blocked_ci_repair "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid" \
+			"$linked_issue" "$pr_labels" "$pr_updated_at" "$_review_gate_mode" || true
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 FEEDBACK_SCRIPT="${SCRIPT_DIR}/../pulse-merge-feedback.sh"
 FINALIZER_SCRIPT="${SCRIPT_DIR}/../pulse-merge-feedback-finalizer.sh"
 
@@ -366,12 +367,16 @@ extract_function() {
 }
 
 define_process_helper() {
-	local fn_src="" review_gate_src=""
+	local fn_src="" repair_helper_src="" review_gate_src=""
 	review_gate_src=$(extract_function _handle_changes_requested_review_gate "$MERGE_SCRIPT")
+	repair_helper_src=$(extract_function _handle_review_blocked_ci_repair "$PROCESS_SCRIPT")
 	fn_src=$(extract_function _process_single_ready_pr "$MERGE_SCRIPT")
-	[[ -n "$review_gate_src" && -n "$fn_src" ]] || return 1
+	[[ -n "$review_gate_src" && -n "$repair_helper_src" && -n "$fn_src" ]] || return 1
 
 	_OW_LABEL_PAT=",origin:worker,"
+	PULSE_MERGE_BOOL_TRUE="true"
+	PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
+	PULSE_REVIEW_REMEDIATION_REPEAT_EXHAUSTED="repeat_exhausted"
 	PULSE_UNKNOWN_STATE="UNKNOWN"
 	PULSE_MERGE_CLOSE_CONFLICTING=false
 	DRY_RUN=0
@@ -444,6 +449,8 @@ define_process_helper() {
 
 	# shellcheck disable=SC1090
 	eval "$review_gate_src"
+	# shellcheck disable=SC1090
+	eval "$repair_helper_src"
 	# shellcheck disable=SC1090
 	eval "$fn_src"
 	return 0
@@ -581,7 +588,7 @@ test_rebase_success_defers_ci_repair_route() {
 	return 0
 }
 
-test_converged_changes_requested_runs_strict_rebase_only() {
+test_converged_changes_requested_prefers_strict_rebase_before_ci_repair() {
 	setup_test_env
 	define_process_helper || { print_result "defines process helper for review-repair rebase" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
 	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 0; }
@@ -595,7 +602,7 @@ test_converged_changes_requested_runs_strict_rebase_only() {
 
 	if [[ "$rc" -ne 1 ]]; then
 		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "Expected skip return 1, got ${rc}"
-	elif [[ "$GATE_CALLS" -ne 1 || "$GATE_REVIEW_ARG" != "CHANGES_REQUESTED" || "$GATE_REVIEW_MODE" != "ci-rebase-only" ]]; then
+	elif [[ "$GATE_CALLS" -ne 1 || "$GATE_REVIEW_ARG" != "CHANGES_REQUESTED" || "$GATE_REVIEW_MODE" != "ci-repair-only" ]]; then
 		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "gate_calls=${GATE_CALLS}, gate_review=${GATE_REVIEW_ARG}, gate_mode=${GATE_REVIEW_MODE}"
 	elif [[ "$REBASE_RETRY_CALLS" -ne 1 || "$REBASE_RETRY_POLICY" != "review-repair" ]]; then
 		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "rebase_calls=${REBASE_RETRY_CALLS}, policy=${REBASE_RETRY_POLICY}"
@@ -604,7 +611,32 @@ test_converged_changes_requested_runs_strict_rebase_only() {
 	elif [[ "$ROUTE_CALLS" -ne 0 ]]; then
 		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
 	else
-		print_result "converged CHANGES_REQUESTED runs trust-gated strict rebase only" 0
+		print_result "converged CHANGES_REQUESTED prefers trust-gated strict rebase before CI repair" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_converged_changes_requested_routes_terminal_ci_after_rebase_noop() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for review-blocked CI repair" 1 "could not extract repair helpers"; teardown_test_env; return 0; }
+	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 0; }
+	_pulse_merge_dispatch_review_thread_remediation() { _PULSE_MERGE_REMEDIATION_OUTCOME="converged"; return 0; }
+
+	local pr_object rc=0
+	PR_REQUIRED_CHECKS_RC=1
+	REBASE_RETRY_RC=1
+	printf -v pr_object '%s' '{"number":561,"state":"OPEN","mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#505: repair terminal CI","updatedAt":"2026-08-03T00:00:00Z","headRefOid":"sha561","headRefName":"fix/review-ci","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"}],"isDraft":false}'
+	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "converged CHANGES_REQUESTED routes terminal CI after rebase no-op" 1 "Expected skip return 1, got ${rc}"
+	elif [[ "$GATE_REVIEW_MODE" != "ci-repair-only" || "$REBASE_RETRY_CALLS" -ne 1 ]]; then
+		print_result "converged CHANGES_REQUESTED routes terminal CI after rebase no-op" 1 "gate_mode=${GATE_REVIEW_MODE}, rebase_calls=${REBASE_RETRY_CALLS}"
+	elif [[ "$ROUTE_CALLS" -ne 1 || "$ROUTE_ARGS" != "561|owner/repo|42|ci" ]]; then
+		print_result "converged CHANGES_REQUESTED routes terminal CI after rebase no-op" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
+	else
+		print_result "converged CHANGES_REQUESTED routes one trust-gated terminal CI repair" 0
 	fi
 	teardown_test_env
 	return 0
@@ -631,7 +663,7 @@ test_converged_changes_requested_never_falls_through_to_merge() {
 	return 0
 }
 
-test_repair_only_gate_stops_before_review_bot_boundary() {
+test_ci_rebase_only_gate_stops_before_review_bot_boundary() {
 	setup_test_env
 	define_process_helper || { print_result "defines repair-only gate helper" 1 "could not extract review gate"; teardown_test_env; return 0; }
 	local gate_src="" gate_rc=0 review_bot_calls=0
@@ -675,6 +707,60 @@ test_repair_only_gate_stops_before_review_bot_boundary() {
 		print_result "repair-only gate stops before review-bot boundary" 1 "gate_rc=${gate_rc}, review_bot_calls=${review_bot_calls}"
 	else
 		print_result "repair-only mode applies non-review trust gates without treating review as cleared" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_only_gate_requires_review_bot_boundary() {
+	setup_test_env
+	define_process_helper || { print_result "defines CI repair-only gate helper" 1 "could not extract review gate"; teardown_test_env; return 0; }
+	local gate_src="" gate_rc=0
+	local old_agents_dir="${AGENTS_DIR:-}"
+	local review_bot_log="${TEST_ROOT}/review-bot.log"
+	gate_src=$(extract_function _check_pr_merge_gates "$MERGE_SCRIPT")
+	if [[ -z "$gate_src" ]]; then
+		print_result "CI repair-only gate requires review-bot boundary" 1 "could not extract _check_pr_merge_gates"
+		teardown_test_env
+		return 0
+	fi
+	AGENTS_DIR="${TEST_ROOT}/agents"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	: >"${AGENTS_DIR}/scripts/review-bot-gate-helper.sh"
+	_is_collaborator_author() { _PULSE_AUTHOR_PERMISSION_VALUE="write"; return 0; }
+	check_pr_modifies_workflows() { return 1; }
+	_pm_issue_api() { local repo_slug="$1" issue_number="$2"; printf 'repos/%s/issues/%s\n' "$repo_slug" "$issue_number"; return 0; }
+	gh() { return 0; }
+	gh_pr_view() {
+		if [[ "$*" == *"labels,isDraft"* ]]; then
+			printf '%s\n' '{"labels":[{"name":"origin:worker"}],"isDraft":false}'
+		else
+			printf 'origin:worker\n'
+		fi
+		return 0
+	}
+	_attempt_worker_briefed_auto_merge() { return 0; }
+	bash() {
+		printf 'called\n' >>"$review_bot_log"
+		printf '%s\n' '{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":560,"head_sha":"sha560","status":"PASS","permitted":true,"state":"pass","merge_gate":"clear"}'
+		return 0
+	}
+	# shellcheck disable=SC1090
+	eval "$gate_src"
+
+	_check_pr_merge_gates "560" "owner/repo" "worker-bot" "CHANGES_REQUESTED" "42" "origin:worker" "sha560" "ci-repair-only" || gate_rc=$?
+	unset -f bash gh gh_pr_view _is_collaborator_author check_pr_modifies_workflows \
+		_pm_issue_api _attempt_worker_briefed_auto_merge _check_pr_merge_gates
+	if [[ -n "$old_agents_dir" ]]; then
+		AGENTS_DIR="$old_agents_dir"
+	else
+		unset AGENTS_DIR
+	fi
+
+	if [[ "$gate_rc" -ne 0 || ! -s "$review_bot_log" ]]; then
+		print_result "CI repair-only gate requires review-bot boundary" 1 "gate_rc=${gate_rc}, review_bot_calls=$(wc -l <"$review_bot_log")"
+	else
+		print_result "CI repair-only mode requires current-head review-bot evidence" 0
 	fi
 	teardown_test_env
 	return 0
@@ -1315,9 +1401,11 @@ test_ci_feedback_includes_required_and_advisory_failures_together() {
 main() {
 	test_red_pr_passes_gates_before_repair_route
 	test_rebase_success_defers_ci_repair_route
-	test_converged_changes_requested_runs_strict_rebase_only
+	test_converged_changes_requested_prefers_strict_rebase_before_ci_repair
+	test_converged_changes_requested_routes_terminal_ci_after_rebase_noop
 	test_converged_changes_requested_never_falls_through_to_merge
-	test_repair_only_gate_stops_before_review_bot_boundary
+	test_ci_rebase_only_gate_stops_before_review_bot_boundary
+	test_ci_repair_only_gate_requires_review_bot_boundary
 	test_preflight_terminal_blocker_routes_supplied_evidence
 	test_changes_requested_unknown_routes_before_mergeable_skip
 	test_rest_missing_review_decision_refreshes_before_ci_route

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -513,8 +513,8 @@ test_changes_requested_converged_remediation_exposes_repair_only_mode() {
 	local gate_rc=0
 
 	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" "" review_gate_mode || gate_rc=$?
-	if [[ "$gate_rc" -eq 1 && "$review_gate_mode" == "ci-rebase-only" && ! -s "$route_log" ]] &&
-		grep -q 'preserving the review block while allowing trust-gated CI-drift repair evaluation' "$LOGFILE"; then
+	if [[ "$gate_rc" -eq 1 && "$review_gate_mode" == "ci-repair-only" && ! -s "$route_log" ]] &&
+		grep -q 'preserving the review block while allowing trust-gated CI repair evaluation' "$LOGFILE"; then
 		print_result "converged response remediation exposes repair-only mode" 0
 	else
 		print_result "converged response remediation exposes repair-only mode" 1 \


### PR DESCRIPTION
## Summary

Add a typed non-merge path that preserves CHANGES_REQUESTED, prefers strict behind-base rebasing, and routes exact-head terminal CI failures through existing trust-gated repair orchestration.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified with test-pulse-merge-ci-repair-routing.sh (38/38), test-pulse-merge-review-thread-remediation.sh (24/24), ShellCheck, git diff --check, and linters-local.sh; independent closeout review found no P0-P2 defects.

Resolves #30446


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 5h 46m and 2,240,266 tokens on this with the user in an interactive session.