### PR TITLE
GH#30461: fix(pulse): defer consolidation for live claims

### DIFF
--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -14,6 +14,7 @@
 #   - _post_simplification_gate_cleared_comment
 #   - _reevaluate_stale_continuations
 #   - _reevaluate_simplification_labels
+#   - _consolidation_live_interactive_claim
 #   - _consolidation_child_exists
 #   - _consolidation_resolving_pr_exists
 #   - _consolidation_substantive_comments
@@ -79,6 +80,77 @@ _clear_needs_consolidation_label() {
 		--remove-label "needs-consolidation" >/dev/null 2>&1 || true
 	echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — ${reason}" >>"$LOGFILE"
 	return 0
+}
+
+#######################################
+# Return whether an issue has a fresh, positively verified interactive claim.
+# This mirrors stale-assignment recovery's ownership proof: a signed claim
+# comment must be recent, its author must still be assigned, and the open
+# issue must retain status:in-review. API or timestamp ambiguity returns 2 so
+# consolidation defers rather than creating a conflicting planning task.
+# Args: $1=issue_number $2=repo_slug
+# Returns: 0=live claim, 1=no live claim, 2=ambiguous read
+#######################################
+_consolidation_live_interactive_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_meta_json="" comments_json="" claim_record=""
+	local claim_timestamp="" claim_author="" claim_epoch="" now_epoch=""
+	local claim_age=0 stale_threshold="${INTERACTIVE_STALE_THRESHOLD_SECONDS:-7200}"
+
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --jq '.' 2>/dev/null) || return 2
+	claim_record=$(printf '%s' "$comments_json" | jq -r '
+		[.[] | if type == "array" then .[] else . end
+		 | select((.body // "") | contains("<!-- aidevops-interactive-claim/v1 -->"))
+		 | [(.created_at // .createdAt // ""), (.user.login // .author.login // "")] | @tsv]
+		| last // empty
+	' 2>/dev/null) || return 2
+	[[ -n "$claim_record" ]] || return 1
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees 2>/dev/null) || return 2
+	IFS=$'\t' read -r claim_timestamp claim_author <<<"$claim_record"
+	[[ -n "$claim_timestamp" && -n "$claim_author" ]] || return 2
+	claim_epoch=$(date -u -d "$claim_timestamp" +%s 2>/dev/null) ||
+		claim_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$claim_timestamp" +%s 2>/dev/null) || return 2
+	now_epoch=$(date +%s) || return 2
+	[[ "$claim_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$stale_threshold" =~ ^[0-9]+$ ]] || return 2
+	claim_age=$((now_epoch - claim_epoch))
+	[[ "$claim_age" -ge 0 && "$claim_age" -lt "$stale_threshold" ]] || return 1
+
+	if printf '%s' "$issue_meta_json" | jq -e --arg claimant "$claim_author" '
+		(.state | ascii_downcase) == "open" and
+		([.labels[]?.name] | index("status:in-review") != null) and
+		([.assignees[]?.login] | index($claimant) != null)
+	' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+_consolidation_dispatch_defers_for_interactive_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local interactive_claim_rc=0
+
+	_consolidation_live_interactive_claim "$issue_number" "$repo_slug" || interactive_claim_rc=$?
+	if [[ "$interactive_claim_rc" -eq 0 || "$interactive_claim_rc" -eq 2 ]]; then
+		echo "[pulse-wrapper] Consolidation: live or unreadable interactive ownership for #${issue_number} in ${repo_slug}; deferring dispatch" >>"$LOGFILE"
+		return 0
+	fi
+	return 1
+}
+
+_consolidation_dispatch_preflight_skips() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	_consolidation_skip_if_resolved "$issue_number" "$repo_slug" && return 0
+	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
+		echo "[pulse-wrapper] Consolidation: in-flight resolving PR exists for #${issue_number} in ${repo_slug}; skipping dispatch (t2161)" >>"$LOGFILE"
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -228,12 +300,12 @@ _reevaluate_stale_continuations() {
 		grep -oE '[0-9]+') || continuation_nums=""
 	[[ -n "$continuation_nums" ]] || return 1
 
-	local all_stale="true"
+	local all_stale=1
 	local cont_num
 	while IFS= read -r cont_num; do
 		[[ "$cont_num" =~ ^[0-9]+$ ]] || continue
 		if ! _pte_rest_core_deferrable_allows_next "simplification_continuation:${repo_slug}#${issue_number}:${cont_num}"; then
-			all_stale="false"
+			all_stale=0
 			break
 		fi
 
@@ -241,14 +313,14 @@ _reevaluate_stale_continuations() {
 		cont_info=$(gh issue view "$cont_num" --repo "$repo_slug" \
 			--json state,labels,title 2>/dev/null) || cont_info=""
 		if [[ -z "$cont_info" ]]; then
-			all_stale="false"
+			all_stale=0
 			break # Unresolvable → conservative
 		fi
 
 		cont_state=$(printf '%s' "$cont_info" | jq -r '.state // "OPEN"' 2>/dev/null)
 		cont_state_upper=$(printf '%s' "$cont_state" | tr '[:lower:]' '[:upper:]')
 		if [[ "$cont_state_upper" != "CLOSED" ]]; then
-			all_stale="false"
+			all_stale=0
 			break # Open → work in progress
 		fi
 
@@ -267,25 +339,25 @@ _reevaluate_stale_continuations() {
 		cont_file_path=$(printf '%s' "$cont_title" |
 			sed 's/^file-size-debt: //;s/^simplification-debt: //;s/ exceeds [0-9]* lines$//' 2>/dev/null) || cont_file_path=""
 		if [[ -z "$cont_file_path" || "$cont_file_path" == "$cont_title" ]]; then
-			all_stale="false"
+			all_stale=0
 			break # Path unresolvable → conservative
 		fi
 
 		# Guard: function is in pulse-dispatch-large-file-gate.sh (sourced first)
 		if ! declare -F _large_file_gate_verify_prior_reduced_size >/dev/null 2>&1; then
-			all_stale="false"
+			all_stale=0
 			break # Function unavailable → conservative
 		fi
 
 		# Returns 0 = file under threshold (valid), 1 = still over (stale)
 		if _large_file_gate_verify_prior_reduced_size \
 			"$cont_num" "$cont_file_path" "$repo_path"; then
-			all_stale="false"
+			all_stale=0
 			break # Prior work was effective → valid citation
 		fi
 	done < <(printf '%s\n' "$continuation_nums")
 
-	if [[ "$all_stale" == "true" ]]; then
+	if [[ "$all_stale" -eq 1 ]]; then
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--remove-label "needs-simplification" >/dev/null 2>&1 || true
 		echo "[pulse-triage] Cleared stale needs-simplification on #${issue_number} (all cited continuations phantom; next dispatch will re-evaluate the gate)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -143,6 +143,17 @@ _issue_needs_consolidation() {
 	if [[ ",$issue_labels," == *",needs-consolidation,"* ]]; then
 		was_already_labeled=true
 	fi
+	# A fresh interactive claim is stronger evidence of live ownership than a
+	# comment-count heuristic. Clear any stale planning label, but defer on an
+	# ambiguous ownership read so a transient API failure cannot create a child.
+	local interactive_claim_rc=0
+	_consolidation_live_interactive_claim "$issue_number" "$repo_slug" || interactive_claim_rc=$?
+	if [[ "$interactive_claim_rc" -eq 0 ]]; then
+		[[ "$was_already_labeled" != false ]] &&
+			_clear_needs_consolidation_label "$issue_number" "$repo_slug" "live interactive claim exists"
+		return 1
+	fi
+	[[ "$interactive_claim_rc" -eq 2 ]] && return 1
 	# t2161: Defence-in-depth — if an open PR already resolves this parent
 	# (closing keyword + #N), the work is in flight. Skip consolidation
 	# regardless of substantive-comment count. This catches the cascade
@@ -246,16 +257,18 @@ _dispatch_issue_consolidation() {
 	local repo_slug="$2"
 	local repo_path="$3"
 
+	# Re-check immediately before any visible consolidation mutation. This
+	# closes the classification-to-dispatch race when an interactive session
+	# claims the issue between pulse stages; ambiguity must defer safely too.
+	if _consolidation_dispatch_defers_for_interactive_claim "$issue_number" "$repo_slug"; then
+		return 0
+	fi
+
 	# Ensure labels exist on this repo up front. Idempotent (--force).
 	_ensure_consolidation_labels "$repo_slug"
 
-	# t3050: pre-flight skip when parent work already resolved. Fail-open.
-	_consolidation_skip_if_resolved "$issue_number" "$repo_slug" && return 0
-
-	# t2161: skip if a resolving PR already exists — defence-in-depth vs
-	# cross-runner version drift; cheaper than child_exists, runs first.
-	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
-		echo "[pulse-wrapper] Consolidation: in-flight resolving PR exists for #${issue_number} in ${repo_slug}; skipping dispatch (t2161)" >>"$LOGFILE"
+	# Resolve and in-flight-PR checks precede child/lock acquisition.
+	if _consolidation_dispatch_preflight_skips "$issue_number" "$repo_slug"; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -98,6 +98,13 @@ issue-view)
 	title) printf '%s\n' "${GH_ISSUE_VIEW_TITLE:-Parent Title}" ;;
 	body) printf '%s\n' "${GH_ISSUE_VIEW_BODY:-Parent body}" ;;
 	labels) printf '%s\n' "${GH_ISSUE_VIEW_LABELS:-bug,tier:standard}" ;;
+	state,labels,assignees)
+		if [[ -n "${GH_ISSUE_META_JSON:-}" ]]; then
+			printf '%s\n' "$GH_ISSUE_META_JSON"
+		else
+			printf '%s\n' '{"state":"OPEN","labels":[],"assignees":[]}'
+		fi
+		;;
 	state,closedAt)
 		[[ "${GH_ISSUE_VIEW_STATE_FAIL:-0}" == "1" ]] && exit 1
 		if [[ -n "${GH_ISSUE_VIEW_STATE_JSON:-}" ]]; then
@@ -217,7 +224,7 @@ teardown_gh_stub() {
 	fi
 	TEST_ROOT=""
 	GH_LOG=""
-	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS GH_ISSUE_VIEW_STATE_JSON GH_ISSUE_VIEW_STATE_FAIL
+	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS GH_ISSUE_VIEW_STATE_JSON GH_ISSUE_VIEW_STATE_FAIL GH_ISSUE_META_JSON
 	unset GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON GH_ISSUE_CREATE_URL
 	unset GH_ISSUE_LIST_FAIL
 	unset GH_PR_LIST_RESOLVING_JSON
@@ -1170,6 +1177,58 @@ test_dispatch_skips_with_inflight_resolving_pr() {
 	return 0
 }
 
+fixture_live_interactive_claim() {
+	local claim_time
+	claim_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	jq -n --arg timestamp "$claim_time" '[{
+		"created_at": $timestamp,
+		"user": {"login": "interactive-owner", "type": "User"},
+		"body": "<!-- aidevops-interactive-claim/v1 -->\n<!-- ops:start -->\n> Interactive session claimed by @interactive-owner.\n<!-- ops:end -->"
+	}]'
+	return 0
+}
+
+test_live_interactive_claim_blocks_classification_and_clears_stale_label() {
+	setup_gh_stub
+	GH_ISSUE_VIEW_LABELS="bug,needs-consolidation,status:in-review"
+	GH_ISSUE_META_JSON=$(jq -n '{state: "OPEN", labels: [{name: "status:in-review"}], assignees: [{login: "interactive-owner"}]}')
+	GH_API_COMMENTS_JSON=$(fixture_live_interactive_claim)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_VIEW_LABELS GH_ISSUE_META_JSON GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON
+
+	if _issue_needs_consolidation 30461 "marcusquinn/aidevops"; then
+		print_result "live interactive claim blocks consolidation classification" 1
+	elif grep -qE 'issue edit .* --remove-label needs-consolidation' "$GH_LOG" 2>/dev/null; then
+		print_result "live interactive claim blocks consolidation classification and clears stale label" 0
+	else
+		print_result "live interactive claim blocks consolidation classification and clears stale label" 1 \
+			"expected stale needs-consolidation cleanup"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+test_live_interactive_claim_appearing_after_classification_blocks_dispatch() {
+	setup_gh_stub
+	GH_ISSUE_META_JSON=$(jq -n '{state: "OPEN", labels: [{name: "status:in-review"}], assignees: [{login: "interactive-owner"}]}')
+	GH_API_COMMENTS_JSON=$(fixture_live_interactive_claim)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_META_JSON GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON
+
+	_dispatch_issue_consolidation 30461 "marcusquinn/aidevops" "/tmp/fake-path" || true
+
+	if grep -qE 'issue (create|edit|comment)' "$GH_LOG" 2>/dev/null; then
+		print_result "late live interactive claim blocks dispatch without mutation" 1 \
+			"dispatch emitted a visible issue mutation"
+	else
+		print_result "late live interactive claim blocks dispatch without mutation" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
 main() {
 	test_dispatch_creates_child_issue
 	test_child_body_contains_parent_content_and_authors
@@ -1205,6 +1264,8 @@ main() {
 	test_resolving_pr_helper_ignores_non_closing_reference
 	test_needs_consolidation_skips_with_inflight_resolving_pr
 	test_dispatch_skips_with_inflight_resolving_pr
+	test_live_interactive_claim_blocks_classification_and_clears_stale_label
+	test_live_interactive_claim_appearing_after_classification_blocks_dispatch
 
 	echo
 	echo "============================================"

--- a/.agents/scripts/tests/test-consolidation-multi-runner.sh
+++ b/.agents/scripts/tests/test-consolidation-multi-runner.sh
@@ -33,8 +33,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)" || exit 1
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -146,6 +146,7 @@ if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
 	title) printf '%s\n' "${GH_ISSUE_VIEW_TITLE:-Parent Title}" ;;
 	body) printf '%s\n' "${GH_ISSUE_VIEW_BODY:-Parent body}" ;;
 	labels) printf '%s\n' "${GH_ISSUE_VIEW_LABELS:-bug,tier:standard}" ;;
