### PR TITLE
GH#30484: preserve unreadable worktrees during dispatch and cleanup

### DIFF
--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -687,8 +687,18 @@ _cleanup_single_worktree() {
 
 	local commits_ahead=0
 	commits_ahead=$(_pc_commits_ahead_from_default "$rp_age" "$wt_path_age" "$main_branch") || return 1
+	local status_out=""
+	if ! status_out=$(GIT_OPTIONAL_LOCKS=0 git -C "$wt_path_age" status --porcelain 2>/dev/null); then
+		local unreadable_context="branch=${wt_branch_age:-detached} age_secs=${wt_age_secs}"
+		echo "[pulse-wrapper] Orphan cleanup: preserving ${wt_branch_age:-detached} — Git index/state is unreadable" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"unreadable-git-state" "$_PC_REMOVAL_SKIPPED" "$unreadable_context"
+		return 1
+	fi
 	local dirty_count=0
-	dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || return 1
+	if [[ -n "$status_out" ]]; then
+		dirty_count=$(printf '%s\n' "$status_out" | wc -l | tr -d ' ') || return 1
+	fi
 	local removal_guard_status=0
 	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE"; then
 		removal_guard_status=0

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -647,6 +647,23 @@ _pc_permanently_remove_eligible_orphan() {
 	return 0
 }
 
+_pc_read_worktree_status_or_skip() {
+	local wt_path_age="$1"
+	local wt_branch_age="$2"
+	local wt_age_secs="$3"
+	local status_out=""
+
+	if ! status_out=$(GIT_OPTIONAL_LOCKS=0 git -C "$wt_path_age" status --porcelain 2>/dev/null); then
+		local unreadable_context="branch=${wt_branch_age:-detached} age_secs=${wt_age_secs}"
+		echo "[pulse-wrapper] Orphan cleanup: preserving ${wt_branch_age:-detached} — Git index/state is unreadable" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"unreadable-git-state" "$_PC_REMOVAL_SKIPPED" "$unreadable_context"
+		return 1
+	fi
+	printf '%s' "$status_out"
+	return 0
+}
+
 #######################################
 # Per-worktree age-based orphan cleanup decision and removal.
 #
@@ -688,13 +705,7 @@ _cleanup_single_worktree() {
 	local commits_ahead=0
 	commits_ahead=$(_pc_commits_ahead_from_default "$rp_age" "$wt_path_age" "$main_branch") || return 1
 	local status_out=""
-	if ! status_out=$(GIT_OPTIONAL_LOCKS=0 git -C "$wt_path_age" status --porcelain 2>/dev/null); then
-		local unreadable_context="branch=${wt_branch_age:-detached} age_secs=${wt_age_secs}"
-		echo "[pulse-wrapper] Orphan cleanup: preserving ${wt_branch_age:-detached} — Git index/state is unreadable" >>"$LOGFILE"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-			"unreadable-git-state" "$_PC_REMOVAL_SKIPPED" "$unreadable_context"
-		return 1
-	fi
+	status_out=$(_pc_read_worktree_status_or_skip "$wt_path_age" "$wt_branch_age" "$wt_age_secs") || return 1
 	local dirty_count=0
 	if [[ -n "$status_out" ]]; then
 		dirty_count=$(printf '%s\n' "$status_out" | wc -l | tr -d ' ') || return 1

--- a/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
@@ -235,7 +235,37 @@ test_reachable_unpushed_commits_protected() {
 	return 0
 }
 
-# Scenario 4: pulse-cleanup must source cleanly under `set -u` — the
+# Scenario 4: an unreadable index must produce an audited skip. Cleanup cannot
+# prove that uncommitted work is absent, so it must preserve the worktree.
+test_unreadable_index_is_preserved_and_audited() {
+	local repo_dir="${TEST_ROOT}/repo-unreadable-index"
+	local wt_path="${TEST_ROOT}/wt-unreadable-index"
+	local branch_name="fix/unreadable-index"
+	setup_repo_with_worktree_aged "$repo_dir" "$wt_path" "$branch_name" 7 || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local git_dir=""
+	git_dir=$(git -C "$wt_path" rev-parse --absolute-git-dir) || return 1
+	: >"${git_dir}/index"
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'unreadable-git-state.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "unreadable worktree index is preserved and audited" "$rc" \
+		"cleanup_rc=$cleanup_rc dir_exists=$([[ -d "$wt_path" ]] && echo y || echo n) log=$(<"$AIDEVOPS_CLEANUP_LOG")"
+	return 0
+}
+
+# Scenario 5: pulse-cleanup must source cleanly under `set -u` — the
 # previous `unset _PULSE_CLEANUP_SCRIPT_DIR` left line ~251 with an
 # unbound variable. This test catches regression of the unset.
 test_sources_under_set_u() {
@@ -276,6 +306,7 @@ echo "=== test-pulse-cleanup-preserves-dirty.sh ==="
 test_dirty_worktree_past_grace_skips_removal
 test_dirty_worktree_past_6h_still_skips
 test_reachable_unpushed_commits_protected
+test_unreadable_index_is_preserved_and_audited
 test_sources_under_set_u
 
 echo ""

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -1072,6 +1072,39 @@ test_force_merged_preserves_unreadable_index() {
 	return 0
 }
 
+test_degraded_cleanup_audits_unreadable_index() {
+	local repo_path="${TEST_ROOT}/repo-degraded-unreadable-index"
+	local wt_path="${TEST_ROOT}/wt-degraded-unreadable-index"
+	local log_file="${TEST_ROOT}/degraded-unreadable-index-cleanup.log"
+	local branch="feature/gh-99027-degraded-unreadable-index"
+	local git_dir=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" branch "$branch" main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+	git_dir=$(git -C "$wt_path" rev-parse --absolute-git-dir) || rc=1
+	: >"${git_dir}/index"
+
+	if (
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		WORKTREE_REMOVAL_GUARD_REASON="cwd-visibility-degraded"
+		_clean_has_exact_removal_lease() { return 0; }
+		_clean_degraded_visibility_fallback_allowed "$wt_path" "$branch" \
+			"$_WT_CLEAN_TYPE_CLOSED_PR" "" "$branch" "" \
+			"test=degraded-unreadable-index" "main"
+	); then
+		rc=1
+	fi
+
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*unreadable-git-state.*mode=skipped" || rc=1
+	print_result "degraded cleanup audits unreadable index" "$rc" \
+		"Expected unreadable index to block degraded recoverable cleanup"
+	return 0
+}
+
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_terminal_pr_proof_bypasses_protected_pass_skip
@@ -1100,6 +1133,7 @@ test_fix_numeric_closed_issue_branch_removes_worktree_preserves_branch
 test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch
 test_closed_issue_dirty_lock_race_preserves_files
 test_force_merged_preserves_unreadable_index
+test_degraded_cleanup_audits_unreadable_index
 
 printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -1042,6 +1042,36 @@ RACE_GIT
 	return 0
 }
 
+test_force_merged_preserves_unreadable_index() {
+	local repo_path="${TEST_ROOT}/repo-unreadable-index"
+	local wt_path="${TEST_ROOT}/wt-unreadable-index"
+	local log_file="${TEST_ROOT}/unreadable-index-cleanup.log"
+	local branch="feature/gh-99026-unreadable-index"
+	local git_dir=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" branch "$branch" main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+	git_dir=$(git -C "$wt_path" rev-parse --absolute-git-dir) || rc=1
+	: >"${git_dir}/index"
+
+	if (
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_remove_classified_worktree "$wt_path" "$branch" "true" "false" \
+			"test=unreadable-index" "$repo_path"
+	); then
+		rc=1
+	fi
+
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*unreadable-git-state.*mode=skipped" || rc=1
+	print_result "force-merged cleanup preserves unreadable index" "$rc" \
+		"Expected unreadable index to block forced merged-worktree removal"
+	return 0
+}
+
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_terminal_pr_proof_bypasses_protected_pass_skip
@@ -1069,6 +1099,7 @@ test_closed_issue_unproven_branch_removes_worktree_preserves_branch
 test_fix_numeric_closed_issue_branch_removes_worktree_preserves_branch
 test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch
 test_closed_issue_dirty_lock_race_preserves_files
+test_force_merged_preserves_unreadable_index
 
 printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -68,6 +68,40 @@ if compgen -G "${WORKTREES}/.canonical-fetch-*" >/dev/null; then
 fi
 printf 'PASS canonical-guard bootstrap fetch worktree is removed\n'
 
+# A registered sibling can exist while its index is unreadable. The fetch
+# selector must skip that candidate and use the bootstrap path instead of
+# allowing one unhealthy worktree to block all new worktree creation.
+UNHEALTHY_FETCH_MARKER="${ROOT}/unhealthy-fetch-attempted"
+if ! (
+	cd "$CANONICAL" || exit 1
+	SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)"
+	# shellcheck source=../worktree-helper-add.sh
+	source "$ADD_HELPER"
+	git() {
+		local first_arg="${1:-}"
+		local second_arg="${2:-}"
+		local third_arg="${3:-}"
+		if [[ "$first_arg" == "-C" && "$second_arg" == "$FRESH_PATH" && "$third_arg" == "status" ]]; then
+			return 128
+		fi
+		if [[ "$first_arg" == "-C" && "$second_arg" == "$FRESH_PATH" && "$third_arg" == "fetch" ]]; then
+			: >"$UNHEALTHY_FETCH_MARKER"
+			return 97
+		fi
+		"$REAL_GIT" "$@"
+		return $?
+	}
+	_worktree_refresh_origin_branch main
+); then
+	printf 'FAIL unhealthy sibling prevented bootstrap fetch fallback\n'
+	exit 1
+fi
+if [[ -e "$UNHEALTHY_FETCH_MARKER" ]]; then
+	printf 'FAIL fetch was attempted through an unhealthy sibling worktree\n'
+	exit 1
+fi
+printf 'PASS unhealthy sibling is skipped for bootstrap fetch fallback\n'
+
 "$REAL_GIT" -C "$CANONICAL" remote set-url origin "${ROOT}/missing.git"
 if (cd "$CANONICAL" && "$HELPER" add test/fetch-failure >/dev/null 2>&1); then
 	printf 'FAIL worktree creation accepted an unrefreshable remote base\n'

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -72,16 +72,21 @@ printf 'PASS canonical-guard bootstrap fetch worktree is removed\n'
 # selector must skip that candidate and use the bootstrap path instead of
 # allowing one unhealthy worktree to block all new worktree creation.
 UNHEALTHY_FETCH_MARKER="${ROOT}/unhealthy-fetch-attempted"
+UNHEALTHY_AUDIT_MARKER="${ROOT}/unhealthy-fetch-audit"
 if ! (
 	cd "$CANONICAL" || exit 1
 	SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)"
 	# shellcheck source=../worktree-helper-add.sh
 	source "$ADD_HELPER"
+	log_worktree_removal_event() {
+		printf '%s\n' "$*" >>"$UNHEALTHY_AUDIT_MARKER"
+		return 0
+	}
 	git() {
 		local first_arg="${1:-}"
 		local second_arg="${2:-}"
 		local third_arg="${3:-}"
-		if [[ "$first_arg" == "-C" && "$second_arg" == "$FRESH_PATH" && "$third_arg" == "status" ]]; then
+		if [[ "$first_arg" == "-C" && "$third_arg" == "status" ]]; then
 			return 128
 		fi
 		if [[ "$first_arg" == "-C" && "$second_arg" == "$FRESH_PATH" && "$third_arg" == "fetch" ]]; then
@@ -98,6 +103,10 @@ if ! (
 fi
 if [[ -e "$UNHEALTHY_FETCH_MARKER" ]]; then
 	printf 'FAIL fetch was attempted through an unhealthy sibling worktree\n'
+	exit 1
+fi
+if ! grep -q "unreadable-git-state.*operation=fresh-base-fetch.*target_branch=main" "$UNHEALTHY_AUDIT_MARKER"; then
+	printf 'FAIL unhealthy sibling skip was not audited\n'
 	exit 1
 fi
 printf 'PASS unhealthy sibling is skipped for bootstrap fetch fallback\n'

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -1462,6 +1462,21 @@ _clean_remove_recoverably_after_lease() {
 	return 0
 }
 
+_clean_worktree_index_is_readable() {
+	local worktree_path="$1"
+	local worktree_branch="$2"
+	local audit_context="$3"
+
+	if GIT_OPTIONAL_LOCKS=0 git -C "$worktree_path" status --porcelain >/dev/null 2>&1; then
+		return 0
+	fi
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" \
+		"unreadable-git-state" "$_WT_CLEAN_MODE_SKIPPED" \
+		"branch=${worktree_branch:-detached} $audit_context"
+	echo -e "${YELLOW}Skipped $worktree_branch - Git index/state is unreadable${NC}" >&2
+	return 1
+}
+
 _clean_remove_classified_worktree() {
 	local worktree_path="$1"
 	local worktree_branch="$2"
@@ -1488,11 +1503,14 @@ _clean_remove_classified_worktree() {
 		if [[ "$guard_status" -ne 0 && "$guard_status" -ne "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]]; then
 			return 1
 		fi
+	elif [[ "$guard_status" -ne 0 ]]; then
+		return "$guard_status"
+	fi
+	_clean_worktree_index_is_readable "$worktree_path" "$worktree_branch" "$audit_context" || return 1
+	if [[ "$removal_mode" == "$_WT_CLEAN_MODE_RECOVERABLE" ]]; then
 		worktree_has_changes "$worktree_path" && return 1
 		_branch_has_active_interactive_claim "$worktree_path" "$worktree_branch" && return 1
 		_clean_has_exact_removal_lease "$worktree_path" || return 1
-	elif [[ "$guard_status" -ne 0 ]]; then
-		return "$guard_status"
 	fi
 
 	if worktree_has_changes "$worktree_path" && [[ "$force_merged" == "$_WT_CLEAN_BOOL_TRUE" ]]; then

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -1397,6 +1397,7 @@ _clean_degraded_visibility_fallback_allowed() {
 	local default_br="$8"
 
 	[[ "${WORKTREE_REMOVAL_GUARD_REASON:-}" == "${_WT_CWD_REASON_DEGRADED:-cwd-visibility-degraded}" ]] || return 1
+	_clean_worktree_index_is_readable "$worktree_path" "$worktree_branch" "$audit_context" || return 1
 	if worktree_has_changes "$worktree_path"; then
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "degraded-cwd-dirty-skip" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
 		return 1

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -875,7 +875,14 @@ _worktree_refresh_origin_branch() {
 			[[ -n "$worktree_path" && "$worktree_path" != "$current_root" && -d "$worktree_path" ]] || continue
 			# `rev-parse HEAD` does not read the index. Probe with status so a
 			# truncated/corrupt sibling index cannot poison fresh-base fetches.
-			GIT_OPTIONAL_LOCKS=0 git -C "$worktree_path" status --porcelain --untracked-files=no >/dev/null 2>&1 || continue
+			if ! GIT_OPTIONAL_LOCKS=0 git -C "$worktree_path" status --porcelain --untracked-files=no >/dev/null 2>&1; then
+				if declare -F log_worktree_removal_event >/dev/null 2>&1; then
+					log_worktree_removal_event "${_WTAR_SKIPPED:-skipped}" "${_WTAR_WH_CALLER:-worktree-helper.sh}" \
+						"$worktree_path" "unreadable-git-state" "skipped" \
+						"operation=fresh-base-fetch target_branch=$branch"
+				fi
+				continue
+			fi
 			fetch_cwd="$worktree_path"
 			break
 		done < <(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -873,6 +873,9 @@ _worktree_refresh_origin_branch() {
 		local worktree_path=""
 		while IFS= read -r worktree_path; do
 			[[ -n "$worktree_path" && "$worktree_path" != "$current_root" && -d "$worktree_path" ]] || continue
+			# `rev-parse HEAD` does not read the index. Probe with status so a
+			# truncated/corrupt sibling index cannot poison fresh-base fetches.
+			GIT_OPTIONAL_LOCKS=0 git -C "$worktree_path" status --porcelain --untracked-files=no >/dev/null 2>&1 || continue
 			fetch_cwd="$worktree_path"
 			break
 		done < <(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')


### PR DESCRIPTION
## Summary

Skip unreadable linked worktrees during fresh-base selection, preserve them in age-based and merged cleanup, and emit audited unreadable-state events.

## Files Changed

.agents/scripts/pulse-cleanup-worktree-removal.sh, .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/tests/test-worktree-fresh-base.sh, .agents/scripts/worktree-clean-lib.sh, .agents/scripts/worktree-helper-add.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck and local quality gates pass; focused fresh-base, orphan-cleanup, and merged-cleanup regressions pass, including corrupt-index and degraded cleanup cases.

Resolves #30484


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.278 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 48m and 492,474 tokens on this with the user in an interactive session.