### PR TITLE
GH#30472: Fix Playwright runtime resolution for browser QA

### DIFF
--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -1040,16 +1040,17 @@ bulk_audit() {
 # ============================================================================
 
 check_playwright() {
-	if ! command -v npx &>/dev/null; then
-		print_error "npx not found (required for Playwright)"
-		print_info "Install Node.js: https://nodejs.org/"
+	if ! command -v node &>/dev/null; then
+		print_error "Node.js not found (required for Playwright)"
 		return 1
 	fi
-	if ! npx --no-install playwright --version &>/dev/null 2>&1; then
-		print_warning "Playwright not installed"
-		print_info "Install: npm install playwright && npx playwright install chromium"
+	local runtime_script="${SCRIPT_DIR}/playwright-runtime.mjs"
+	local resolved_module
+	if ! resolved_module=$(node "$runtime_script" check); then
+		print_warning "Playwright package or browser binary is unavailable"
 		return 1
 	fi
+	export AIDEVOPS_PLAYWRIGHT_MODULE="$resolved_module"
 	return 0
 }
 
@@ -1075,24 +1076,11 @@ run_playwright_contrast() {
 		return 1
 	fi
 
-	local script_dir
-	script_dir="$(dirname "$script_path")"
 	local exit_code=0
-
-	# Install dependencies if node_modules is missing
-	if [[ ! -d "${script_dir}/node_modules" ]]; then
-		print_info "Installing Playwright dependencies..."
-		if ! (cd "$script_dir" && npm install --silent 2>/dev/null); then
-			print_error "Failed to install Playwright dependencies"
-			return 1
-		fi
-	fi
-
-	# Run from the script directory so node resolves local node_modules
 	case "$format" in
 	"json")
 		report_file="${report_file}.json"
-		if (cd "$script_dir" && node playwright-contrast.mjs "$url" --format json --level "$level") >"$report_file" 2>&1; then
+		if node "$script_path" "$url" --format json --level "$level" >"$report_file" 2>&1; then
 			exit_code=0
 		else
 			exit_code=$?
@@ -1100,7 +1088,7 @@ run_playwright_contrast() {
 		;;
 	"markdown" | "md")
 		report_file="${report_file}.md"
-		if (cd "$script_dir" && node playwright-contrast.mjs "$url" --format markdown --level "$level") >"$report_file" 2>&1; then
+		if node "$script_path" "$url" --format markdown --level "$level" >"$report_file" 2>&1; then
 			exit_code=0
 		else
 			exit_code=$?
@@ -1108,7 +1096,7 @@ run_playwright_contrast() {
 		;;
 	"summary" | *)
 		report_file="${report_file}.txt"
-		if (cd "$script_dir" && node playwright-contrast.mjs "$url" --format summary --level "$level") 2>&1 | tee "$report_file"; then
+		if node "$script_path" "$url" --format summary --level "$level" 2>&1 | tee "$report_file"; then
 			exit_code=0
 		else
 			exit_code=${PIPESTATUS[0]}

--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -11,7 +11,7 @@
 //
 // Output: JSON array of contrast issues or Markdown report
 
-import { chromium } from 'playwright';
+import { loadPlaywright } from '../playwright-runtime.mjs';
 
 // ============================================================================
 // CLI Argument Parsing
@@ -265,7 +265,10 @@ async function main() {
   const options = parseArgs();
   let browser;
   try {
-    browser = await chromium.launch({ headless: true, args: ['--no-sandbox', '--disable-gpu'] });
+    const { chromium } = await loadPlaywright();
+    const launchOptions = { headless: true, args: ['--no-sandbox', '--disable-gpu'] };
+    if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+    browser = await chromium.launch(launchOptions);
     const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
     await context.addInitScript(BROWSER_SCRIPT);
     const page = await context.newPage();

--- a/.agents/scripts/browser-qa-helper-a11y.sh
+++ b/.agents/scripts/browser-qa-helper-a11y.sh
@@ -51,7 +51,7 @@ _run_contrast_checks() {
 
 		if [[ -f "$contrast_script" ]]; then
 			local contrast_result
-			contrast_result=$(node "$contrast_script" "$full_url" --format json --level "$level" 2>/dev/null) || contrast_result='{"error": "contrast check failed"}'
+			contrast_result=$(run_playwright_node "$contrast_script" "$full_url" --format json --level "$level" 2>/dev/null) || contrast_result='{"error": "contrast check failed"}'
 			contrast_json=$(jq -c \
 				--arg page "$page_path" \
 				--argjson contrast "$contrast_result" \
@@ -190,13 +190,16 @@ _generate_a11y_script() {
 ${document_checks}"
 
 	cat >"$script_file" <<SCRIPT
-import { chromium } from 'playwright';
+const playwrightImport = await import(process.env.AIDEVOPS_PLAYWRIGHT_MODULE);
+const { chromium } = playwrightImport.chromium ? playwrightImport : playwrightImport.default;
 
 const baseUrl = '${safe_url}'.replace(/\/\$/, '');
 const pages = [${pages_array}];
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const launchOptions = { headless: true };
+  if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  const browser = await chromium.launch(launchOptions);
   const context = await browser.newContext();
   const page = await context.newPage();
   const a11yResults = [];
@@ -283,7 +286,7 @@ cmd_a11y() {
 	_generate_a11y_script "$script_file" "$safe_url" "$pages_array"
 
 	local exit_code=0
-	node "$script_file" "$contrast_json" || exit_code=$?
+	run_playwright_node "$script_file" "$contrast_json" || exit_code=$?
 	rm -rf "$script_dir"
 	return $exit_code
 }

--- a/.agents/scripts/browser-qa-helper-core.sh
+++ b/.agents/scripts/browser-qa-helper-core.sh
@@ -249,19 +249,38 @@ _build_pages_js_array() {
 # Prerequisite Checks
 # =============================================================================
 
-# Verify Playwright is installed and available.
+# Resolve the exact Playwright package and browser runtime used by generated scripts.
 check_playwright() {
-	if ! command -v npx &>/dev/null; then
-		log_error "npx not found. Install Node.js first."
+	if ! command -v node &>/dev/null; then
+		log_error "Node.js not found. Install Node.js first."
 		return 1
 	fi
 
-	# Check if playwright is available (don't install browsers, just check)
-	if ! npx --no-install playwright --version &>/dev/null 2>&1; then
-		log_error "Playwright not installed. Run: npm install playwright && npx playwright install"
+	local runtime_script="${SCRIPT_DIR}/playwright-runtime.mjs"
+	if [[ ! -f "$runtime_script" ]]; then
+		log_error "Playwright runtime resolver not found: ${runtime_script}"
 		return 1
 	fi
+
+	local resolved_module
+	if ! resolved_module=$(node "$runtime_script" check); then
+		log_error "Browser QA requires both an importable Playwright Node package and an installed browser binary."
+		return 1
+	fi
+	export AIDEVOPS_PLAYWRIGHT_MODULE="$resolved_module"
 	return 0
+}
+
+# Run a Node script with the exact Playwright module verified by check_playwright.
+# Args: $1 = script path, remaining args are passed to the script.
+run_playwright_node() {
+	local script_file="$1"
+	shift
+	if [[ -z "${AIDEVOPS_PLAYWRIGHT_MODULE:-}" ]]; then
+		check_playwright || return 1
+	fi
+	AIDEVOPS_PLAYWRIGHT_MODULE="$AIDEVOPS_PLAYWRIGHT_MODULE" node "$script_file" "$@"
+	return $?
 }
 
 # Wait for a URL to become reachable.
@@ -300,7 +319,8 @@ _generate_screenshot_script() {
 	local full_page="$7"
 
 	cat >"$script_file" <<SCRIPT
-import { chromium } from 'playwright';
+const playwrightImport = await import(process.env.AIDEVOPS_PLAYWRIGHT_MODULE);
+const { chromium } = playwrightImport.chromium ? playwrightImport : playwrightImport.default;
 
 const baseUrl = '${safe_url}'.replace(/\/\$/, '');
 const viewports = [${viewport_array}];
@@ -310,7 +330,9 @@ const timeout = ${timeout};
 const fullPage = ${full_page};
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const launchOptions = { headless: true };
+  if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  const browser = await chromium.launch(launchOptions);
   const results = [];
 
   for (const vp of viewports) {
@@ -425,7 +447,7 @@ cmd_screenshot() {
 
 	log_info "Capturing screenshots for ${pages} at viewports: ${viewports}"
 	local exit_code=0
-	node "$script_file" || exit_code=$?
+	run_playwright_node "$script_file" || exit_code=$?
 	rm -rf "$script_dir"
 
 	if [[ "$exit_code" -ne 0 ]]; then

--- a/.agents/scripts/browser-qa-helper-tests.sh
+++ b/.agents/scripts/browser-qa-helper-tests.sh
@@ -114,7 +114,7 @@ cmd_stability() {
 	log_info "Running stability test on ${url} for pages: ${pages} (${reloads} reloads each)"
 	local exit_code=0
 	local output
-	output=$(node "$script_file") || exit_code=$?
+	output=$(run_playwright_node "$script_file") || exit_code=$?
 	rm -rf "$script_dir"
 
 	if [[ $exit_code -ne 0 ]]; then
@@ -182,14 +182,17 @@ _generate_smoke_script() {
 	local timeout="$4"
 
 	cat >"$script_file" <<SCRIPT
-import { chromium } from 'playwright';
+const playwrightImport = await import(process.env.AIDEVOPS_PLAYWRIGHT_MODULE);
+const { chromium } = playwrightImport.chromium ? playwrightImport : playwrightImport.default;
 
 const baseUrl = '${safe_url}'.replace(/\/\$/, '');
 const pages = [${pages_array}];
 const timeout = ${timeout};
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const launchOptions = { headless: true };
+  if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  const browser = await chromium.launch(launchOptions);
   const context = await browser.newContext();
   const results = [];
 
@@ -327,7 +330,7 @@ cmd_smoke() {
 	log_info "Running smoke test on ${url} for pages: ${pages}"
 	local exit_code=0
 	local output
-	output=$(node "$script_file") || exit_code=$?
+	output=$(run_playwright_node "$script_file") || exit_code=$?
 	rm -rf "$script_dir"
 
 	if [[ $exit_code -ne 0 ]]; then

--- a/.agents/scripts/browser-qa-helper.sh
+++ b/.agents/scripts/browser-qa-helper.sh
@@ -86,14 +86,17 @@ cmd_links() {
 	script_file="$script_dir/script.mjs"
 
 	cat >"$script_file" <<'SCRIPT'
-import { chromium } from 'playwright';
+const playwrightImport = await import(process.env.AIDEVOPS_PLAYWRIGHT_MODULE);
+const { chromium } = playwrightImport.chromium ? playwrightImport : playwrightImport.default;
 
 const baseUrl = process.argv[2].replace(/\/$/, '');
 const maxDepth = parseInt(process.argv[3] || '2', 10);
 const timeout = parseInt(process.argv[4] || '30000', 10);
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const launchOptions = { headless: true };
+  if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  const browser = await chromium.launch(launchOptions);
   const context = await browser.newContext();
   const page = await context.newPage();
 
@@ -151,7 +154,7 @@ SCRIPT
 
 	log_info "Checking links from ${url} (depth: ${depth})"
 	local exit_code=0
-	node "$script_file" "$url" "$depth" "$timeout" || exit_code=$?
+	run_playwright_node "$script_file" "$url" "$depth" "$timeout" || exit_code=$?
 	rm -rf "$script_dir"
 	return $exit_code
 }
@@ -174,7 +177,8 @@ _generate_stability_script() {
 	local poll_max_wait="$7"
 
 	cat >"$script_file" <<SCRIPT
-import { chromium } from 'playwright';
+const playwrightImport = await import(process.env.AIDEVOPS_PLAYWRIGHT_MODULE);
+const { chromium } = playwrightImport.chromium ? playwrightImport : playwrightImport.default;
 
 const baseUrl = '${safe_url}'.replace(/\/\$/, '');
 const pages = [${pages_array}];
@@ -229,7 +233,9 @@ async function domFingerprint(page) {
 }
 
 async function run() {
-  const browser = await chromium.launch({ headless: true });
+  const launchOptions = { headless: true };
+  if (process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE) launchOptions.executablePath = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  const browser = await chromium.launch(launchOptions);
   const allResults = [];
 
   for (const pagePath of pages) {
@@ -388,7 +394,8 @@ Examples:
 
 Prerequisites:
   - Node.js and npm installed
-  - Playwright installed: npm install playwright && npx playwright install
+  - Importable Playwright Node package (CLI presence alone is insufficient)
+  - Playwright browser binary: npx playwright install chromium
 
 Integration:
   Used by milestone-validation.md (Phase 3: Browser QA) during mission orchestration.
@@ -404,6 +411,9 @@ HELP
 main() {
 	local command="${1:-help}"
 	shift || true
+	if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
+		check_playwright || return 1
+	fi
 
 	case "$command" in
 	run) cmd_run "$@" ;;

--- a/.agents/scripts/browser-qa-worker.sh
+++ b/.agents/scripts/browser-qa-worker.sh
@@ -228,23 +228,18 @@ check_prerequisites() {
 		return 2
 	fi
 
-	# Check for npx (comes with Node.js)
-	if ! command -v npx >/dev/null 2>&1; then
-		log_error "npx is required but not found"
+	local runtime_script="${SCRIPT_DIR}/playwright-runtime.mjs"
+	if [[ ! -f "$runtime_script" ]]; then
+		log_error "Playwright runtime resolver not found: ${runtime_script}"
 		return 2
 	fi
 
-	# Check if Playwright is available
-	local pw_check=0
-	npx --no-install playwright --version >/dev/null 2>&1 || pw_check=$?
-	if [[ $pw_check -ne 0 ]]; then
-		log_warn "Playwright not installed globally. Will attempt to use npx."
-		# Check if playwright is in any local node_modules
-		if ! node -e "require('playwright')" 2>/dev/null; then
-			log_error "Playwright is not installed. Run: npm install playwright && npx playwright install"
-			return 2
-		fi
+	local resolved_module
+	if ! resolved_module=$(node "$runtime_script" check); then
+		log_error "Browser QA requires an importable Playwright package and browser binary"
+		return 2
 	fi
+	export AIDEVOPS_PLAYWRIGHT_MODULE="$resolved_module"
 
 	return 0
 }
@@ -376,7 +371,7 @@ run_browser_qa() {
 
 	# Run the Playwright QA script
 	local qa_exit=0
-	node "${node_args[@]}" || qa_exit=$?
+	AIDEVOPS_PLAYWRIGHT_MODULE="$AIDEVOPS_PLAYWRIGHT_MODULE" node "${node_args[@]}" || qa_exit=$?
 
 	case $qa_exit in
 	0)

--- a/.agents/scripts/browser-qa/browser-qa.mjs
+++ b/.agents/scripts/browser-qa/browser-qa.mjs
@@ -23,7 +23,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { chromium } from 'playwright';
+import { loadPlaywright } from '../playwright-runtime.mjs';
 
 // ============================================================================
 // CLI Argument Parsing
@@ -322,6 +322,7 @@ async function main() {
   const flows = parseFlows(options.baseUrl, options.flows);
   let browser;
   try {
+    const { chromium } = await loadPlaywright();
     browser = await chromium.launch(launchOptions());
     const context = await browser.newContext({ viewport: { width: options.viewportWidth, height: options.viewportHeight }, ignoreHTTPSErrors: true });
     const page = await context.newPage();

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -344,11 +344,19 @@ check_context_tools() {
 check_browser() {
 	echo -e "${BLUE}Browser Automation${NC}"
 
-	if is_installed "npx" && npx --no-install playwright --version &>/dev/null 2>&1; then
-		print_service "Playwright" "ready" "installed"
-	else
-		print_service "Playwright" "optional" "not installed"
+	local playwright_runtime="${SCRIPT_DIR}/playwright-runtime.mjs"
+	local playwright_state="optional"
+	local playwright_detail="Node package not importable"
+	if is_installed "node"; then
+		if node "$playwright_runtime" check &>/dev/null; then
+			playwright_state="ready"
+			playwright_detail="Node package and browser binary ready"
+		elif node "$playwright_runtime" resolve &>/dev/null; then
+			playwright_state="partial"
+			playwright_detail="Node package ready; browser binary missing"
+		fi
 	fi
+	print_service "Playwright" "$playwright_state" "$playwright_detail"
 
 	# Stagehand needs OpenAI or Anthropic key
 	if is_configured "OPENAI_API_KEY" || is_configured "ANTHROPIC_API_KEY"; then

--- a/.agents/scripts/playwright-runtime.mjs
+++ b/.agents/scripts/playwright-runtime.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { basename, delimiter, dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const MODULE_ENV = 'AIDEVOPS_PLAYWRIGHT_MODULE';
+const NPM_FALLBACK_ENV = 'AIDEVOPS_PLAYWRIGHT_NPX_FALLBACK';
+
+function moduleUrl(value) {
+  if (!value) return null;
+  if (value.startsWith('file:')) return value;
+  return pathToFileURL(realpathSync(value)).href;
+}
+
+function resolveFromAnchor(anchor) {
+  try {
+    const require = createRequire(pathToFileURL(anchor));
+    return pathToFileURL(realpathSync(require.resolve('playwright'))).href;
+  } catch {
+    return null;
+  }
+}
+
+function resolutionAnchors() {
+  const anchors = [fileURLToPath(import.meta.url), join(process.cwd(), '.aidevops-playwright-resolver.cjs')];
+  for (const entry of (process.env.PATH || '').split(delimiter)) {
+    if (!entry || dirname(entry) === entry) continue;
+    if (basename(entry) === '.bin' && basename(dirname(entry)) === 'node_modules') {
+      anchors.push(join(dirname(entry), '.aidevops-playwright-resolver.cjs'));
+    }
+  }
+  return [...new Set(anchors)];
+}
+
+async function validateModule(resolved) {
+  if (!resolved) return null;
+  try {
+    const imported = await import(resolved);
+    const runtime = imported.chromium ? imported : imported.default;
+    return runtime?.chromium ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveWithoutNpx() {
+  const explicit = process.env[MODULE_ENV];
+  if (explicit) {
+    const validated = await validateModule(moduleUrl(explicit));
+    if (validated) return validated;
+  }
+
+  for (const anchor of resolutionAnchors()) {
+    const validated = await validateModule(resolveFromAnchor(anchor));
+    if (validated) return validated;
+  }
+  return null;
+}
+
+function resolveViaNpx() {
+  if (process.env[NPM_FALLBACK_ENV] === '0') return null;
+  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  const result = spawnSync(
+    npxCommand,
+    ['--no-install', '--package', 'playwright', 'node', fileURLToPath(import.meta.url), 'resolve-path'],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, [NPM_FALLBACK_ENV]: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  if (result.status !== 0) return null;
+  const resolved = result.stdout.trim().split('\n').at(-1);
+  return resolved || null;
+}
+
+export async function resolvePlaywrightModule({ allowNpx = true } = {}) {
+  const local = await resolveWithoutNpx();
+  if (local) return local;
+
+  if (allowNpx) {
+    const npxResolved = resolveViaNpx();
+    const validated = await validateModule(npxResolved);
+    if (validated) return validated;
+  }
+
+  throw new Error(
+    'Playwright Node package is not importable. CLI availability alone is insufficient; install the package in an importable framework runtime.',
+  );
+}
+
+export async function loadPlaywright(resolvedModule = null) {
+  const resolved = resolvedModule || await resolvePlaywrightModule();
+  const imported = await import(resolved);
+  return imported.chromium ? imported : imported.default;
+}
+
+export async function playwrightStatus() {
+  let resolved;
+  let runtime;
+  try {
+    resolved = await resolvePlaywrightModule();
+    runtime = await loadPlaywright(resolved);
+  } catch (error) {
+    return {
+      packageImportable: false,
+      module: null,
+      browserBinaryAvailable: false,
+      browserExecutable: null,
+      error: error.message,
+    };
+  }
+
+  const configuredExecutable = process.env.AIDEVOPS_PLAYWRIGHT_EXECUTABLE;
+  let browserExecutable = configuredExecutable || null;
+  try {
+    browserExecutable ||= runtime.chromium.executablePath();
+  } catch {
+    browserExecutable = null;
+  }
+  return {
+    packageImportable: true,
+    module: resolved,
+    browserBinaryAvailable: Boolean(browserExecutable && existsSync(browserExecutable)),
+    browserExecutable: browserExecutable || null,
+  };
+}
+
+async function main() {
+  const command = process.argv[2] || 'status';
+  if (command === 'resolve' || command === 'resolve-path') {
+    const resolved = await resolvePlaywrightModule({ allowNpx: command === 'resolve' });
+    process.stdout.write(`${resolved}\n`);
+    return 0;
+  }
+
+  const status = await playwrightStatus();
+  if (command === 'status') {
+    process.stdout.write(`${JSON.stringify(status)}\n`);
+    return 0;
+  }
+  if (command === 'check') {
+    if (!status.packageImportable) throw new Error(status.error);
+    if (!status.browserBinaryAvailable) {
+      throw new Error('Playwright Node package is importable, but its Chromium browser binary is unavailable. Run: npx playwright install chromium');
+    }
+    process.stdout.write(`${status.module}\n`);
+    return 0;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : '';
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.agents/scripts/tests/test-browser-qa-helper.sh
+++ b/.agents/scripts/tests/test-browser-qa-helper.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../browser-qa-helper.sh"
+PLAYWRIGHT_RUNTIME="${SCRIPT_DIR}/../playwright-runtime.mjs"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -235,6 +236,75 @@ test_format_stability_markdown_unstable() {
 	return 0
 }
 
+test_runtime_resolves_npx_cached_package() {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	local fake_bin="${tmp_dir}/bin"
+	local fake_modules="${tmp_dir}/cache/node_modules"
+	local isolated_dir="${tmp_dir}/isolated"
+	local browser_path="${tmp_dir}/chromium"
+	mkdir -p "$fake_bin" "${fake_modules}/.bin" "${fake_modules}/playwright" "$isolated_dir"
+	touch "$browser_path"
+
+	cat >"${fake_modules}/playwright/package.json" <<'JSON'
+{"name":"playwright","type":"module","exports":"./index.mjs"}
+JSON
+	cat >"${fake_modules}/playwright/index.mjs" <<'JS'
+export const chromium = { executablePath: () => process.env.FAKE_PLAYWRIGHT_BROWSER };
+JS
+	cat >"${fake_bin}/npx" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "--no-install" ]] || exit 2
+while [[ $# -gt 0 && "$1" != "node" ]]; do shift; done
+[[ "${1:-}" == "node" ]] || exit 2
+shift
+export PATH="${FAKE_PLAYWRIGHT_MODULES}/.bin:${PATH}"
+exec node "$@"
+SH
+	chmod +x "${fake_bin}/npx"
+
+	local node_path
+	node_path=$(command -v node)
+	local direct_exit=0
+	(
+		cd "$isolated_dir" || exit 1
+		PATH="${node_path%/*}:/usr/bin:/bin" node --input-type=module -e "import('playwright')"
+	) >/dev/null 2>&1 || direct_exit=$?
+
+	local resolved=""
+	resolved=$(
+		AIDEVOPS_PLAYWRIGHT_MODULE="" \
+			FAKE_PLAYWRIGHT_BROWSER="$browser_path" \
+			FAKE_PLAYWRIGHT_MODULES="$fake_modules" \
+			PATH="${fake_bin}:${node_path%/*}:/usr/bin:/bin" \
+			node "$PLAYWRIGHT_RUNTIME" check
+	) || true
+
+	rm -f "$browser_path"
+	local missing_browser_status=""
+	missing_browser_status=$(
+		AIDEVOPS_PLAYWRIGHT_MODULE="" \
+			FAKE_PLAYWRIGHT_BROWSER="$browser_path" \
+			FAKE_PLAYWRIGHT_MODULES="$fake_modules" \
+			PATH="${fake_bin}:${node_path%/*}:/usr/bin:/bin" \
+			node "$PLAYWRIGHT_RUNTIME" status
+	) || true
+	local status_distinguishes_browser=0
+	if node -e 'const s=JSON.parse(process.argv[1]); process.exit(s.packageImportable && !s.browserBinaryAvailable ? 0 : 1)' "$missing_browser_status"; then
+		status_distinguishes_browser=1
+	fi
+
+	if [[ "$direct_exit" -ne 0 && "$resolved" == *"${fake_modules}/playwright/index.mjs" && "$status_distinguishes_browser" -eq 1 && ! -e "${isolated_dir}/package.json" && ! -d "${isolated_dir}/node_modules" ]]; then
+		print_result "runtime resolves npx cache when bare import fails" 0
+	else
+		print_result "runtime resolves npx cache when bare import fails" 1 "direct_exit=${direct_exit}, resolved=${resolved:-none}, browser_status=${missing_browser_status:-none}"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
 main() {
 	# Source after function declarations so helper functions are available here.
 	# main() in helper is guarded and will not auto-run when sourced.
@@ -262,6 +332,7 @@ main() {
 	test_stability_script_generation
 	test_format_stability_markdown_stable
 	test_format_stability_markdown_unstable
+	test_runtime_resolves_npx_cached_package
 
 	echo "============================================="
 	echo "  Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"


### PR DESCRIPTION
## Summary

- resolve the exact importable Playwright Node module from local resolution or an existing `npx --no-install` cache
- route generated browser-QA scripts and fixed accessibility/browser workers through the shared runtime contract
- remove accessibility's implicit dependency installation and report package importability separately from browser-binary availability

## Verification

- `bash .agents/scripts/tests/test-browser-qa-helper.sh` — 13/13 passed
- `.agents/scripts/linters-local.sh` — all local checks passed
- `node .agents/scripts/playwright-runtime.mjs check` — resolved and validated the existing Playwright runtime
- Node syntax checks passed for the resolver and both fixed `.mjs` consumers

Resolves #30472
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.277 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 35m and 457,525 tokens on this with the user in an interactive session.