### PR TITLE
GH#30485: preserve worker floor for inconclusive canary failures

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1789,6 +1789,14 @@ _classify_canary_failure_reason() {
 			return 0
 			;;
 	esac
+	if [[ "$reason" == "local_error" ]]; then
+		local lowered=""
+		lowered=$(_read_failure_output_lowercase "$output_file")
+		if ! _classify_local_runtime_failure "$lowered" >/dev/null; then
+			printf '%s' "inconclusive"
+			return 0
+		fi
+	fi
 	printf '%s' "local_error"
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-worker-gates.sh
+++ b/.agents/scripts/pulse-dispatch-worker-gates.sh
@@ -231,7 +231,7 @@ _dlw_canary_last_failure_reason() {
 _dlw_canary_failure_is_soft() {
 	local reason="$1"
 	case "$reason" in
-		overload | provider_error | rate_limit | timeout | transient)
+		inconclusive | overload | provider_error | rate_limit | timeout | transient)
 			return 0
 			;;
 	esac

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -837,6 +837,32 @@ EOF
 	return 0
 }
 
+test_local_error_canary_failure_stays_hard_under_minimum_floor() {
+	local fake_helper worker_log state_dir
+	fake_helper="${TEST_ROOT}/fake-local-error-canary.sh"
+	worker_log="${TEST_ROOT}/worker-local-error.log"
+	state_dir="${HOME}/.aidevops/.agent-workspace/headless-runtime"
+	cat >"$fake_helper" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+mkdir -p "$state_dir"
+date +%s >"${state_dir}/canary-last-fail"
+printf 'local_error\n' >"${state_dir}/canary-last-fail.reason"
+exit 1
+EOF
+	chmod +x "$fake_helper"
+	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	AIDEVOPS_HEADLESS_RUNTIME_DIR="$state_dir"
+	TEST_ACTIVE_WORKERS=5
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	if _dlw_canary_preflight 105 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: local runtime failure stays hard under minimum floor" 1 "unexpected success"
+	else
+		print_result "canary: local runtime failure stays hard under minimum floor" 0
+	fi
+	return 0
+}
+
 test_soft_canary_failure_bypasses_under_minimum_floor_without_recent_evidence() {
 	local fake_helper worker_log state_dir
 	fake_helper="${TEST_ROOT}/fake-floor-canary.sh"
@@ -847,7 +873,7 @@ test_soft_canary_failure_bypasses_under_minimum_floor_without_recent_evidence() 
 state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 mkdir -p "$state_dir"
 date +%s >"${state_dir}/canary-last-fail"
-printf 'transient\n' >"${state_dir}/canary-last-fail.reason"
+printf 'inconclusive\n' >"${state_dir}/canary-last-fail.reason"
 exit 1
 EOF
 	chmod +x "$fake_helper"
@@ -858,9 +884,9 @@ EOF
 	TEST_ACTIVE_WORKERS=5
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
 	if _dlw_canary_preflight 104 "o/r" "$worker_log" "standard" ""; then
-		print_result "canary: soft failure bypassed under minimum worker floor" 0
+		print_result "canary: inconclusive failure bypassed under minimum worker floor" 0
 	else
-		print_result "canary: soft failure bypassed under minimum worker floor" 1
+		print_result "canary: inconclusive failure bypassed under minimum worker floor" 1
 	fi
 	return 0
 }
@@ -888,6 +914,7 @@ test_early_exit_refill_reuses_precomputed_active_count
 test_active_pulse_refill_uses_min_floor_above_raw_max
 test_soft_canary_failure_bypasses_with_recent_worker_evidence
 test_hard_canary_failure_blocks_despite_recent_worker_evidence
+test_local_error_canary_failure_stays_hard_under_minimum_floor
 test_soft_canary_failure_bypasses_under_minimum_floor_without_recent_evidence
 
 echo ""

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -170,6 +170,16 @@ check_classification \
 	'OSError: [Errno 28] No space left on device while writing worker log' \
 	"local_error" "" "" "runtime_storage_full" "local_runtime"
 
+empty_canary_path=$(write_fixture "empty_canary" "")
+assert_eq "empty canary output is inconclusive" "inconclusive" \
+	"$(_classify_canary_failure_reason "$empty_canary_path" "1")"
+generic_canary_path=$(write_fixture "generic_canary" "unexpected canary response")
+assert_eq "generic canary output is inconclusive" "inconclusive" \
+	"$(_classify_canary_failure_reason "$generic_canary_path" "1")"
+runtime_canary_path=$(write_fixture "runtime_canary" "Error: spawn opencode ENOENT")
+assert_eq "explicit local runtime canary failure stays hard" "local_error" \
+	"$(_classify_canary_failure_reason "$runtime_canary_path" "1")"
+
 mkdir -p "$METRICS_DIR"
 append_runtime_metric "worker" "issue-22379" "openai/gpt-5.5" "openai" \
 	"provider_error" "1" "provider_error" "1" "1234" "22379" "marcusquinn/aidevops" \


### PR DESCRIPTION
## Summary

Classify empty or generic non-timeout canary failures as inconclusive and allow that reason through the existing bounded soft-failure gates while keeping explicit local runtime errors hard.

## Files Changed

.agents/scripts/headless-runtime-lib.sh, .agents/scripts/pulse-dispatch-worker-gates.sh, .agents/scripts/tests/test-dispatch-min-concurrency.sh, .agents/scripts/tests/test-headless-runtime-failure-classification.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck and local quality gates pass; headless failure classification passed 113 checks, minimum-concurrency dispatch passed 26 checks, and canary classification passed 15 checks.

Resolves #30485


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.278 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 21m and 781,149 tokens on this with the user in an interactive session.