### PR TITLE
GH#30464: feat(observability): classify tool outcomes

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability-init.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-init.mjs
@@ -16,8 +16,8 @@ import { dirname } from "path";
 import { sqliteExecSync } from "./observability-sqlite.mjs";
 
 /**
- * Read-only check: are all expected tables present and is the t1309 `intent`
- * column on `tool_calls`, and are routing/version columns present on
+ * Read-only check: are all expected tables present and are the required
+ * `tool_calls` and routing/version columns present on
  * `llm_requests`?
  * Uses `sqlite3 -readonly` so it never contends on
  * the writer lock — safe to call from N concurrent workers without race.
@@ -36,7 +36,8 @@ export function isSchemaInitialized(dbPath) {
        "SELECT " +
       "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' " +
        "AND name IN ('llm_requests','tool_calls','session_summaries','runtime_events','runtime_event_archives')) AS tbls, " +
-       "(SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent') AS intent_col, " +
+        "(SELECT COUNT(*) FROM pragma_table_info('tool_calls') " +
+        "WHERE name IN ('intent','outcome_category')) AS tool_call_cols, " +
        "(SELECT COUNT(*) FROM pragma_table_info('llm_requests') WHERE name IN " +
         "('parent_session_id','routing_tier','routing_candidate_index','routing_attempt','routing_reason','routing_escalated','aidevops_version')) AS routing_cols, " +
        "(SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' " +
@@ -49,8 +50,8 @@ export function isSchemaInitialized(dbPath) {
       },
     ).trim();
     if (!result) return false;
-    const [tbls, intentCol, routingCols, guards] = result.split("|");
-    return tbls === "5" && intentCol === "1" && routingCols === "7" && guards === "4";
+    const [tbls, toolCallCols, routingCols, guards] = result.split("|");
+    return tbls === "5" && toolCallCols === "2" && routingCols === "7" && guards === "4";
   } catch {
     return false;
   }
@@ -117,7 +118,8 @@ CREATE TABLE IF NOT EXISTS tool_calls (
   intent TEXT,
   success INTEGER DEFAULT 1,
   duration_ms INTEGER,
-  metadata TEXT
+  metadata TEXT,
+  outcome_category TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_tool_calls_session

--- a/.agents/plugins/opencode-aidevops/observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-retention.mjs
@@ -60,7 +60,7 @@ export function summarizeToolMetadata(metadata) {
     omitted_keys: Object.keys(source).length,
   };
   const status = normalizedStatus(firstDefined(source, ["status", "state", "outcome"]));
-  const exitCode = safeInteger(firstDefined(source, ["exitCode", "exit_code"]));
+  const exitCode = safeInteger(firstDefined(source, ["exit", "exitCode", "exit_code"]));
   const outputBytes = safeInteger(firstDefined(source, ["outputBytes", "output_bytes", "bytes"]));
   const outputLines = safeInteger(firstDefined(source, ["outputLines", "output_lines", "lineCount"]));
   const truncated = firstDefined(source, ["truncated", "isTruncated"]);
@@ -75,7 +75,7 @@ export function summarizeToolMetadata(metadata) {
   if (source.error !== undefined) summary.has_error = Boolean(source.error);
 
   const retainedSourceKeys = [
-    "status", "state", "outcome", "exitCode", "exit_code", "outputBytes",
+    "status", "state", "outcome", "exit", "exitCode", "exit_code", "outputBytes",
     "output_bytes", "bytes", "outputLines", "output_lines", "lineCount",
     "truncated", "isTruncated", "timedOut", "timed_out", "timeout", "error",
   ].filter((key) => Object.hasOwn(source, key)).length;

--- a/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
@@ -3,19 +3,20 @@
 
 import { summarizeToolMetadata } from "./observability-retention.mjs";
 import { sqlEscape } from "./observability-sqlite.mjs";
-import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
+import { classifyToolOutcome } from "./session-continuation-guard.mjs";
+
+export { classifyToolOutcome };
 
 /** Return whether a tool result is safe to record as successful. */
 export function toolCallSucceeded(output) {
-  return !toolOutcomeFailed(output);
+  return classifyToolOutcome(output) === "success";
 }
 
 /**
  * Build the INSERT SQL for a tool_calls row. Pure function — no DB access or
  * global state — so it is exhaustively testable without sqlite3.
  *
- * Column order must stay aligned with the `tool_calls` CREATE TABLE in
- * observability-init.mjs.
+ * Column and value order must stay aligned within this explicit INSERT.
  *
  * @param {object} args
  * @param {string} args.sessionID
@@ -25,9 +26,12 @@ export function toolCallSucceeded(output) {
  * @param {0 | 1} args.isSuccess
  * @param {number | null | undefined} args.durationMs - Elapsed ms, or null/undefined to store SQL NULL
  * @param {object | null | undefined} args.metadata - Raw metadata object; summarized before persistence
+ * @param {string | null | undefined} args.outcomeCategory - Bounded outcome classification
  * @returns {string} INSERT statement ready for sqliteExec
  */
