### PR TITLE
t18296: Add domain opportunity SQLite foundation

### DIFF
--- a/.agents/schemas/domain-opportunity-record.schema.json
+++ b/.agents/schemas/domain-opportunity-record.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Normalized domain opportunity listing observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "provider",
+    "provider_listing_id",
+    "fqdn",
+    "sld",
+    "tld",
+    "status",
+    "auction_type",
+    "current_price_micros",
+    "current_price_currency",
+    "bid_count",
+    "start_time",
+    "end_time",
+    "source_url",
+    "observed_at",
+    "source_run_id",
+    "payload_hash"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "provider_listing_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "fqdn": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 253
+    },
+    "sld": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tld": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": ["active", "ended", "sold", "cancelled", "unknown"]
+    },
+    "auction_type": {
+      "enum": ["auction", "buy_now", "closeout", "offer", "unknown"]
+    },
+    "current_price_micros": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "current_price_currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "bid_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "start_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "end_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https?://"
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "payload_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "raw_json": {
+      "type": ["object", "array", "string", "number", "boolean", "null"]
+    }
+  }
+}

--- a/.agents/scripts/domain-opportunity-helper.py
+++ b/.agents/scripts/domain-opportunity-helper.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Manage the provider-neutral local domain-opportunity evidence store."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from domain_opportunity_contract import DomainOpportunityContractError, normalize_listing
+from domain_opportunity_store import DomainOpportunityStore, DomainOpportunityStoreError
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    """Initialize or reopen a compatible local store."""
+    with DomainOpportunityStore(args.db, initialize=True) as store:
+        print(f"initialized schema v{store.status()['schema_version']}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Report schema compatibility and local record counts."""
+    with DomainOpportunityStore(args.db) as store:
+        status = store.status()
+    if args.json:
+        print(json.dumps(status, sort_keys=True, separators=(",", ":")))
+    else:
+        print(f"schema v{status['schema_version']}: {status['counts']['listings']} listings")
+    return 0
+
+
+def _load_jsonl(path: Path, provider: str) -> list[dict[str, Any]]:
+    if path.is_symlink() or not path.is_file():
+        raise DomainOpportunityContractError("input must be a regular JSONL file")
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                document = json.loads(line)
+                document["provider"] = provider
+                records.append(normalize_listing(document))
+            except (AttributeError, TypeError, json.JSONDecodeError, DomainOpportunityContractError) as exc:
+                raise DomainOpportunityContractError(f"input record {line_number} is invalid") from exc
+    if not records:
+        raise DomainOpportunityContractError("input contains no listing records")
+    run_ids = {record["source_run_id"] for record in records}
+    if len(run_ids) != 1:
+        raise DomainOpportunityContractError("one import must contain exactly one source_run_id")
+    return records
+
+
+def cmd_import_jsonl(args: argparse.Namespace) -> int:
+    """Import one validated provider batch atomically."""
+    provider = args.provider.strip().lower()
+    records = _load_jsonl(Path(args.input).expanduser(), provider)
+    run_id = records[0]["source_run_id"]
+    with DomainOpportunityStore(args.db) as store:
+        try:
+            with store.transaction():
+                store.begin_source_run(run_id, provider, started_at=records[0]["observed_at"])
+                inserted = sum(store.upsert_listing_observation(record) for record in records)
+                store.complete_source_run(run_id, len(records))
+        except Exception:
+            with store.transaction():
+                existing = store.connection.execute(
+                    "SELECT 1 FROM source_runs WHERE source_run_id=?", (run_id,)
+                ).fetchone()
+                if existing is None:
+                    store.begin_source_run(run_id, provider, started_at=records[0]["observed_at"])
+                store.fail_source_run(run_id, "import_failed")
+            raise
+    print(json.dumps({"imported": inserted, "records": len(records)}, sort_keys=True))
+    return 0
+
+
+def cmd_export_csv(args: argparse.Namespace) -> int:
+    """Export the stable current listing view to CSV."""
+    with DomainOpportunityStore(args.db) as store:
+        count = store.export_csv(args.output, active_only=args.active_only)
+    print(json.dumps({"exported": count}, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the provider-neutral local evidence CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    init_parser = subparsers.add_parser("init", help="Initialize or reopen a compatible store")
+    init_parser.add_argument("--db")
+    init_parser.set_defaults(handler=cmd_init)
+    status_parser = subparsers.add_parser("status", help="Show local store status")
+    status_parser.add_argument("--db")
+    status_parser.add_argument("--json", action="store_true")
+    status_parser.set_defaults(handler=cmd_status)
+    import_parser = subparsers.add_parser("import-jsonl", help="Import normalized JSONL evidence")
+    import_parser.add_argument("--db")
+    import_parser.add_argument("--input", required=True)
+    import_parser.add_argument("--provider", required=True)
+    import_parser.set_defaults(handler=cmd_import_jsonl)
+    export_parser = subparsers.add_parser("export-csv", help="Export current listing evidence")
+    export_parser.add_argument("--db")
+    export_parser.add_argument("--output", required=True)
+    export_parser.add_argument("--active-only", action="store_true")
+    export_parser.set_defaults(handler=cmd_export_csv)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch one deterministic local evidence operation."""
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (DomainOpportunityContractError, DomainOpportunityStoreError) as exc:
+        print(f"domain-opportunity: {exc}", file=sys.stderr)
+        return 1
+    except (OSError, sqlite3.Error):
+        print("domain-opportunity: local storage operation failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/domain_opportunity_contract.py
+++ b/.agents/scripts/domain_opportunity_contract.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalized interchange contract for local domain-auction evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+SCHEMA_VERSION = 1
+LISTING_STATUSES = frozenset({"active", "ended", "sold", "cancelled", "unknown"})
+AUCTION_TYPES = frozenset({"auction", "buy_now", "closeout", "offer", "unknown"})
+CSV_COLUMNS = tuple(
+    (
+        "provider provider_listing_id fqdn sld tld status auction_type "
+        "current_price_micros current_price_currency bid_count start_time end_time "
+        "source_url observed_at source_run_id payload_hash"
+    ).split()
+)
+LISTING_FIELDS = CSV_COLUMNS + ("raw_json",)
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class DomainOpportunityContractError(ValueError):
+    """Raised when normalized evidence violates the interchange contract."""
+
+
+@dataclass(frozen=True)
+class KeywordMetric:
+    """One source-labelled keyword metric for a known listing."""
+
+    provider: str
+    provider_listing_id: str
+    source_run_id: str
+    source: str
+    metric_name: str
+    value: str | int
+    unit: str
+    observed_at: str
+    payload_hash: str
+
+
+@dataclass(frozen=True)
+class TrendSeries:
+    """One source-labelled trend series for a known listing."""
+
+    provider: str
+    provider_listing_id: str
+    source_run_id: str
+    source: str
+    query: str
+    geography: str
+    timeframe: str
+    observed_at: str
+    points: tuple[tuple[str, int], ...]
+    payload_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    """One reproducible model score and its named components."""
+
+    provider: str
+    provider_listing_id: str
+    source_run_id: str
+    model: str
+    score_micros: int
+    observed_at: str
+    components: Mapping[str, Mapping[str, Any]]
+    payload_hash: str | None = None
+
+
+def utc_timestamp(value: Any, field: str) -> str:
+    """Return a canonical UTC ISO-8601 timestamp."""
+    if not isinstance(value, str) or not value.strip():
+        raise DomainOpportunityContractError(f"{field} must be a UTC timestamp")
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise DomainOpportunityContractError(f"{field} must be a UTC timestamp") from exc
+    if parsed.tzinfo is None:
+        raise DomainOpportunityContractError(f"{field} must include a timezone")
+    normalized = parsed.astimezone(timezone.utc)
+    return normalized.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def utc_now() -> str:
+    """Return the current whole-second UTC timestamp."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def money_micros(value: Any, field: str = "current_price_micros") -> int:
+    """Validate an integer number of currency micros without float coercion."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DomainOpportunityContractError(f"{field} must be a non-negative integer")
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize JSON evidence deterministically."""
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise DomainOpportunityContractError("raw_json must contain valid JSON data") from exc
+
+
+def content_hash(value: Any) -> str:
+    """Hash canonical JSON evidence for idempotent observation storage."""
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _required_text(record: Mapping[str, Any], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise DomainOpportunityContractError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _domain_parts(record: Mapping[str, Any]) -> tuple[str, str, str]:
+    raw_fqdn = _required_text(record, "fqdn").rstrip(".").lower()
+    try:
+        fqdn = raw_fqdn.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise DomainOpportunityContractError("fqdn is invalid") from exc
+    if "." not in fqdn or len(fqdn) > 253:
+        raise DomainOpportunityContractError("fqdn must contain an sld and tld")
+    sld, tld = fqdn.split(".", 1)
+    if not sld or not tld or any(not label for label in fqdn.split(".")):
+        raise DomainOpportunityContractError("fqdn must contain valid labels")
+    supplied_sld = _required_text(record, "sld").lower()
+    supplied_tld = _required_text(record, "tld").lower().lstrip(".")
+    if (supplied_sld, supplied_tld) != (sld, tld):
+        raise DomainOpportunityContractError("sld and tld must match fqdn")
+    return fqdn, sld, tld
+
+
+def normalize_listing(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and canonicalize one normalized listing observation."""
+    if not isinstance(record, Mapping):
+        raise DomainOpportunityContractError("listing record must be a JSON object")
+    provider = _required_text(record, "provider").lower()
+    listing_id = _required_text(record, "provider_listing_id")
+    run_id = _required_text(record, "source_run_id")
+    if not _NAME_RE.fullmatch(provider):
+        raise DomainOpportunityContractError("provider contains unsupported characters")
+    if len(listing_id) > 256 or len(run_id) > 256:
+        raise DomainOpportunityContractError("listing and run identifiers must be at most 256 characters")
+    fqdn, sld, tld = _domain_parts(record)
+    status = _required_text(record, "status").lower()
+    auction_type = _required_text(record, "auction_type").lower()
+    if status not in LISTING_STATUSES:
+        raise DomainOpportunityContractError("status is not supported")
+    if auction_type not in AUCTION_TYPES:
+        raise DomainOpportunityContractError("auction_type is not supported")
+    currency = _required_text(record, "current_price_currency").upper()
+    if not _CURRENCY_RE.fullmatch(currency):
+        raise DomainOpportunityContractError("current_price_currency must be an ISO 4217 code")
+    bid_count = record.get("bid_count")
+    if isinstance(bid_count, bool) or not isinstance(bid_count, int) or bid_count < 0:
+        raise DomainOpportunityContractError("bid_count must be a non-negative integer")
+    source_url = _required_text(record, "source_url")
+    parsed_url = urlparse(source_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise DomainOpportunityContractError("source_url must be an HTTP(S) URL")
+    payload_hash = _required_text(record, "payload_hash").lower()
+    if not _HASH_RE.fullmatch(payload_hash):
+        raise DomainOpportunityContractError("payload_hash must be a lowercase SHA-256 digest")
+    raw_json = record.get("raw_json")
+    if isinstance(raw_json, str):
+        try:
+            raw_json = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise DomainOpportunityContractError("raw_json must contain valid JSON data") from exc
+    normalized: dict[str, Any] = {
+        "provider": provider,
+        "provider_listing_id": listing_id,
+        "fqdn": fqdn,
+        "sld": sld,
+        "tld": tld,
+        "status": status,
+        "auction_type": auction_type,
+        "current_price_micros": money_micros(record.get("current_price_micros")),
+        "current_price_currency": currency,
+        "bid_count": bid_count,
+        "start_time": utc_timestamp(record.get("start_time"), "start_time"),
+        "end_time": utc_timestamp(record.get("end_time"), "end_time"),
+        "source_url": source_url,
+        "observed_at": utc_timestamp(record.get("observed_at"), "observed_at"),
+        "source_run_id": run_id,
+        "payload_hash": payload_hash,
+        "raw_json": None if raw_json is None else canonical_json(raw_json),
+    }
+    if normalized["end_time"] < normalized["start_time"]:
+        raise DomainOpportunityContractError("end_time must not precede start_time")
+    return normalized

--- a/.agents/scripts/domain_opportunity_store.py
+++ b/.agents/scripts/domain_opportunity_store.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Versioned SQLite persistence for local domain-opportunity evidence."""
+
+from __future__ import annotations
+
+import csv
+import os
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from domain_opportunity_contract import (
+    CSV_COLUMNS,
+    SCHEMA_VERSION,
+    CandidateScore,
+    DomainOpportunityContractError,
+    KeywordMetric,
+    TrendSeries,
+    canonical_json,
+    content_hash,
+    money_micros,
+    normalize_listing,
+    utc_now,
+    utc_timestamp,
+)
+
+DEFAULT_ROOT = Path.home() / ".aidevops" / ".agent-workspace" / "work" / "domain-opportunities"
+DEFAULT_DATABASE = DEFAULT_ROOT / "opportunities.sqlite"
+
+
+class DomainOpportunityStoreError(RuntimeError):
+    """Raised when the local evidence store cannot satisfy its contract."""
+
+
+def _safe_path(path: str | os.PathLike[str] | None, default: Path) -> Path:
+    candidate = Path(path).expanduser() if path is not None else default
+    if not candidate.name or candidate.name in {".", ".."}:
+        raise DomainOpportunityStoreError("local storage path must name a file")
+    absolute = candidate.absolute()
+    if absolute.exists() and absolute.is_symlink():
+        raise DomainOpportunityStoreError("local storage path must not be a symbolic link")
+    probe = absolute
+    while probe != probe.parent and not probe.exists():
+        probe = probe.parent
+    if probe.is_symlink():
+        raise DomainOpportunityStoreError("local storage parent must not be a symbolic link")
+    return probe.resolve(strict=True).joinpath(absolute.relative_to(probe))
+
+
+class DomainOpportunityStore:
+    """Own all mutations of one compatible domain-opportunity database."""
+
+    def __init__(self, path: str | os.PathLike[str] | None = None, *, initialize: bool = False) -> None:
+        self.path = _safe_path(path, DEFAULT_DATABASE)
+        existed = self.path.exists()
+        existing_size = self.path.stat().st_size if existed else 0
+        if not existed and not initialize:
+            raise DomainOpportunityStoreError("domain opportunity store does not exist; run init first")
+        if initialize:
+            self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            self.connection = sqlite3.connect(self.path, timeout=5.0)
+            self.connection.row_factory = sqlite3.Row
+            version = int(self.connection.execute("PRAGMA user_version").fetchone()[0])
+            if version > SCHEMA_VERSION:
+                raise DomainOpportunityStoreError("domain opportunity store schema is newer than this runtime")
+            if version == 0:
+                if not initialize or (existed and existing_size > 0):
+                    raise DomainOpportunityStoreError("domain opportunity store is uninitialized or incompatible")
+                self._configure()
+                self._create_schema_v1()
+            elif version != SCHEMA_VERSION:
+                raise DomainOpportunityStoreError("unsupported domain opportunity store migration path")
+            else:
+                self._configure()
+            os.chmod(self.path, 0o600)
+        except Exception:
+            if hasattr(self, "connection"):
+                self.connection.close()
+            raise
+
+    def _configure(self) -> None:
+        self.connection.execute("PRAGMA foreign_keys=ON")
+        self.connection.execute("PRAGMA busy_timeout=5000")
+        self.connection.execute("PRAGMA journal_mode=WAL")
+
+    def _create_schema_v1(self) -> None:
+        self.connection.executescript(
+            """
+            BEGIN IMMEDIATE;
+            CREATE TABLE source_runs (
+                source_run_id TEXT PRIMARY KEY,
+                provider TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                status TEXT NOT NULL CHECK(status IN ('running','completed','failed')),
+                records_seen INTEGER NOT NULL DEFAULT 0 CHECK(records_seen >= 0),
+                error_code TEXT
+            );
+            CREATE TABLE listings (
+                listing_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider TEXT NOT NULL,
+                provider_listing_id TEXT NOT NULL,
+                fqdn TEXT NOT NULL,
+                sld TEXT NOT NULL,
+                tld TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                current_observation_id INTEGER,
+                UNIQUE(provider, provider_listing_id)
+            );
+            CREATE INDEX listings_fqdn_idx ON listings(fqdn);
+            CREATE TABLE listing_observations (
+                observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                listing_id INTEGER NOT NULL REFERENCES listings(listing_id),
+                source_run_id TEXT NOT NULL REFERENCES source_runs(source_run_id),
+                status TEXT NOT NULL,
+                auction_type TEXT NOT NULL,
+                current_price_micros INTEGER NOT NULL CHECK(current_price_micros >= 0),
+                current_price_currency TEXT NOT NULL,
+                bid_count INTEGER NOT NULL CHECK(bid_count >= 0),
+                start_time TEXT NOT NULL,
+                end_time TEXT NOT NULL,
+                source_url TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                payload_hash TEXT NOT NULL,
+                raw_json TEXT,
+                UNIQUE(listing_id, payload_hash)
+            );
+            CREATE INDEX observations_listing_time_idx ON listing_observations(listing_id,observed_at);
+            CREATE TABLE keyword_metrics (
+                metric_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                listing_id INTEGER NOT NULL REFERENCES listings(listing_id),
+                source_run_id TEXT NOT NULL REFERENCES source_runs(source_run_id),
+                source TEXT NOT NULL,
+                metric_name TEXT NOT NULL,
+                value_text TEXT NOT NULL,
+                unit TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                payload_hash TEXT NOT NULL,
+                UNIQUE(listing_id, source, metric_name, payload_hash)
+            );
+            CREATE TABLE trend_series (
+                series_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                listing_id INTEGER NOT NULL REFERENCES listings(listing_id),
+                source_run_id TEXT NOT NULL REFERENCES source_runs(source_run_id),
+                source TEXT NOT NULL,
+                query TEXT NOT NULL,
+                geography TEXT NOT NULL,
+                timeframe TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                payload_hash TEXT NOT NULL,
+                UNIQUE(listing_id, source, payload_hash)
+            );
+            CREATE TABLE trend_points (
+                point_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                series_id INTEGER NOT NULL REFERENCES trend_series(series_id) ON DELETE CASCADE,
+                point_time TEXT NOT NULL,
+                value INTEGER NOT NULL CHECK(value >= 0),
+                UNIQUE(series_id, point_time)
+            );
+            CREATE TABLE candidate_scores (
+                score_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                listing_id INTEGER NOT NULL REFERENCES listings(listing_id),
+                source_run_id TEXT NOT NULL REFERENCES source_runs(source_run_id),
+                model TEXT NOT NULL,
+                score_micros INTEGER NOT NULL,
+                observed_at TEXT NOT NULL,
+                payload_hash TEXT NOT NULL,
+                UNIQUE(listing_id, model, payload_hash)
+            );
+            CREATE TABLE score_components (
+                component_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                score_id INTEGER NOT NULL REFERENCES candidate_scores(score_id) ON DELETE CASCADE,
+                name TEXT NOT NULL,
+                value_micros INTEGER NOT NULL,
+                weight_micros INTEGER NOT NULL,
+                evidence_json TEXT,
+                UNIQUE(score_id, name)
+            );
+            PRAGMA user_version=1;
+            COMMIT;
+            """
+        )
+
+    def close(self) -> None:
+        """Close this store connection."""
+        self.connection.close()
+
+    def __enter__(self) -> "DomainOpportunityStore":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Wrap a source batch in one explicit immediate transaction."""
+        if self.connection.in_transaction:
+            raise DomainOpportunityStoreError("nested store transactions are not supported")
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            yield
+        except Exception:
+            self.connection.rollback()
+            raise
+        else:
+            self.connection.commit()
+
+    def begin_source_run(self, source_run_id: str, provider: str, *, started_at: str | None = None) -> None:
+        """Create or restart an idempotent source-run record."""
+        timestamp = utc_timestamp(started_at, "started_at") if started_at else utc_now()
+        existing = self.connection.execute(
+            "SELECT provider FROM source_runs WHERE source_run_id=?", (source_run_id,)
+        ).fetchone()
+        if existing is not None and existing["provider"] != provider:
+            raise DomainOpportunityStoreError("source run already belongs to another provider")
+        self.connection.execute(
+            """INSERT INTO source_runs(source_run_id,provider,started_at,status)
+               VALUES(?,?,?,'running')
+               ON CONFLICT(source_run_id) DO UPDATE SET
+                 started_at=excluded.started_at, completed_at=NULL,
+                 status='running', records_seen=0, error_code=NULL""",
+            (source_run_id, provider, timestamp),
+        )
+
+    def complete_source_run(self, source_run_id: str, records_seen: int) -> None:
+        """Mark a source run complete in the caller's transaction."""
+        cursor = self.connection.execute(
+            "UPDATE source_runs SET status='completed',completed_at=?,records_seen=?,error_code=NULL WHERE source_run_id=?",
+            (utc_now(), records_seen, source_run_id),
+        )
+        if cursor.rowcount != 1:
+            raise DomainOpportunityStoreError("source run does not exist")
+
+    def fail_source_run(self, source_run_id: str, error_code: str) -> None:
+        """Mark a source run failed without recording sensitive error details."""
+        cursor = self.connection.execute(
+            "UPDATE source_runs SET status='failed',completed_at=?,error_code=? WHERE source_run_id=?",
+            (utc_now(), error_code[:64], source_run_id),
+        )
+        if cursor.rowcount != 1:
+            raise DomainOpportunityStoreError("source run does not exist")
+
+    def _listing_id(self, provider: str, provider_listing_id: str) -> int:
+        row = self.connection.execute(
+            "SELECT listing_id FROM listings WHERE provider=? AND provider_listing_id=?",
+            (provider, provider_listing_id),
+        ).fetchone()
+        if row is None:
+            raise DomainOpportunityStoreError("listing identity does not exist")
+        return int(row["listing_id"])
+
+    def upsert_listing_observation(self, record: Mapping[str, Any]) -> bool:
+        """Store a normalized observation; return whether it was new."""
+        item = normalize_listing(record)
+        run = self.connection.execute(
+            "SELECT provider FROM source_runs WHERE source_run_id=?",
+            (item["source_run_id"],),
+        ).fetchone()
+        if run is None or run["provider"] != item["provider"]:
+            raise DomainOpportunityStoreError("listing source run is missing or belongs to another provider")
+        timestamp = item["observed_at"]
+        self.connection.execute(
+            """INSERT INTO listings(provider,provider_listing_id,fqdn,sld,tld,created_at,updated_at)
+               VALUES(?,?,?,?,?,?,?)
+               ON CONFLICT(provider,provider_listing_id) DO NOTHING""",
+            (item["provider"], item["provider_listing_id"], item["fqdn"], item["sld"], item["tld"], timestamp, timestamp),
+        )
+        listing_id = self._listing_id(item["provider"], item["provider_listing_id"])
+        cursor = self.connection.execute(
+            """INSERT OR IGNORE INTO listing_observations(
+                 listing_id,source_run_id,status,auction_type,current_price_micros,
+                 current_price_currency,bid_count,start_time,end_time,source_url,
+                 observed_at,payload_hash,raw_json)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                listing_id,
+                item["source_run_id"],
+                item["status"],
+                item["auction_type"],
+                item["current_price_micros"],
+                item["current_price_currency"],
+                item["bid_count"],
+                item["start_time"],
+                item["end_time"],
+                item["source_url"],
+                item["observed_at"],
+                item["payload_hash"],
+                item["raw_json"],
+            ),
+        )
+        if cursor.rowcount == 0:
+            return False
+        observation_id = int(cursor.lastrowid)
+        current = self.connection.execute(
+            """SELECT o.observed_at FROM listings l
+               LEFT JOIN listing_observations o ON o.observation_id=l.current_observation_id
+               WHERE l.listing_id=?""",
+            (listing_id,),
+        ).fetchone()
+        if current is None or current["observed_at"] is None or timestamp >= current["observed_at"]:
+            self.connection.execute(
+                """UPDATE listings SET fqdn=?,sld=?,tld=?,updated_at=?,current_observation_id=?
+                   WHERE listing_id=?""",
+                (item["fqdn"], item["sld"], item["tld"], timestamp, observation_id, listing_id),
+            )
+        return True
+
+    def insert_keyword_metric(self, metric: KeywordMetric) -> bool:
+        """Insert one typed keyword metric with source and freshness provenance."""
+        listing_id = self._listing_id(metric.provider, metric.provider_listing_id)
+        cursor = self.connection.execute(
+            """INSERT OR IGNORE INTO keyword_metrics(
+                 listing_id,source_run_id,source,metric_name,value_text,unit,observed_at,payload_hash)
+               VALUES(?,?,?,?,?,?,?,?)""",
+            (
+                listing_id,
+                metric.source_run_id,
+                metric.source,
+                metric.metric_name,
+                str(metric.value),
+                metric.unit,
+                utc_timestamp(metric.observed_at, "observed_at"),
+                metric.payload_hash,
+            ),
+        )
+        return cursor.rowcount == 1
+
+    def insert_trend_series(self, series: TrendSeries) -> int:
+        """Insert a deduplicated trend series and its typed points."""
+        listing_id = self._listing_id(series.provider, series.provider_listing_id)
+        normalized_points = [
+            (utc_timestamp(point_time, "point_time"), value) for point_time, value in series.points
+        ]
+        if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for _, value in normalized_points):
+            raise DomainOpportunityContractError("trend values must be non-negative integers")
+        digest = series.payload_hash or content_hash(normalized_points)
+        self.connection.execute(
+            """INSERT OR IGNORE INTO trend_series(
+                 listing_id,source_run_id,source,query,geography,timeframe,observed_at,payload_hash)
+               VALUES(?,?,?,?,?,?,?,?)""",
+            (
+                listing_id,
+                series.source_run_id,
+                series.source,
+                series.query,
+                series.geography,
+                series.timeframe,
+                utc_timestamp(series.observed_at, "observed_at"),
+                digest,
+            ),
+        )
+        row = self.connection.execute(
+            "SELECT series_id FROM trend_series WHERE listing_id=? AND source=? AND payload_hash=?",
+            (listing_id, series.source, digest),
+        ).fetchone()
+        series_id = int(row["series_id"])
+        self.connection.executemany(
+            "INSERT OR IGNORE INTO trend_points(series_id,point_time,value) VALUES(?,?,?)",
+            [(series_id, point_time, value) for point_time, value in normalized_points],
+        )
+        return series_id
+
+    def insert_candidate_score(self, candidate: CandidateScore) -> int:
+        """Insert one reproducible score and its named integer-micro components."""
+        listing_id = self._listing_id(candidate.provider, candidate.provider_listing_id)
+        score = money_micros(candidate.score_micros, "score_micros")
+        digest = candidate.payload_hash or content_hash(
+            {"score_micros": score, "components": candidate.components}
+        )
+        self.connection.execute(
+            """INSERT OR IGNORE INTO candidate_scores(
+                 listing_id,source_run_id,model,score_micros,observed_at,payload_hash)
+               VALUES(?,?,?,?,?,?)""",
+            (
+                listing_id,
+                candidate.source_run_id,
+                candidate.model,
+                score,
+                utc_timestamp(candidate.observed_at, "observed_at"),
+                digest,
+            ),
+        )
+        row = self.connection.execute(
+            "SELECT score_id FROM candidate_scores WHERE listing_id=? AND model=? AND payload_hash=?",
+            (listing_id, candidate.model, digest),
+        ).fetchone()
+        score_id = int(row["score_id"])
+        for name, component in sorted(candidate.components.items()):
+            value = money_micros(component.get("value_micros"), "component value_micros")
+            weight = money_micros(component.get("weight_micros"), "component weight_micros")
+            evidence = component.get("evidence")
+            self.connection.execute(
+                """INSERT OR IGNORE INTO score_components(
+                     score_id,name,value_micros,weight_micros,evidence_json) VALUES(?,?,?,?,?)""",
+                (score_id, name, value, weight, None if evidence is None else canonical_json(evidence)),
+            )
+        return score_id
+
+    def current_listings(self, *, active_only: bool = False) -> list[dict[str, Any]]:
+        """Return the current normalized listing view in stable identity order."""
+        rows = self.connection.execute(
+            """SELECT l.provider,l.provider_listing_id,l.fqdn,l.sld,l.tld,
+                       o.status,o.auction_type,o.current_price_micros,
+                       o.current_price_currency,o.bid_count,o.start_time,o.end_time,
+                       o.source_url,o.observed_at,o.source_run_id,o.payload_hash
+                FROM listings l JOIN listing_observations o
+                  ON o.observation_id=l.current_observation_id
+                WHERE (?=0 OR o.status='active')
+                ORDER BY l.provider,l.provider_listing_id""",
+            (int(active_only),),
+        ).fetchall()
+        return [{column: row[column] for column in CSV_COLUMNS} for row in rows]
+
+    def status(self) -> dict[str, Any]:
+        """Return deterministic compatibility and row-count status."""
+        queries = (
+            ("source_runs", "SELECT COUNT(*) FROM source_runs"),
+            ("listings", "SELECT COUNT(*) FROM listings"),
+            ("listing_observations", "SELECT COUNT(*) FROM listing_observations"),
+            ("keyword_metrics", "SELECT COUNT(*) FROM keyword_metrics"),
+            ("trend_series", "SELECT COUNT(*) FROM trend_series"),
+            ("trend_points", "SELECT COUNT(*) FROM trend_points"),
+            ("candidate_scores", "SELECT COUNT(*) FROM candidate_scores"),
+            ("score_components", "SELECT COUNT(*) FROM score_components"),
+        )
+        counts = {
+            table: int(self.connection.execute(query).fetchone()[0]) for table, query in queries
+        }
+        return {"schema_version": SCHEMA_VERSION, "database": str(self.path), "counts": counts}
+
+    def export_csv(self, output: str | os.PathLike[str], *, active_only: bool = False) -> int:
+        """Atomically export the current normalized listing view."""
+        destination = _safe_path(output, DEFAULT_ROOT / "opportunities.csv")
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, lineterminator="\n")
+                writer.writeheader()
+                rows = self.current_listings(active_only=active_only)
+                writer.writerows(rows)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary_name, 0o600)
+            os.replace(temporary_name, destination)
+            return len(rows)
+        except Exception:
+            try:
+                os.unlink(temporary_name)
+            except FileNotFoundError:
+                pass
+            raise

--- a/.agents/scripts/tests/test-domain-opportunity.py
+++ b/.agents/scripts/tests/test-domain-opportunity.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic contracts for the local domain-opportunity evidence foundation."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from domain_opportunity_contract import (  # noqa: E402
+    CSV_COLUMNS,
+    CandidateScore,
+    KeywordMetric,
+    TrendSeries,
+)
+from domain_opportunity_store import (  # noqa: E402
+    DomainOpportunityStore,
+    DomainOpportunityStoreError,
+)
+
+HELPER = SCRIPTS / "domain-opportunity-helper.py"
+
+
+class DomainOpportunityTests(unittest.TestCase):
+    """Exercise migrations, idempotency, provenance, and CSV interchange."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.database = self.root / "evidence.sqlite"
+        self.input = self.root / "records.jsonl"
+        self.output = self.root / "records.csv"
+        self.network_guard = self.root / "network-guard"
+        self.network_guard.mkdir()
+        (self.network_guard / "sitecustomize.py").write_text(
+            "import socket\n"
+            "def denied(*args, **kwargs):\n"
+            "    raise AssertionError('network access attempted')\n"
+            "socket.socket = denied\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def command(self, *arguments: str, expected: int = 0) -> subprocess.CompletedProcess[str]:
+        """Run the production CLI without network access."""
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(self.network_guard)
+        completed = subprocess.run(  # nosec B603 -- fixed local helper
+            [sys.executable, str(HELPER), *arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        self.assertEqual(completed.returncode, expected, completed.stderr)
+        return completed
+
+    @staticmethod
+    def record(*, price: int = 1_500_000, payload: str = "a" * 64) -> dict[str, object]:
+        """Build one normalized provider fixture."""
+        return {
+            "provider": "fixture",
+            "provider_listing_id": "listing-1",
+            "fqdn": "example.com",
+            "sld": "example",
+            "tld": "com",
+            "status": "active",
+            "auction_type": "auction",
+            "current_price_micros": price,
+            "current_price_currency": "USD",
+            "bid_count": 2,
+            "start_time": "2026-08-20T10:00:00Z",
+            "end_time": "2026-08-22T10:00:00Z",
+            "source_url": "https://example.test/listing-1",
+            "observed_at": "2026-08-21T10:00:00Z",
+            "source_run_id": "fixture-run-1",
+            "payload_hash": payload,
+            "raw_json": {"fixture": True},
+        }
+
+    def write_records(self, *records: dict[str, object]) -> None:
+        """Write normalized fixtures as JSONL."""
+        self.input.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+
+    def test_cli_init_reopen_import_idempotency_and_csv_round_trip(self) -> None:
+        """Persist one fixture, retry it, preserve a change, and export stable CSV."""
+        self.command("init", "--db", str(self.database))
+        status = json.loads(self.command("status", "--db", str(self.database), "--json").stdout)
+        self.assertEqual(status["schema_version"], 1)
+        self.assertEqual(status["counts"]["listings"], 0)
+
+        self.write_records(self.record())
+        first = json.loads(
+            self.command(
+                "import-jsonl", "--db", str(self.database), "--input", str(self.input), "--provider", "fixture"
+            ).stdout
+        )
+        second = json.loads(
+            self.command(
+                "import-jsonl", "--db", str(self.database), "--input", str(self.input), "--provider", "fixture"
+            ).stdout
+        )
+        self.assertEqual((first["imported"], second["imported"]), (1, 0))
+
+        changed = self.record(price=2_000_000, payload="b" * 64)
+        self.write_records(changed)
+        self.command(
+            "import-jsonl", "--db", str(self.database), "--input", str(self.input), "--provider", "fixture"
+        )
+        status = json.loads(self.command("status", "--db", str(self.database), "--json").stdout)
+        self.assertEqual(status["counts"]["listings"], 1)
+        self.assertEqual(status["counts"]["listing_observations"], 2)
+
+        self.command("export-csv", "--db", str(self.database), "--output", str(self.output))
+        with self.output.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        self.assertEqual(tuple(rows[0]), CSV_COLUMNS)
+        self.assertEqual(rows[0]["current_price_micros"], "2000000")
+        self.assertEqual(rows[0]["observed_at"], changed["observed_at"])
+        self.assertEqual(rows[0]["source_run_id"], changed["source_run_id"])
+
+    def test_future_version_is_rejected_without_database_mutation(self) -> None:
+        """Reject a future owner version before applying local PRAGMAs or writes."""
+        connection = sqlite3.connect(self.database)
+        connection.execute("PRAGMA user_version=99")
+        connection.execute("CREATE TABLE future_owner(value TEXT)")
+        connection.commit()
+        connection.close()
+        before = hashlib.sha256(self.database.read_bytes()).hexdigest()
+
+        with self.assertRaisesRegex(DomainOpportunityStoreError, "newer"):
+            DomainOpportunityStore(self.database)
+
+        after = hashlib.sha256(self.database.read_bytes()).hexdigest()
+        self.assertEqual(after, before)
+        connection = sqlite3.connect(self.database)
+        self.assertEqual(connection.execute("PRAGMA user_version").fetchone()[0], 99)
+        self.assertIsNotNone(connection.execute("SELECT name FROM sqlite_master WHERE name='future_owner'").fetchone())
+        connection.close()
+
+    def test_typed_successor_writer_apis_keep_provenance(self) -> None:
+        """Expose stable typed metric, trend, and scoring boundaries to successors."""
+        record = self.record()
+        with DomainOpportunityStore(self.database, initialize=True) as store:
+            with store.transaction():
+                store.begin_source_run("fixture-run-1", "fixture", started_at="2026-08-21T10:00:00Z")
+                self.assertTrue(store.upsert_listing_observation(record))
+                self.assertTrue(
+                    store.insert_keyword_metric(
+                        KeywordMetric(
+                            provider="fixture",
+                            provider_listing_id="listing-1",
+                            source_run_id="fixture-run-1",
+                            source="keyword-planner",
+                            metric_name="monthly_searches",
+                            value=1200,
+                            unit="count",
+                            observed_at="2026-08-21T10:00:00Z",
+                            payload_hash="c" * 64,
+                        )
+                    )
+                )
+                series_id = store.insert_trend_series(
+                    TrendSeries(
+                        provider="fixture",
+                        provider_listing_id="listing-1",
+                        source_run_id="fixture-run-1",
+                        source="trends",
+                        query="example",
+                        geography="US",
+                        timeframe="today 12-m",
+                        observed_at="2026-08-21T10:00:00Z",
+                        points=(("2026-08-20T10:00:00Z", 42),),
+                    )
+                )
+                score_id = store.insert_candidate_score(
+                    CandidateScore(
+                        provider="fixture",
+                        provider_listing_id="listing-1",
+                        source_run_id="fixture-run-1",
+                        model="exact-match-v1",
+                        score_micros=750_000,
+                        observed_at="2026-08-21T10:00:00Z",
+                        components={
+                            "demand": {"value_micros": 800_000, "weight_micros": 500_000}
+                        },
+                    )
+                )
+                store.complete_source_run("fixture-run-1", 1)
+            self.assertGreater(series_id, 0)
+            self.assertGreater(score_id, 0)
+            self.assertEqual(store.status()["counts"]["keyword_metrics"], 1)
+            self.assertEqual(store.status()["counts"]["trend_series"], 1)
+            self.assertEqual(store.status()["counts"]["candidate_scores"], 1)
+
+    def test_source_run_identity_cannot_move_between_providers(self) -> None:
+        """Keep source-run provenance bound to its original provider."""
+        with DomainOpportunityStore(self.database, initialize=True) as store:
+            with store.transaction():
+                store.begin_source_run("fixed-run", "fixture", started_at="2026-08-21T10:00:00Z")
+            with self.assertRaisesRegex(DomainOpportunityStoreError, "another provider"):
+                with store.transaction():
+                    store.begin_source_run("fixed-run", "other", started_at="2026-08-21T11:00:00Z")
+            provider = store.connection.execute(
+                "SELECT provider FROM source_runs WHERE source_run_id='fixed-run'"
+            ).fetchone()[0]
+            self.assertEqual(provider, "fixture")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the normalized domain-auction record contract
- add the versioned local SQLite store and provider-neutral CLI
- add focused hermetic persistence and CSV coverage

## Verification

- `python3 .agents/scripts/tests/test-domain-opportunity.py`
- `.agents/scripts/linters-local.sh --changed`

Resolves #30493
For #30492

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.279 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 8m and 88,604 tokens on this as a headless worker.
