### PR TITLE
GH#30483: Fix bounded browser MCP activation

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -119,10 +119,10 @@ Implements proven patterns from Lance Martin (LangChain), validated across Claud
 
 **Two-tier MCP strategy** (all MCPs use `eager: false` and start disabled):
 
-1. **Explicit activation agents** (`activationAgent`): a bounded profile can use `aidevops_mcp` to connect its registry-approved MCP. Playwriter is the initial implementation.
+1. **Explicit activation agents** (`activationAgent`): a bounded profile can use `aidevops_mcp` to connect its registry-approved MCP. Playwriter and Playwright are the initial browser implementations.
 2. **Per-agent permission only** (`globallyEnabled: false`): tool patterns stay hidden globally and are exposed only on the owning agent profile.
 
-**How it works:** OpenCode treats `enabled: false` as disconnected, not automatic lazy loading. An explicit activation agent calls the registry-allowlisted `aidevops_mcp` tool, which uses OpenCode's MCP connect API. The MCP tools appear on the following model step and can be disconnected when work is complete. There are no idle MCP processes or tool-schema cost in unrelated sessions. The plugin registry is authoritative; do not edit generated `opencode.json` MCP entries directly.
+**How it works:** OpenCode treats `enabled: false` as disconnected, not automatic lazy loading. An explicit activation agent calls the registry-allowlisted `aidevops_mcp` tool, which uses OpenCode's MCP connect API and waits for the asynchronous status to report `connected`. The MCP tools appear on the following model step and can be disconnected when work is complete. There are no idle MCP processes or tool-schema cost in unrelated sessions. The plugin registry is authoritative; do not edit generated `opencode.json` MCP entries directly.
 
 **Adding runtime activation for an MCP requires:**
 1. `mcp-registry.mjs` — add the MCP plus an explicit `activationAgent`, `agentSource`, and `modelTier`.

--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -30,6 +30,7 @@ subagents:
   - context7
   - toon
   # Browser/testing
+  - playwriter
   - playwright
   - stagehand
   - pagespeed

--- a/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
+++ b/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
@@ -120,7 +120,7 @@ function createOnDemandMcpProfile(mcp, agentsDir) {
       [mcp.toolPattern]: true,
     },
     permission: {
-      ...(parsed?.profile.permission || {}),
+      ...parsed?.profile.permission,
       [MCP_ACTIVATION_TOOL]: "allow",
       [mcp.toolPattern]: "allow",
     },

--- a/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
+++ b/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
@@ -119,6 +119,11 @@ function createOnDemandMcpProfile(mcp, agentsDir) {
       [MCP_ACTIVATION_TOOL]: true,
       [mcp.toolPattern]: true,
     },
+    permission: {
+      ...(parsed?.profile.permission || {}),
+      [MCP_ACTIVATION_TOOL]: "allow",
+      [mcp.toolPattern]: "allow",
+    },
   };
 }
 
@@ -132,6 +137,12 @@ function ensureOnDemandMcpAgent(config, mcp, agentsDir) {
   if (!(MCP_ACTIVATION_TOOL in config.agent[mcp.agentName].tools)) {
     config.agent[mcp.agentName].tools[MCP_ACTIVATION_TOOL] = true;
   }
+  config.agent[mcp.agentName].tools[mcp.toolPattern] = true;
+  if (!config.agent[mcp.agentName].permission) config.agent[mcp.agentName].permission = {};
+  if (!(MCP_ACTIVATION_TOOL in config.agent[mcp.agentName].permission)) {
+    config.agent[mcp.agentName].permission[MCP_ACTIVATION_TOOL] = "allow";
+  }
+  config.agent[mcp.agentName].permission[mcp.toolPattern] = "allow";
   return false;
 }
 

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -5,12 +5,40 @@
  * Create the bounded MCP activation tool.
  * @param {function} tool
  * @param {object} z