+	state,labels,assignees) printf '%s\n' '{"state":"OPEN","labels":[],"assignees":[]}' ;;
 	*) printf '\n' ;;
 	esac
 	exit 0
@@ -224,6 +225,9 @@ _setup_gh_stub_globals() {
 	printf '{"initialized_repos": []}\n' >"$REPOS_JSON"
 	# Tests should never actually sleep during tiebreak re-check.
 	export CONSOLIDATION_LOCK_TIEBREAK_WAIT_SEC=0
+	# pulse-triage.sh resolves its sub-libraries from SCRIPT_DIR when supplied.
+	# Keep the test's own directory separate so it cannot redirect those sources.
+	SCRIPT_DIR="${REPO_ROOT}/.agents/scripts"
 
 	# shellcheck disable=SC1091
 	source "${REPO_ROOT}/.agents/scripts/pulse-triage.sh"
@@ -233,6 +237,26 @@ _setup_gh_stub_globals() {
 	# issue create` path. Mirrors test-consolidation-dispatch.sh.
 	gh_create_issue() {
 		gh issue create "$@"
+		return $?
+	}
+	gh_issue_comment() {
+		gh issue comment "$@"
+		return $?
+	}
+	gh_issue_list() {
+		gh issue list "$@"
+		return $?
+	}
+	gh_pr_list() {
+		gh pr list "$@"
+		return $?
+	}
+	repo_allows_pulse_write_actions() {
+		local repo_slug="$1"
+		if [[ "$repo_slug" == "owner/repo" || "$repo_slug" == "marcusquinn/aidevops" ]]; then
+			return 0
+		fi
+		return 1
 	}
 	return 0
 }


### PR DESCRIPTION
Summary: guard classification and dispatch against verified live interactive claims; defer ambiguous ownership reads. Testing: consolidation dispatch and multi-runner suites, ShellCheck, linters-local. Resolves #30461
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.276 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
