### PR TITLE
GH#30478: close superseded Dependabot source PRs

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -31,6 +31,82 @@ _pulse_dependabot_existing_intake_issue() {
 	return $?
 }
 
+_pulse_dependabot_completed_intake_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local issues_json="[]"
+
+	issues_json=$(gh_issue_list --repo "$repo_slug" --state closed \
+		--search "Dependabot PR #${pr_number} in:title" --limit 20 \
+		--json number,body,labels 2>/dev/null) || return 1
+	printf '%s' "$issues_json" | jq -r --arg marker "$marker" '
+		[.[]
+			 | select((.body // "") | contains($marker))
+			 | ([.labels[]?.name // ""] | unique) as $labels
+			 | select(($labels | index("origin:worker")) != null)
+			 | select(($labels | index("status:done")) != null)
+			 | select(($labels | index("solved:worker")) != null)]
+		| .[0].number // ""' 2>/dev/null
+	return $?
+}
+
+# Close an authentic held source PR only when its generated worker intake is
+# terminal and a different same-repository PR verifiably merged to close it.
+# Missing, truncated, stale-head, or unavailable evidence preserves the hold.
+_pulse_dependabot_close_superseded_source_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local marker="$4"
+	local intake_issue=""
+	local superseding_pr=""
+	local final_json=""
+	local final_state=""
+	local final_head=""
+	local final_labels=""
+	local close_comment=""
+
+	declare -F _psh_find_merged_closer_for_closed_issue >/dev/null 2>&1 || return 1
+	declare -F gh_pr_close_safe >/dev/null 2>&1 || return 1
+	intake_issue=$(_pulse_dependabot_completed_intake_issue "$pr_number" "$repo_slug" "$marker") || return 1
+	[[ "$intake_issue" =~ ^[0-9]+$ ]] || return 1
+	superseding_pr=$(_psh_find_merged_closer_for_closed_issue \
+		"$repo_slug" "$intake_issue" "$pr_number" 2>/dev/null) || return 1
+	[[ "$superseding_pr" =~ ^[0-9]+$ && "$superseding_pr" != "$pr_number" ]] || return 1
+
+	final_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json state,headRefOid,labels 2>/dev/null) || return 1
+	final_state=$(printf '%s' "$final_json" | jq -r '.state // ""' 2>/dev/null) || return 1
+	final_head=$(printf '%s' "$final_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
+	final_labels=$(printf '%s' "$final_json" | jq -r '[.labels[]?.name] | join(",")' 2>/dev/null) || return 1
+	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" ]] || return 1
+	[[ ",${final_labels}," == *",needs-maintainer-review,"* ]] || return 1
+
+	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE="$intake_issue"
+	_PULSE_DEPENDABOT_SUPERSEDING_PR="$superseding_pr"
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-dependabot-intake] DRY-RUN: PR #${pr_number} in ${repo_slug} would close as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
+		return 0
+	fi
+
+	close_comment="<!-- aidevops:dependabot-source-superseded intake=${intake_issue} replacement=${superseding_pr} -->
+Closing this Dependabot source PR as superseded: generated worker intake #${intake_issue} is terminal and was closed by verified merged replacement PR #${superseding_pr}.
+
+The explicit maintainer hold prevented unsafe automatic merge while the replacement converged. Pulse revalidated the source head and hold immediately before this close.
+
+_Closed by deterministic Dependabot lifecycle reconciliation (GH#30478)._"
+	if ! gh_pr_close_safe "$pr_number" --repo "$repo_slug" --comment "$close_comment" >/dev/null 2>&1; then
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: verified replacement PR #${superseding_pr}, but source close failed" >>"$LOGFILE"
+		return 1
+	fi
+	if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+		_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed superseded Dependabot source PR #${pr_number}"
+	fi
+	echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: closed as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
+	return 0
+}
+
 # Return 0 when the source PR carries an explicit maintainer-review hold,
 # 1 when it does not, and 2 when the live label state cannot be verified.
 _pulse_dependabot_pr_has_maintainer_hold() {
@@ -175,6 +251,10 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	_pulse_dependabot_pr_has_maintainer_hold "$pr_number" "$repo_slug" || hold_rc=$?
 	case "$hold_rc" in
 	0)
+		if _pulse_dependabot_close_superseded_source_pr \
+			"$pr_number" "$repo_slug" "$expected_head_sha" "$marker"; then
+			return 4
+		fi
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: preserving explicit needs-maintainer-review hold; no worker issue created" >>"$LOGFILE"
 		return 3
 		;;

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -527,6 +527,13 @@ _check_pr_merge_gates() {
 			3)
 				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR has an explicit maintainer-review hold; preserving it without worker intake (GH#30389)" >>"$LOGFILE"
 				;;
+			4)
+				if [[ "${DRY_RUN:-0}" == "1" ]]; then
+					echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — would close superseded Dependabot source after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
+				else
+					echo "[pulse-wrapper] Merge pass: closed superseded Dependabot source PR #${pr_number} in ${repo_slug} after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
+				fi
+				;;
 			*)
 				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
 				;;

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -7,10 +7,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 INTAKE_SCRIPT="${SCRIPT_DIR}/../pulse-dependabot-intake.sh"
 TEST_ROOT=""
-ISSUES_JSON="[]"
+OPEN_ISSUES_JSON="[]"
+CLOSED_ISSUES_JSON="[]"
 AUTHENTIC=1
 PR_LABELS=""
+PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
 PR_VIEW_FAIL=0
+SUPERSEDING_PR=""
 
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
@@ -38,13 +41,37 @@ _is_authentic_dependabot_pr() {
 }
 
 gh_issue_list() {
-	printf '%s\n' "$ISSUES_JSON"
+	local args=" $* "
+	if [[ "$args" == *" --state closed "* ]]; then
+		printf '%s\n' "$CLOSED_ISSUES_JSON"
+	else
+		printf '%s\n' "$OPEN_ISSUES_JSON"
+	fi
 	return 0
 }
 
 gh_pr_view() {
 	[[ "$PR_VIEW_FAIL" -eq 0 ]] || return 1
-	printf '%s\n' "$PR_LABELS"
+	if [[ " $* " == *" --json state,headRefOid,labels "* ]]; then
+		printf '%s\n' "$PR_FINAL_JSON"
+	else
+		printf '%s\n' "$PR_LABELS"
+	fi
+	return 0
+}
+
+_psh_find_merged_closer_for_closed_issue() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local current_pr="$3"
+	[[ "$repo_slug" == "owner/repo" && "$issue_number" == "42" && "$current_pr" == "30038" ]] || return 1
+	[[ "$SUPERSEDING_PR" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$SUPERSEDING_PR"
+	return 0
+}
+
+gh_pr_close_safe() {
+	printf '%s\n' "$@" >"${TEST_ROOT}/pr-close-args"
 	return 0
 }
 
@@ -81,7 +108,8 @@ assert_file_contains() {
 
 test_creates_worker_ready_issue() {
 	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/created-body"
-	ISSUES_JSON="[]"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON="[]"
 	AUTHENTIC=1
 	PR_LABELS=""
 	PR_VIEW_FAIL=0
@@ -95,7 +123,7 @@ test_creates_worker_ready_issue() {
 
 test_reuses_existing_issue() {
 	rm -f "${TEST_ROOT}/create-args"
-	ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
+	OPEN_ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "terminal-ci-failure"
 	[[ ! -e "${TEST_ROOT}/create-args" ]]
 	return $?
@@ -103,7 +131,7 @@ test_reuses_existing_issue() {
 
 test_rejects_unverified_author() {
 	rm -f "${TEST_ROOT}/create-args"
-	ISSUES_JSON="[]"
+	OPEN_ISSUES_JSON="[]"
 	AUTHENTIC=0
 	if _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"; then
 		return 1
@@ -116,7 +144,8 @@ test_preserves_explicit_maintainer_hold() {
 	local route_rc=0
 
 	rm -f "${TEST_ROOT}/create-args"
-	ISSUES_JSON="[]"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON="[]"
 	AUTHENTIC=1
 	PR_LABELS="needs-maintainer-review"
 	PR_VIEW_FAIL=0
@@ -128,11 +157,108 @@ test_preserves_explicit_maintainer_hold() {
 	return 0
 }
 
+test_closes_held_source_after_verified_replacement() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_VIEW_FAIL=0
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 4 ]] || return 1
+	assert_file_contains "superseded source PR is closed" "${TEST_ROOT}/pr-close-args" "30038"
+	assert_file_contains "source close names verified replacement" "${TEST_ROOT}/pr-close-args" "verified merged replacement PR #99"
+	assert_file_contains "source close is diagnosed" "$LOGFILE" "closed as superseded by merged PR #99 for completed intake #42"
+	CLOSED_ISSUES_JSON="[]"
+	PR_LABELS=""
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_preserves_hold_when_terminal_issue_has_no_merged_replacement() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	SUPERSEDING_PR=""
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	CLOSED_ISSUES_JSON="[]"
+	PR_LABELS=""
+	return 0
+}
+
+test_preserves_hold_without_worker_solution_attribution() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:interactive"}]}]'
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	CLOSED_ISSUES_JSON="[]"
+	PR_LABELS=""
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_preserves_hold_when_source_head_drifted() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","labels":[{"name":"needs-maintainer-review"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	CLOSED_ISSUES_JSON="[]"
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_LABELS=""
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_dry_run_reports_supersession_without_close() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS="needs-maintainer-review"
+	SUPERSEDING_PR="99"
+	DRY_RUN=1 _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 4 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	assert_file_contains "dry-run reports verified source supersession" "$LOGFILE" "would close as superseded by merged PR #99"
+	CLOSED_ISSUES_JSON="[]"
+	PR_LABELS=""
+	SUPERSEDING_PR=""
+	return 0
+}
+
 test_fails_closed_when_hold_state_is_unavailable() {
 	local route_rc=0
 
 	rm -f "${TEST_ROOT}/create-args"
-	ISSUES_JSON="[]"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON="[]"
 	AUTHENTIC=1
 	PR_LABELS=""
 	PR_VIEW_FAIL=1
@@ -146,7 +272,8 @@ test_fails_closed_when_hold_state_is_unavailable() {
 
 test_dry_run_has_no_write() {
 	rm -f "${TEST_ROOT}/create-args"
-	ISSUES_JSON="[]"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON="[]"
 	AUTHENTIC=1
 	DRY_RUN=1 _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "merge-conflict"
 	[[ ! -e "${TEST_ROOT}/create-args" ]]
@@ -232,6 +359,11 @@ main() {
 	test_rejects_unverified_author
 	printf 'PASS unverified authors fail closed\n'
 	test_preserves_explicit_maintainer_hold
+	test_closes_held_source_after_verified_replacement
+	test_preserves_hold_when_terminal_issue_has_no_merged_replacement
+	test_preserves_hold_without_worker_solution_attribution
+	test_preserves_hold_when_source_head_drifted
+	test_dry_run_reports_supersession_without_close
 	test_fails_closed_when_hold_state_is_unavailable
 	test_dry_run_has_no_write
 	printf 'PASS dry-run performs no GitHub write\n'


### PR DESCRIPTION
## Summary

- reconcile held Dependabot source PRs after their generated worker intake is completed by a verified merged replacement
- revalidate source state, exact head, and maintainer hold immediately before audited closure
- preserve genuine holds when completion, attribution, replacement, or head evidence is missing

## Verification

- `bash .agents/scripts/tests/test-pulse-dependabot-intake.sh`
- `bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `bash .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh`
- `.agents/scripts/linters-local.sh`

Resolves #30478
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.277 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 17m and 442,291 tokens on this with the user in an interactive session.