-export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, isSuccess, durationMs, metadata }) {
+export function buildToolCallInsertSql({
+  sessionID, callID, toolName, intent, isSuccess, durationMs, metadata, outcomeCategory,
+}) {
   const durationSql = (durationMs !== null && durationMs !== undefined)
     ? String(durationMs)
     : "NULL";
@@ -35,7 +39,7 @@ export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, is
   const metadataValue = metadataSummary === null ? null : JSON.stringify(metadataSummary);
 
   return `INSERT INTO tool_calls (
-    session_id, call_id, tool_name, intent, success, duration_ms, metadata
+    session_id, call_id, tool_name, intent, success, duration_ms, metadata, outcome_category
   ) VALUES (
     ${sqlEscape(sessionID)},
     ${sqlEscape(callID)},
@@ -43,6 +47,7 @@ export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, is
     ${sqlEscape(intent || null)},
     ${isSuccess},
     ${durationSql},
-    ${sqlEscape(metadataValue)}
+    ${sqlEscape(metadataValue)},
+    ${sqlEscape(outcomeCategory || null)}
   );`;
 }

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -47,6 +47,7 @@ import {
 } from "./observability-retention.mjs";
 import {
   buildToolCallInsertSql,
+  classifyToolOutcome,
   toolCallSucceeded,
 } from "./observability-tool-calls.mjs";
 import {
@@ -70,7 +71,7 @@ const COST_BACKFILL_MARKER = `${DB_PATH}.cost-backfill-v1.done`;
 
 export { getPricing };
 export { getRoutingFeedback, recordRoutingDecision };
-export { buildToolCallInsertSql, toolCallSucceeded };
+export { buildToolCallInsertSql, classifyToolOutcome, toolCallSucceeded };
 
 /**
  * Initialise the observability database with WAL mode and schema.
@@ -102,7 +103,7 @@ function initDatabase() {
   // 100% of worker startups. Read-only check first — no lock contention,
   // skips the slow path entirely once the DB is ready.
   if (existsSync(DB_PATH) && _isSchemaInitialized(DB_PATH)) {
-    return _runDataMigrations({ intentColumnReady: true, routingColumnsReady: true });
+    return _runDataMigrations({ toolCallColumnsReady: true, routingColumnsReady: true });
   }
 
   // SLOW PATH (t2900): serialise schema creation across concurrent workers
@@ -113,7 +114,7 @@ function initDatabase() {
     // DOUBLE-CHECKED LOCKING: another worker may have completed init while
     // we waited. If schema is now ready, skip the writer-lock-heavy path.
     if (existsSync(DB_PATH) && _isSchemaInitialized(DB_PATH)) {
-      return _runDataMigrations({ intentColumnReady: true, routingColumnsReady: true });
+      return _runDataMigrations({ toolCallColumnsReady: true, routingColumnsReady: true });
     }
     if (!_createSchema()) return false;
     return _runDataMigrations();
@@ -127,21 +128,24 @@ function initDatabase() {
  * Historical data backfills are scheduled after startup so large observability
  * databases do not block the OpenCode TUI on table scans or writer locks.
  *
- * @param {{ intentColumnReady?: boolean, routingColumnsReady?: boolean }} [options]
+ * @param {{ toolCallColumnsReady?: boolean, routingColumnsReady?: boolean }} [options]
  * @returns {boolean} true on success (best-effort — never returns false)
  */
 function _runDataMigrations(options = {}) {
-  // Migration: add intent column to tool_calls if it doesn't exist (t1309).
-  // Check first to avoid noisy "duplicate column" errors in logs.
-  // Fresh DBs already have the column from the CREATE TABLE above.
-  const hasIntentCol = options.intentColumnReady
-    ? "1"
-    : sqliteExecSync(
-      "SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent';",
-      5000,
-    );
-  if (hasIntentCol === "0") {
-    sqliteExecSync("ALTER TABLE tool_calls ADD COLUMN intent TEXT;", 5000);
+  if (!options.toolCallColumnsReady) {
+    const toolCallColumns = [
+      ["intent", "TEXT"],
+      ["outcome_category", "TEXT"],
+    ];
+    for (const [column, definition] of toolCallColumns) {
+      const exists = sqliteExecSync(
+        `SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name=${sqlEscape(column)};`,
+        5000,
+      );
+      if (exists === "0") {
+        sqliteExecSync(`ALTER TABLE tool_calls ADD COLUMN ${column} ${definition};`, 5000);
+      }
+    }
   }
 
   if (!options.routingColumnsReady) {
@@ -501,7 +505,8 @@ export function recordToolCall(input, output, intent, durationMs) {
     }
   }
 
-  const isSuccess = toolCallSucceeded(output) ? 1 : 0;
+  const outcomeCategory = classifyToolOutcome(output);
+  const isSuccess = outcomeCategory === "success" ? 1 : 0;
 
   const sql = buildToolCallInsertSql({
     sessionID,
@@ -511,6 +516,7 @@ export function recordToolCall(input, output, intent, durationMs) {
     isSuccess,
     durationMs,
     metadata: output?.metadata,
+    outcomeCategory,
   });
 
   sqliteExec(sql);
@@ -525,6 +531,7 @@ export function recordToolCall(input, output, intent, durationMs) {
       duration_ms: durationMs ?? null,
       success: isSuccess === 1,
       tool_name: toolName,
+      outcome_category: outcomeCategory,
     },
   });
   projectRuntimeEvent(runtimeEnvelope);

--- a/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
@@ -8,6 +8,7 @@ import {
   activeTodos,
   boundedText,
   capMap,
+  classifyToolOutcome,
   isExplicitCompletionClaim,
   operationFingerprint,
   sessionId,
@@ -223,4 +224,10 @@ export function createSessionContinuationGuard(options = {}) {
   };
 }
 
-export { COMPLETION_CORRECTION_MARKER, isExplicitCompletionClaim, operationFingerprint, toolOutcomeFailed };
+export {
+  COMPLETION_CORRECTION_MARKER,
+  classifyToolOutcome,
+  isExplicitCompletionClaim,
+  operationFingerprint,
+  toolOutcomeFailed,
+};

--- a/.agents/plugins/opencode-aidevops/session-continuation-utils.mjs
+++ b/.agents/plugins/opencode-aidevops/session-continuation-utils.mjs
@@ -41,13 +41,29 @@ export function operationFingerprint(toolName, args) {
   return createHash("sha256").update(shape).digest("hex");
 }
 
-export function toolOutcomeFailed(output) {
-  const status = String(output?.metadata?.status || output?.status || "").toLowerCase();
-  if (["error", "failed", "aborted", "cancelled", "canceled", "timeout", "timed_out"].includes(status)) return true;
-  if (output?.error || output?.metadata?.error) return true;
-  if (Number.isInteger(output?.metadata?.exitCode) && output.metadata.exitCode !== 0) return true;
+export function classifyToolOutcome(output) {
   const text = String(output?.output || "").trim();
-  return /^(?:error|failed|aborted|cancelled|canceled|tool execution aborted|operation timed out)\b/i.test(text);
+  if (/^BLOCKED by shared command policy\b/i.test(text)) return "policy_block";
+
+  const status = String(output?.metadata?.status || output?.status || "").toLowerCase();
+  const failedStatuses = [
+    "aborted", "blocked", "cancelled", "canceled", "denied", "error", "failed",
+    "rejected", "timed_out", "timeout",
+  ];
+  if (failedStatuses.includes(status) || output?.error || output?.metadata?.error) return "tool_error";
+
+  const exitCode = [output?.metadata?.exit, output?.metadata?.exitCode, output?.metadata?.exit_code]
+    .find((value) => Number.isInteger(value));
+  if (exitCode !== undefined) return exitCode === 0 ? "success" : "command_failure";
+  if (["completed", "success", "succeeded"].includes(status)) return "success";
+  if (/^(?:error|failed|aborted|cancelled|canceled|tool execution aborted|operation timed out)\b/i.test(text)) {
+    return "tool_error";
+  }
+  return "success";
+}
+
+export function toolOutcomeFailed(output) {
+  return classifyToolOutcome(output) !== "success";
 }
 
 export function isExplicitCompletionClaim(text) {

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
@@ -15,7 +15,7 @@ describe("tool metadata retention", () => {
     const summary = summarizeToolMetadata({
       bytes: 4096,
       error: "sensitive-value",
-      exitCode: 7,
+      exit: 7,
       filePath: "/private/project/file.txt",
       raw: "x".repeat(100_000),
       status: "failed",

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
@@ -22,7 +22,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildToolCallInsertSql, toolCallSucceeded } from "../observability.mjs";
+import { buildToolCallInsertSql, classifyToolOutcome, toolCallSucceeded } from "../observability.mjs";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,11 +97,29 @@ describe("toolCallSucceeded", () => {
 
   test("rejects non-zero metadata exit codes", () => {
     assert.equal(toolCallSucceeded({ output: "", metadata: { exitCode: 1 } }), false);
+    assert.equal(toolCallSucceeded({ output: "", metadata: { exit: 7 } }), false);
   });
 
   test("rejects leading terminal failure markers without structured status", () => {
     assert.equal(toolCallSucceeded({ output: "Error: file not found" }), false);
     assert.equal(toolCallSucceeded({ output: "FAILED to read file" }), false);
+  });
+});
+
+describe("classifyToolOutcome", () => {
+  test("distinguishes command failures and policy blocks", () => {
+    assert.equal(classifyToolOutcome({ output: "", metadata: { exit: 7 } }), "command_failure");
+    assert.equal(classifyToolOutcome({
+      output: "BLOCKED by shared command policy (forbid, command.parse-error)",
+    }), "policy_block");
+  });
+
+  test("distinguishes tool errors from successful output", () => {
+    assert.equal(classifyToolOutcome({ output: "", metadata: { status: "failed" } }), "tool_error");
+    assert.equal(classifyToolOutcome({
+      output: "Error: this is fixture text",
+      metadata: { exit: 0 },
+    }), "success");
   });
 });
 
@@ -137,8 +155,7 @@ describe("buildToolCallInsertSql — column/value alignment", () => {
       metadata: { filePath: "/tmp/x" },
     });
     const cols = extractColumns(sql);
-    // Order must match the CREATE TABLE in observability-init.mjs.
-    // Any drift breaks SQLite positional binding in the live path.
+    // Keep the explicit INSERT contract stable for downstream readers.
     assert.deepEqual(cols, [
       "session_id",
       "call_id",
@@ -147,7 +164,23 @@ describe("buildToolCallInsertSql — column/value alignment", () => {
       "success",
       "duration_ms",
       "metadata",
+      "outcome_category",
     ]);
+  });
+
+  test("persists the bounded outcome category", () => {
+    const sql = buildToolCallInsertSql({
+      sessionID: "s1",
+      callID: "c1",
+      toolName: "Bash",
+      intent: "running a fixture",
+      isSuccess: 0,
+      durationMs: 10,
+      metadata: { exit: 7 },
+      outcomeCategory: "command_failure",
+    });
+    const vals = extractValues(sql);
+    assert.equal(vals[7], "'command_failure'");
   });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
@@ -451,6 +451,50 @@ test("SQLite enforces append-only rows and concurrent state versions", {
   }
 });
 
+test("OpenCode observability migrates existing tool-call rows without guessing outcomes", {
+  skip: !sqliteAvailable() && "sqlite3 is unavailable",
+}, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-observability-migration-"));
+  const dbPath = join(tempDir, "llm-requests.db");
+  const observabilityUrl = new URL("../observability.mjs", import.meta.url).href;
+  const driver = `
+    const observability = await import(${JSON.stringify(observabilityUrl)});
+    if (!observability.initObservability()) process.exit(2);
+    process.exit(0);
+  `;
+
+  try {
+    execFileSync("sqlite3", [dbPath, `
+      CREATE TABLE tool_calls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        call_id TEXT,
+        tool_name TEXT NOT NULL,
+        intent TEXT,
+        success INTEGER DEFAULT 1,
+        duration_ms INTEGER,
+        metadata TEXT
+      );
+      INSERT INTO tool_calls (session_id, call_id, tool_name, success)
+      VALUES ('legacy-session', 'legacy-call', 'Bash', 0);
+    `]);
+    execFileSync(process.execPath, ["--input-type=module", "-e", driver], {
+      env: { ...process.env, AIDEVOPS_OBS_DB_OVERRIDE: dbPath },
+      stdio: "pipe",
+      timeout: 5000,
+    });
+    const migrated = execFileSync("sqlite3", [dbPath, `
+      SELECT
+        (SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='outcome_category'),
+        (SELECT success FROM tool_calls WHERE call_id='legacy-call'),
+        (SELECT outcome_category IS NULL FROM tool_calls WHERE call_id='legacy-call');
+    `], { encoding: "utf8" }).trim();
+    assert.equal(migrated, "1|0|1");
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test("OpenCode observability emits runtime evidence without changing legacy tables", {
   skip: !sqliteAvailable() && "sqlite3 is unavailable",
 }, () => {
@@ -543,11 +587,14 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
         (SELECT json_extract(payload_json, '$.observation.provider_error.request_id')
           FROM runtime_events WHERE event_type = 'session.error'),
         (SELECT payload_json NOT LIKE '%private%' AND payload_json NOT LIKE '%doctype%'
-          FROM runtime_events WHERE event_type = 'session.error');
+          FROM runtime_events WHERE event_type = 'session.error'),
+        (SELECT json_extract(payload_json, '$.outcome_category')
+          FROM runtime_events WHERE event_type = 'tool.completed'),
+        (SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='outcome_category');
     `], { encoding: "utf8" }).trim();
     assert.equal(
       counts,
-      "1|1|6|session.created,message.part.updated,message.completed,session.error,tool.completed,subagent.cancellation.receipt|100|PartFailure|gateway_denied|req-safe|1",
+      "1|1|6|session.created,message.part.updated,message.completed,session.error,tool.completed,subagent.cancellation.receipt|100|PartFailure|gateway_denied|req-safe|1|success|1",
     );
   } finally {
     rmSync(tempDir, { force: true, recursive: true });

--- a/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
@@ -112,8 +112,8 @@ test("observability.mjs skips heavy cost backfill when no rows need migration", 
   );
   assert.match(
     src,
-    /_runDataMigrations\(\{ intentColumnReady: true, routingColumnsReady: true \}\)/,
-    "Known-good schemas should skip redundant intent and routing-column migration probes.",
+    /_runDataMigrations\(\{ toolCallColumnsReady: true, routingColumnsReady: true \}\)/,
+    "Known-good schemas should skip redundant tool-call and routing-column migration probes.",
   );
 });
 

--- a/.agents/scripts/runtime-events-payload.mjs
+++ b/.agents/scripts/runtime-events-payload.mjs
@@ -24,7 +24,7 @@ const ABSOLUTE_PATH_PATTERN = /(^|[\s("'=])(?:\/[^\s"',)}\]]+|[A-Za-z]:[\\/][^\s
 const REPOSITORY_LIKE_PATTERN = /\b[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\b/g;
 const ORDINARY_PAYLOAD_KEYS = new Set([
   "attempt_id", "call_id", "classification", "duration_ms", "error_type", "exit_code",
-  "finish_reason", "model_id", "observation", "provider_id", "reason", "result",
+  "finish_reason", "model_id", "observation", "outcome_category", "provider_id", "reason", "result",
   "role", "run_id", "source", "status", "success", "suppressed_part_bytes",
   "suppressed_part_events", "tool_name",
 ]);

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -135,6 +135,18 @@ _escape_sql() {
 	printf '%s' "$1" | sed "s/'/''/g"
 }
 
+_outcome_category_sql() {
+	local db="$1"
+	local has_column
+	has_column=$(sqlite3 "$db" "SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='outcome_category';")
+	if [[ "$has_column" == "1" ]]; then
+		printf '%s' "CASE WHEN outcome_category IS NOT NULL AND outcome_category<>'' THEN outcome_category WHEN success=0 THEN 'unknown_failure' ELSE 'legacy_unknown' END"
+	else
+		printf '%s' "CASE WHEN success=0 THEN 'unknown_failure' ELSE 'legacy_unknown' END"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Commands
 # =============================================================================
@@ -250,6 +262,18 @@ cmd_patterns() {
 		ORDER BY n DESC;
 	")
 
+	# Additive outcome categories retain unknown legacy rows without guessing.
+	local outcome_expr
+	outcome_expr=$(_outcome_category_sql "$db")
+	local outcomes
+	outcomes=$(sqlite3 -separator '|' "$db" "
+		SELECT ${outcome_expr} AS category, COUNT(*) AS n
+		FROM tool_calls
+		WHERE session_id='${sid_esc}' ${since}
+		GROUP BY 1
+		ORDER BY n DESC, category;
+	")
+
 	# Repeated-path evidence — parse filePath from metadata JSON. Two accesses is
 	# the semantic minimum for repetition, not a heuristic problem threshold.
 	# Report the evidence and leave interpretation to the retrospective.
@@ -279,10 +303,10 @@ cmd_patterns() {
 
 	if [[ "$json_flag" == "true" ]]; then
 		_patterns_json "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
 	else
 		_patterns_table "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
 	fi
 	return 0
 }
@@ -290,6 +314,7 @@ cmd_patterns() {
 _patterns_table() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
+	local outcomes="${10}"
 	printf 'Session: %s\n' "$sid"
 	printf 'Window:  %s → %s\n' "${first_ts:-?}" "${last_ts:-?}"
 	printf 'Calls:   %s total, %s error(s), %s calls/min, avg %sms\n\n' \
@@ -301,6 +326,16 @@ _patterns_table() {
 			[[ -z "$tool" ]] && continue
 			printf '  %-12s %6s calls (%s errors)\n' "$tool" "$n" "$err"
 		done <<<"$by_tool"
+	else
+		printf '  (none)\n'
+	fi
+
+	printf '\nOutcome categories:\n'
+	if [[ -n "$outcomes" ]]; then
+		while IFS='|' read -r category n; do
+			[[ -z "$category" ]] && continue
+			printf '  %-18s %6s calls\n' "$category" "$n"
+		done <<<"$outcomes"
 	else
 		printf '  (none)\n'
 	fi
@@ -321,6 +356,7 @@ _patterns_table() {
 _patterns_json() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
+	local outcomes="${10}"
 	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
@@ -337,16 +373,30 @@ _patterns_json() {
 			count: (.[1] | tonumber? // 0)
 		})
 	')
+	local outcomes_json
+	outcomes_json=$(printf '%s' "$outcomes" | jq -R -s '
+		split("\n") | map(select(length > 0) | split("|") | {
+			key: .[0],
+			value: (.[1] | tonumber? // 0)
+		}) | from_entries
+	')
 	jq -n \
 		--arg sid "$sid" --arg first_ts "$first_ts" --arg last_ts "$last_ts" \
 		--argjson total "${total:-0}" --argjson errors "${errors:-0}" \
 		--argjson avg_dur "${avg_dur:-0}" --arg rate "$rate" \
-		--argjson by_tool "$by_tool_json" --argjson rereads "$rereads_json" \
+		--argjson by_tool "$by_tool_json" --argjson outcomes "$outcomes_json" \
+		--argjson rereads "$rereads_json" \
 		--argjson minimum_repeat_count "$REPEATED_PATH_MIN_COUNT" '
 		{
 			session: $sid,
 			window: { first: $first_ts, last: $last_ts },
-			calls: { total: $total, errors: $errors, rate_per_min: ($rate|tonumber), avg_ms: $avg_dur },
+			calls: {
+				total: $total,
+				errors: $errors,
+				rate_per_min: ($rate|tonumber),
+				avg_ms: $avg_dur,
+				outcomes: $outcomes
+			},
 			by_tool: $by_tool,
 			repeated_file_access: {
 				semantic_minimum: $minimum_repeat_count,
@@ -375,9 +425,11 @@ cmd_errors() {
 
 	local since; since=$(_since_clause "$since_min") || return 1
 	local sid_esc; sid_esc=$(_escape_sql "$sid")
+	local outcome_expr
+	outcome_expr=$(_outcome_category_sql "$db")
 
 	local query="
-		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0)
+		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0), ${outcome_expr}
 		FROM tool_calls
 		WHERE session_id='${sid_esc}' AND success=0 ${since}
 		ORDER BY timestamp DESC
@@ -388,16 +440,17 @@ cmd_errors() {
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s --arg sid "$sid" '
 			split("\n") | map(select(length > 0) | split("|") | {
 				timestamp: .[0], tool: .[1], intent: .[2],
-				duration_ms: (.[3] | tonumber? // 0)
+				duration_ms: (.[3] | tonumber? // 0), category: .[4]
 			}) | { session: $sid, errors: . }'
 	else
 		printf 'Session: %s\n\n' "$sid"
-		printf '%-23s  %-8s  %-6s  %s\n' "TIMESTAMP" "TOOL" "MS" "INTENT"
-		printf '%-23s  %-8s  %-6s  %s\n' "-----------------------" "--------" "------" "----------------------------------------"
+		printf '%-23s  %-8s  %-6s  %-18s  %s\n' "TIMESTAMP" "TOOL" "MS" "CATEGORY" "INTENT"
+		printf '%-23s  %-8s  %-6s  %-18s  %s\n' "-----------------------" "--------" "------" "------------------" "----------------------------------------"
 		local count=0
-		while IFS='|' read -r ts tool intent dur; do
+		while IFS='|' read -r ts tool intent dur category; do
 			[[ -z "$ts" ]] && continue
-			printf '%-23s  %-8s  %-6s  %s\n' "${ts:0:23}" "${tool:0:8}" "${dur}" "${intent:0:60}"
+			printf '%-23s  %-8s  %-6s  %-18s  %s\n' \
+				"${ts:0:23}" "${tool:0:8}" "${dur}" "${category:0:18}" "${intent:0:60}"
 			count=$((count + 1))
 		done < <(sqlite3 -separator '|' "$db" "$query")
 		printf '\n%d error(s) shown\n' "$count"

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -54,7 +54,8 @@ CREATE TABLE tool_calls (
   intent TEXT,
   success INTEGER DEFAULT 1,
   duration_ms INTEGER,
-  metadata TEXT
+  metadata TEXT,
+  outcome_category TEXT
 );
 
 CREATE TABLE session_summaries (
@@ -73,24 +74,25 @@ CREATE TABLE session_summaries (
 );
 
 -- Session A (most recent — becomes the "current" for default lookup)
-INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata) VALUES
- ('2026-04-18T04:00:00Z', 'sess-A', 'Read',   'scanning file index',           1, 120, '{"args":{"filePath":"/repo/a.sh"}}'),
- ('2026-04-18T04:00:05Z', 'sess-A', 'Read',   'reading auth handler',          1,  90, '{"args":{"filePath":"/repo/b.sh"}}'),
- ('2026-04-18T04:00:10Z', 'sess-A', 'Read',   'rechecking auth handler',       1,  88, '{"args":{"filePath":"/repo/b.sh"}}'),
- ('2026-04-18T04:00:15Z', 'sess-A', 'Read',   're-reading auth handler',       1,  95, '{"args":{"filePath":"/repo/b.sh"}}'),
- ('2026-04-18T04:00:20Z', 'sess-A', 'Read',   'reading auth handler AGAIN',    1,  80, '{"args":{"filePath":"/repo/b.sh"}}'),
- ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   'patching auth handler',         1, 240, '{"args":{"filePath":"/repo/b.sh"}}'),
- ('2026-04-18T04:00:30Z', 'sess-A', 'Bash',   'running shellcheck',            0, 850, '{}'),
- ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   'running shellcheck retry',      0, 910, '{}'),
- ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{}');
+INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata, outcome_category) VALUES
+ ('2026-04-18T04:00:00Z', 'sess-A', 'Read',   'scanning file index',           1, 120, '{"args":{"filePath":"/repo/a.sh"}}', NULL),
+ ('2026-04-18T04:00:05Z', 'sess-A', 'Read',   'reading auth handler',          1,  90, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:10Z', 'sess-A', 'Read',   'rechecking auth handler',       1,  88, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:15Z', 'sess-A', 'Read',   're-reading auth handler',       1,  95, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:20Z', 'sess-A', 'Read',   'reading auth handler AGAIN',    1,  80, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   'patching auth handler',         1, 240, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:30Z', 'sess-A', 'Bash',   'running shellcheck',            0, 850, '{}', 'command_failure'),
+ ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   'running blocked retry',         0, 910, '{}', 'policy_block'),
+ ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{}', 'success'),
+ ('2026-04-18T04:00:45Z', 'sess-A', 'Task',   'handling runtime error',        0,  50, '{}', 'tool_error');
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
-VALUES ('sess-A', '2026-04-18T04:00:00Z', '2026-04-18T04:00:40Z', 9, 9, 2, 0.0184, 'claude-sonnet-4');
+VALUES ('sess-A', '2026-04-18T04:00:00Z', '2026-04-18T04:00:45Z', 10, 10, 3, 0.0184, 'claude-sonnet-4');
 
 -- Session B (older)
-INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata) VALUES
- ('2026-04-17T10:00:00Z', 'sess-B', 'Read',   'initial context scan',          1, 100, '{"args":{"filePath":"/repo/c.sh"}}'),
- ('2026-04-17T10:00:05Z', 'sess-B', 'Write',  'creating new helper',           1, 200, '{"args":{"filePath":"/repo/new.sh"}}');
+INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata, outcome_category) VALUES
+ ('2026-04-17T10:00:00Z', 'sess-B', 'Read',   'initial context scan',          1, 100, '{"args":{"filePath":"/repo/c.sh"}}', 'success'),
+ ('2026-04-17T10:00:05Z', 'sess-B', 'Write',  'creating new helper',           1, 200, '{"args":{"filePath":"/repo/new.sh"}}', 'success');
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
 VALUES ('sess-B', '2026-04-17T10:00:00Z', '2026-04-17T10:00:05Z', 2, 2, 0, 0.0041, 'claude-sonnet-4');
@@ -127,15 +129,20 @@ fi
 printf '\n%s=== patterns ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" patterns 2>&1) || true
 assert_contains "patterns: shows session ID"         "$out" "sess-A"
-assert_contains "patterns: shows total calls"        "$out" "9 total"
-assert_contains "patterns: shows error count"        "$out" "2 error"
+assert_contains "patterns: shows total calls"        "$out" "10 total"
+assert_contains "patterns: shows error count"        "$out" "3 error"
+assert_contains "patterns: separates command failures" "$out" "command_failure"
+assert_contains "patterns: separates policy blocks"  "$out" "policy_block"
+assert_contains "patterns: separates tool errors"    "$out" "tool_error"
+assert_contains "patterns: preserves unknown legacy outcomes" "$out" "legacy_unknown"
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
 assert_contains "errors: shows failed Bash call"     "$out" "shellcheck"
-assert_contains "errors: excludes succeeded calls"   "$out" "2 error"
+assert_contains "errors: shows outcome category"     "$out" "command_failure"
+assert_contains "errors: excludes succeeded calls"   "$out" "3 error"
 
 printf '\n%s=== sessions ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" sessions 2>&1) || true
@@ -166,6 +173,23 @@ if command -v jq >/dev/null 2>&1; then
 		pass "patterns --json: surfaces repeated-path evidence"
 	else
 		fail "patterns --json: missing repeated_file_access.evidence" "$out"
+	fi
+	if printf '%s' "$out" | jq -e '
+		.calls.outcomes.command_failure == 1 and
+		.calls.outcomes.policy_block == 1 and
+		.calls.outcomes.tool_error == 1 and
+		.calls.outcomes.legacy_unknown == 1
+	' >/dev/null 2>&1; then
+		pass "patterns --json: separates outcome categories"
+	else
+		fail "patterns --json: missing outcome category counters" "$out"
+	fi
+
+	out=$("$HELPER" errors --json 2>&1) || true
+	if printf '%s' "$out" | jq -e '.errors | map(.category) | index("policy_block") != null' >/dev/null 2>&1; then
+		pass "errors --json: includes outcome categories"
+	else
+		fail "errors --json: missing outcome categories" "$out"
 	fi
 
 	out=$("$HELPER" sessions --json 2>&1) || true


### PR DESCRIPTION
## Summary

Classify successful calls, command failures, policy blocks, and tool/runtime errors while retaining the existing success boolean.

## Files Changed

.agents/plugins/opencode-aidevops/observability-init.mjs, .agents/plugins/opencode-aidevops/observability-retention.mjs, .agents/plugins/opencode-aidevops/observability-tool-calls.mjs, .agents/plugins/opencode-aidevops/observability.mjs, .agents/plugins/opencode-aidevops/session-continuation-guard.mjs, .agents/plugins/opencode-aidevops/session-continuation-utils.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs, .agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs, .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs, .agents/scripts/runtime-events-payload.mjs, .agents/scripts/session-introspect-helper.sh, .agents/scripts/tests/test-session-introspect.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: 52 focused Node tests passed, including live SQLite schema migration and tool.completed event persistence; 28 session-introspection tests and ShellCheck passed; local linters passed.

Resolves #30464


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.276 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 32m and 513,216 tokens on this with the user in an interactive session.