- * @param {{client: object, directory?: string, allowedNames: string[]}} options
+ * @param {{client: object, directory?: string, allowedNames: string[], connectTimeoutMs?: number, pollIntervalMs?: number, pause?: function}} options
  * @returns {object}
  */
 export function createMcpActivationTool(tool, z, options) {
   const allowedNames = [...new Set(options.allowedNames || [])];
   const allowed = new Set(allowedNames);
+  const connectTimeoutMs = options.connectTimeoutMs || 30_000;
+  const pollIntervalMs = options.pollIntervalMs || 500;
+  const pause = options.pause
+    || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+
+  async function waitForConnection(name) {
+    const statusMethod = options.client?.status;
+    if (typeof statusMethod !== "function") return;
+
+    const request = options.directory ? { query: { directory: options.directory } } : {};
+    const deadline = Date.now() + connectTimeoutMs;
+    let status = "unknown";
+    do {
+      const result = await statusMethod.call(options.client, request);
+      if (result?.error) {
+        throw new Error(result.error.message || String(result.error));
+      }
+      const payload = result?.data ?? result;
+      status = payload?.[name]?.status || "unknown";
+      if (status === "connected") return;
+      if (["error", "failed"].includes(status)) {
+        throw new Error(`MCP entered ${status} status`);
+      }
+      await pause(pollIntervalMs);
+    } while (Date.now() < deadline);
+
+    throw new Error(`MCP did not become ready (last status: ${status})`);
+  }
 
   return tool({
     description:
@@ -34,12 +62,13 @@ export function createMcpActivationTool(tool, z, options) {
 
       try {
         const result = await method.call(options.client, {
-          name,
-          ...(options.directory ? { directory: options.directory } : {}),
+          path: { name },
+          ...(options.directory ? { query: { directory: options.directory } } : {}),
         });
         if (result?.error) {
           return `Error: MCP ${action} failed for ${name}: ${result.error.message || String(result.error)}`;
         }
+        if (action === "connect") await waitForConnection(name);
       } catch (error) {
         return `Error: MCP ${action} failed for ${name}: ${error instanceof Error ? error.message : String(error)}`;
       }

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -1,6 +1,33 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+async function waitForConnection(name, options) {
+  const statusMethod = options.client?.status;
+  if (typeof statusMethod !== "function") return;
+
+  const request = options.directory ? { query: { directory: options.directory } } : {};
+  const deadline = Date.now() + (options.connectTimeoutMs || 30_000);
+  const pollIntervalMs = options.pollIntervalMs || 500;
+  const pause = options.pause
+    || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  let status = "unknown";
+  do {
+    const result = await statusMethod.call(options.client, request);
+    if (result?.error) {
+      throw new Error(result.error.message || String(result.error));
+    }
+    const payload = result?.data ?? result;
+    status = payload?.[name]?.status || "unknown";
+    if (status === "connected") return;
+    if (["error", "failed"].includes(status)) {
+      throw new Error(`MCP entered ${status} status`);
+    }
+    await pause(pollIntervalMs);
+  } while (Date.now() < deadline);
+
+  throw new Error(`MCP did not become ready (last status: ${status})`);
+}
+
 /**
  * Create the bounded MCP activation tool.
  * @param {function} tool
@@ -11,34 +38,6 @@
 export function createMcpActivationTool(tool, z, options) {
   const allowedNames = [...new Set(options.allowedNames || [])];
   const allowed = new Set(allowedNames);
-  const connectTimeoutMs = options.connectTimeoutMs || 30_000;
-  const pollIntervalMs = options.pollIntervalMs || 500;
-  const pause = options.pause
-    || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
-
-  async function waitForConnection(name) {
-    const statusMethod = options.client?.status;
-    if (typeof statusMethod !== "function") return;
-
-    const request = options.directory ? { query: { directory: options.directory } } : {};
-    const deadline = Date.now() + connectTimeoutMs;
-    let status = "unknown";
-    do {
-      const result = await statusMethod.call(options.client, request);
-      if (result?.error) {
-        throw new Error(result.error.message || String(result.error));
-      }
-      const payload = result?.data ?? result;
-      status = payload?.[name]?.status || "unknown";
-      if (status === "connected") return;
-      if (["error", "failed"].includes(status)) {
-        throw new Error(`MCP entered ${status} status`);
-      }
-      await pause(pollIntervalMs);
-    } while (Date.now() < deadline);
-
-    throw new Error(`MCP did not become ready (last status: ${status})`);
-  }
 
   return tool({
     description:
@@ -68,7 +67,7 @@ export function createMcpActivationTool(tool, z, options) {
         if (result?.error) {
           return `Error: MCP ${action} failed for ${name}: ${result.error.message || String(result.error)}`;
         }
-        if (action === "connect") await waitForConnection(name);
+        if (action === "connect") await waitForConnection(name, options);
       } catch (error) {
         return `Error: MCP ${action} failed for ${name}: ${error instanceof Error ? error.message : String(error)}`;
       }

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -216,6 +216,9 @@ function getMcpRegistry() {
       eager: false,
       toolPattern: "playwright_*",
       globallyEnabled: false,
+      activationAgent: "playwright",
+      agentSource: ["tools", "browser", "playwright.md"],
+      modelTier: "standard",
       description: "Cross-browser test automation",
     },
     {

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -15,22 +15,31 @@ const schemaNode = { describe() { return this; } };
 const z = { enum() { return schemaNode; } };
 const tool = (definition) => definition;
 
-test("registers only the explicit Playwriter activation profile", () => {
+test("registers only the explicit browser MCP activation profiles", () => {
   const config = {};
   const count = registerOnDemandMcpAgents(config, AGENTS_DIR);
 
-  assert.equal(count, 1);
-  assert.deepEqual(Object.keys(config.agent), ["playwriter"]);
+  assert.equal(count, 2);
+  assert.deepEqual(Object.keys(config.agent), ["playwriter", "playwright"]);
   assert.equal(config.tools.aidevops_mcp, false);
   assert.equal(config.agent.playwriter.mode, "subagent");
   assert.equal(config.agent.playwriter.tools.aidevops_mcp, true);
   assert.equal(config.agent.playwriter.tools["playwriter_*"], true);
+  assert.equal(config.agent.playwriter.permission.aidevops_mcp, "allow");
+  assert.equal(config.agent.playwriter.permission["playwriter_*"], "allow");
   assert.match(config.agent.playwriter.prompt, /connect.*playwriter/);
   assert.match(config.agent.playwriter.prompt, /no browser tab is approved/i);
   assert.match(config.agent.playwriter.prompt, /# Playwriter - Browser Extension MCP/);
+  assert.equal(config.agent.playwright.mode, "subagent");
+  assert.equal(config.agent.playwright.tools.aidevops_mcp, true);
+  assert.equal(config.agent.playwright.tools["playwright_*"], true);
+  assert.equal(config.agent.playwright.permission.aidevops_mcp, "allow");
+  assert.equal(config.agent.playwright.permission["playwright_*"], "allow");
+  assert.match(config.agent.playwright.prompt, /connect.*playwright/);
+  assert.match(config.agent.playwright.prompt, /# Playwright MCP/);
 });
 
-test("migrates Playwriter to disconnected and globally denied", () => {
+test("migrates browser MCPs to disconnected and globally denied", () => {
   const config = {
     mcp: {
       playwriter: {
@@ -38,14 +47,21 @@ test("migrates Playwriter to disconnected and globally denied", () => {
         command: ["npx", "playwriter@latest"],
         enabled: true,
       },
+      playwright: {
+        type: "local",
+        command: ["npx", "-y", "@playwright/mcp@latest"],
+        enabled: true,
+      },
     },
-    tools: { "playwriter_*": true },
+    tools: { "playwriter_*": true, "playwright_*": true },
   };
 
   registerMcpServers(config);
 
   assert.equal(config.mcp.playwriter.enabled, false);
+  assert.equal(config.mcp.playwright.enabled, false);
   assert.equal(config.tools["playwriter_*"], false);
+  assert.equal(config.tools["playwright_*"], false);
 });
 
 test("connects and disconnects only registry-approved MCP names", async () => {
@@ -74,8 +90,50 @@ test("connects and disconnects only registry-approved MCP names", async () => {
     /Disconnected MCP playwriter/,
   );
   assert.deepEqual(calls, [
-    ["connect", { name: "playwriter", directory: "/workspace" }],
-    ["disconnect", { name: "playwriter", directory: "/workspace" }],
+    ["connect", { path: { name: "playwriter" }, query: { directory: "/workspace" } }],
+    ["disconnect", { path: { name: "playwriter" }, query: { directory: "/workspace" } }],
+  ]);
+});
+
+test("omits the optional SDK query when no directory is available", async () => {
+  const calls = [];
+  const activation = createMcpActivationTool(tool, z, {
+    client: { async connect(args) { calls.push(args); } },
+    allowedNames: ["playwright"],
+  });
+
+  assert.match(
+    await activation.execute({ action: "connect", name: "playwright" }),
+    /Connected MCP playwright/,
+  );
+  assert.deepEqual(calls, [{ path: { name: "playwright" } }]);
+});
+
+test("waits until an asynchronously connecting MCP reports ready", async () => {
+  const statuses = ["disabled", "connecting", "connected"];
+  const calls = [];
+  const activation = createMcpActivationTool(tool, z, {
+    client: {
+      async connect(args) { calls.push(["connect", args]); },
+      async status(args) {
+        calls.push(["status", args]);
+        return { data: { playwright: { status: statuses.shift() } } };
+      },
+    },
+    directory: "/workspace",
+    allowedNames: ["playwright"],
+    pause: async () => {},
+  });
+
+  assert.match(
+    await activation.execute({ action: "connect", name: "playwright" }),
+    /Connected MCP playwright/,
+  );
+  assert.deepEqual(calls, [
+    ["connect", { path: { name: "playwright" }, query: { directory: "/workspace" } }],
+    ["status", { query: { directory: "/workspace" } }],
+    ["status", { query: { directory: "/workspace" } }],
+    ["status", { query: { directory: "/workspace" } }],
   ]);
 });
 

--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -29,6 +29,7 @@ mcp:
 - **Purpose**: Cross-browser testing and automation (fastest browser engine) — engine for dev-browser, agent-browser, and Stagehand
 - **Install**: `npm install playwright && npx playwright install` (lib + browsers) | `npx @playwright/mcp@latest` (MCP server)
 - **Setup**: `./setup.sh --interactive` → "Setup browser automation tools"
+- **OpenCode activation**: Invoke `@playwright`; it connects the disabled MCP on demand through the registry-allowlisted `aidevops_mcp` tool
 - **MCP config**: `{ "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] } }`
 - **Browsers**: chromium, firefox, webkit + custom (Brave, Edge, Chrome via `executablePath`); Browser QA defaults to Brave when installed and falls back to bundled Chromium
 - **Headless**: Yes (default) | **Proxy**: HTTP/SOCKS5 | **Session**: `storageState` / `userDataDir`
@@ -40,6 +41,10 @@ mcp:
 - **Subagents**: `playwright-emulation.md` (device/viewport), `playwright-cli.md` (CLI agent)
 
 <!-- AI-CONTEXT-END -->
+
+## OpenCode Activation
+
+aidevops keeps Playwright disconnected and its tool schema hidden globally. Use `@playwright` for isolated browser work; the bounded agent connects Playwright before its first operation and disconnects after completion. The activation tool accepts only MCP names declared by the plugin registry.
 
 ## Custom Browser Engines
 

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -80,7 +80,8 @@ mcp:
   "tools": { "aidevops_mcp": false, "playwriter_*": false },
   "agent": {
     "playwriter": {
-      "tools": { "aidevops_mcp": true, "playwriter_*": true }
+      "tools": { "aidevops_mcp": true },
+      "permission": { "playwriter_*": "allow" }
     }
   }
 }

--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -55,6 +55,7 @@ npx mcporter generate-cli --command https://mcp.context7.com/mcp --compile
 | MCP | Tokens | Activation | When to enable |
 |-----|--------|------------|----------------|
 | `playwriter` | ~3K | `@playwriter` calls `aidevops_mcp` | Browser automation needed |
+| `playwright` | Varies | `@playwright` calls `aidevops_mcp` | Isolated browser automation needed |
 | `google-analytics-mcp` | ~800 | Disabled by default | Analytics reporting |
 | `context7` | ~800 | Disabled by default | Library docs lookup |
 
@@ -122,7 +123,7 @@ mcp:
 ---
 ```
 
-The `mcp:` field is declarative -- it documents which MCP the subagent requires. Tool permission alone does not connect an OpenCode MCP configured with `enabled: false`. Explicit activation profiles, currently `@playwriter`, call `aidevops_mcp` before their first MCP operation.
+The `mcp:` field is declarative -- it documents which MCP the subagent requires. Tool permission alone does not connect an OpenCode MCP configured with `enabled: false`. Explicit activation profiles, currently `@playwriter` and `@playwright`, call `aidevops_mcp` before their first MCP operation.
 
 ### Main Agent Pattern
 
@@ -150,8 +151,10 @@ In `opencode.json`, MCP tools are denied globally and granted only to an owning 
   "agent": {
     "playwriter": {
       "tools": {
-        "aidevops_mcp": true,
-        "playwriter_*": true
+        "aidevops_mcp": true
+      },
+      "permission": {
+        "playwriter_*": "allow"
       }
     }
   }


### PR DESCRIPTION
## Summary

- serialize OpenCode MCP lifecycle requests with the SDK's `path` and optional `query` shape
- add bounded Playwright activation alongside Playwriter, with owning-agent permissions and Build+ delegation
- wait for asynchronous MCP readiness before exposing the connected tool schema

## Implementation

- Registry/profile ownership: `.agents/plugins/opencode-aidevops/mcp-registry.mjs` and `config-agent-profiles.mjs`
- Lifecycle contract: `.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs`
- Regression coverage: `.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs`
- User guidance: browser MCP and architecture documentation under `.agents/tools/` and `.agents/aidevops/architecture.md`

## Verification

- `npm test` in `.agents/plugins/opencode-aidevops` — 651 passed
- `.agents/scripts/linters-local.sh` — passed
- `opencode-test-helper.sh test-mcp playwriter playwriter` — `playwriter_execute` exposed
- `opencode-test-helper.sh test-mcp playwright playwright` — `playwright_browser_tabs` executed successfully
- `git diff --check` — passed

Resolves #30483

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.278 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 13m and 591,870 tokens on this with the user in an interactive session.