### PR TITLE
GH#30501: fail closed when planning publication partially succeeds

### DIFF
--- a/.agents/scripts/planning-publication-reconcile.sh
+++ b/.agents/scripts/planning-publication-reconcile.sh
@@ -15,6 +15,7 @@ source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
 
 PUBLICATION_PENDING_LABEL="publication:pending"
 PUBLICATION_AVAILABLE_LABEL="status:available"
+PUBLICATION_BLOCKED_LABEL="status:blocked"
 PUBLICATION_AUTO_LABEL="auto-dispatch"
 PUBLICATION_LIMIT="${AIDEVOPS_PUBLICATION_RECONCILE_LIMIT:-100}"
 
@@ -56,12 +57,58 @@ _publication_desired_labels() {
 	return 0
 }
 
+_publication_task_has_dependency() {
+	local task_line="$1"
+	local parsed="" blocked_by=""
+	parsed=$(parse_task_line "$task_line") || return 1
+	blocked_by=$(printf '%s\n' "$parsed" | grep '^blocked_by=' | cut -d= -f2-)
+	[[ -n "$blocked_by" ]] || return 1
+	return 0
+}
+
+_publication_issue_has_active_status() {
+	local issue_json="$1"
+	jq -e 'any(.labels[]?.name;
+		. == "status:queued" or
+		. == "status:claimed" or
+		. == "status:in-progress" or
+		. == "status:in-review" or
+		. == "status:done")' <<<"$issue_json" >/dev/null || return 1
+	return 0
+}
+
+_publication_issue_has_inactive_status() {
+	local issue_json="$1"
+	_publication_issue_has_labels "$issue_json" "$PUBLICATION_AVAILABLE_LABEL" && return 0
+	_publication_issue_has_labels "$issue_json" "$PUBLICATION_BLOCKED_LABEL" && return 0
+	return 1
+}
+
+_publication_remove_inactive_statuses() {
+	local repo="$1"
+	local issue_num="$2"
+	gh_issue_edit_safe "$issue_num" --repo "$repo" \
+		--remove-label "${PUBLICATION_AVAILABLE_LABEL},${PUBLICATION_BLOCKED_LABEL}" >/dev/null || return 1
+	return 0
+}
+
 _publication_status_label() {
 	local desired_labels="$1"
+	local has_dependency="$2"
+	local issue_json="$3"
 	local fenced=",${desired_labels},"
+	if [[ "$has_dependency" -eq 1 ]]; then
+		if ! _publication_issue_has_active_status "$issue_json"; then
+			printf '%s\n' "$PUBLICATION_BLOCKED_LABEL"
+		fi
+		return 0
+	fi
+	_publication_issue_has_active_status "$issue_json" && return 0
 	if [[ "$fenced" == *",${PUBLICATION_AUTO_LABEL},"* &&
 		"$fenced" != *",parent-task,"* && "$fenced" != *",meta,"* &&
-		"$fenced" != *",status:blocked,"* && "$fenced" != *",status:in-review,"* &&
+		"$fenced" != *",${PUBLICATION_BLOCKED_LABEL},"* && "$fenced" != *",status:queued,"* &&
+		"$fenced" != *",status:claimed,"* && "$fenced" != *",status:in-progress,"* &&
+		"$fenced" != *",status:in-review,"* && "$fenced" != *",status:done,"* &&
 		"$fenced" != *",no-auto-dispatch,"* && "$fenced" != *",hold-for-review,"* ]]; then
 		printf '%s\n' "$PUBLICATION_AVAILABLE_LABEL"
 	fi
@@ -92,13 +139,19 @@ _publication_validate_mapping() {
 
 _publication_reconcile_one() {
 	local repo="$1" task_id="$2" issue_num="$3"
-	local task_line="" desired_labels="" status_label="" projected_labels="" issue_json=""
+	local task_line="" desired_labels="" status_label="" projected_labels="" issue_json="" has_dependency=0
 	task_line=$(_publication_validate_mapping "$task_id" "$issue_num") || {
 		print_warning "${task_id}/#${issue_num}: canonical task, ref, or brief validation failed; retaining ${PUBLICATION_PENDING_LABEL}"
 		return 1
 	}
 	desired_labels=$(_publication_desired_labels "$task_line") || return 1
-	status_label=$(_publication_status_label "$desired_labels")
+	_publication_task_has_dependency "$task_line" && has_dependency=1
+	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json number,title,state,labels) || return 1
+	jq -e --arg task_prefix "${task_id}:" \
+		'.state == "OPEN" and (.title | startswith($task_prefix))' \
+		<<<"$issue_json" >/dev/null || return 1
+	_publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL" || return 1
+	status_label=$(_publication_status_label "$desired_labels" "$has_dependency" "$issue_json")
 	projected_labels="$desired_labels"
 	[[ -n "$status_label" ]] && projected_labels="${projected_labels:+${projected_labels},}${status_label}"
 
@@ -107,12 +160,32 @@ _publication_reconcile_one() {
 		gh_issue_edit_safe "$issue_num" --repo "$repo" \
 			--add-label "$projected_labels" >/dev/null || return 1
 	fi
+	# Dependency metadata is authoritative even before native relationship repair.
+	# Remove stale availability only after blocked/active state is established, so
+	# every intermediate failure remains pending or non-dispatchable.
+	if [[ "$has_dependency" -eq 1 ]] || _publication_issue_has_active_status "$issue_json"; then
+		gh_issue_edit_safe "$issue_num" --repo "$repo" \
+			--remove-label "$PUBLICATION_AVAILABLE_LABEL" >/dev/null || return 1
+	fi
 	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json number,title,state,labels) || return 1
 	jq -e --arg task_prefix "${task_id}:" \
 		'.state == "OPEN" and (.title | startswith($task_prefix))' \
 		<<<"$issue_json" >/dev/null || return 1
-	_publication_issue_has_labels "$issue_json" "$projected_labels" || return 1
+	# Active lifecycle state wins if assignment races with label projection.
+	if _publication_issue_has_active_status "$issue_json"; then
+		_publication_remove_inactive_statuses "$repo" "$issue_num" || return 1
+		issue_json=$(gh issue view "$issue_num" --repo "$repo" --json number,title,state,labels) || return 1
+	fi
+	_publication_issue_has_labels "$issue_json" "$desired_labels" || return 1
 	_publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL" || return 1
+	if [[ "$has_dependency" -eq 1 ]]; then
+		! _publication_issue_has_labels "$issue_json" "$PUBLICATION_AVAILABLE_LABEL" || return 1
+		_publication_issue_has_active_status "$issue_json" || \
+			_publication_issue_has_labels "$issue_json" "$PUBLICATION_BLOCKED_LABEL" || return 1
+	elif [[ "$status_label" == "$PUBLICATION_AVAILABLE_LABEL" ]] && \
+		! _publication_issue_has_active_status "$issue_json"; then
+		_publication_issue_has_labels "$issue_json" "$PUBLICATION_AVAILABLE_LABEL" || return 1
+	fi
 
 	# The blocker is intentionally the final mutation. Every prior failure leaves
 	# the issue undispatchable and safely retryable.
@@ -122,7 +195,22 @@ _publication_reconcile_one() {
 	if _publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL"; then
 		return 1
 	fi
-	_publication_issue_has_labels "$issue_json" "$projected_labels" || return 1
+	if _publication_issue_has_active_status "$issue_json" && \
+		_publication_issue_has_inactive_status "$issue_json"; then
+		# A lifecycle transition raced with the final pending-label removal.
+		# Restore the dispatch fence before cleanup; a failed cleanup therefore
+		# remains safely retryable instead of leaving a conflicting live status.
+		gh_issue_edit_safe "$issue_num" --repo "$repo" \
+			--add-label "$PUBLICATION_PENDING_LABEL" >/dev/null || return 1
+		_publication_remove_inactive_statuses "$repo" "$issue_num" || return 1
+		return 1
+	fi
+	_publication_issue_has_labels "$issue_json" "$desired_labels" || return 1
+	if [[ "$has_dependency" -eq 1 ]]; then
+		! _publication_issue_has_labels "$issue_json" "$PUBLICATION_AVAILABLE_LABEL" || return 1
+		_publication_issue_has_active_status "$issue_json" || \
+			_publication_issue_has_labels "$issue_json" "$PUBLICATION_BLOCKED_LABEL" || return 1
+	fi
 	print_success "${task_id}/#${issue_num}: planning publication reconciled"
 	return 0
 }

--- a/.agents/scripts/tests/test-planning-publication-lifecycle.sh
+++ b/.agents/scripts/tests/test-planning-publication-lifecycle.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NEW_TASK="${SCRIPT_DIR}/../new-task-helper.sh"
 PLANNING_COMMIT="${SCRIPT_DIR}/../planning-commit-helper.sh"
 PULSE_RECONCILE="${SCRIPT_DIR}/../pulse-issue-reconcile.sh"
+PUBLICATION_RECONCILE="${SCRIPT_DIR}/../planning-publication-reconcile.sh"
 WORKFLOW_DOC="${SCRIPT_DIR}/../../workflows/new-task.md"
 
 grep -Fq 'AIDEVOPS_PLANNING_COMMIT_RESULT=' "$PLANNING_COMMIT"
@@ -15,8 +16,14 @@ grep -Fq '_BATCH_PUBLICATION_RESULT="failed"' "$NEW_TASK"
 grep -Fq 'all created issues remain publication:pending' "$NEW_TASK"
 grep -Fq '_repair_pending_planning_publications' "$PULSE_RECONCILE"
 grep -Fq 'AIDEVOPS_PUBLICATION_RECONCILE_LIMIT=10' "$PULSE_RECONCILE"
+grep -Fq 'PUBLICATION_BLOCKED_LABEL="status:blocked"' "$PUBLICATION_RECONCILE"
+grep -Fq '_publication_task_has_dependency' "$PUBLICATION_RECONCILE"
+# Matching the literal variable reference in source.
+# shellcheck disable=SC2016
+grep -Fq -- '--remove-label "$PUBLICATION_AVAILABLE_LABEL"' "$PUBLICATION_RECONCILE"
 grep -Fq 'closed-unmerged' "$WORKFLOW_DOC"
 grep -Fq 'reported as queued' "$WORKFLOW_DOC"
 
 printf 'PASS batch publication outcomes remain pending on failure\n'
 printf 'PASS pulse recovery is bounded and documentation is fail-closed\n'
+printf 'PASS dependency-bearing publication projects a blocked lifecycle state\n'

--- a/.agents/scripts/tests/test-planning-publication-reconcile.sh
+++ b/.agents/scripts/tests/test-planning-publication-reconcile.sh
@@ -13,7 +13,7 @@ REMOVE_PATTERN='--remove-label "$PUBLICATION_PENDING_LABEL"'
 # shellcheck disable=SC2016
 WORKFLOW_PATTERN='--repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"'
 # shellcheck disable=SC2016
-VERIFY_PATTERN='_publication_issue_has_labels "$issue_json" "$projected_labels"'
+VERIFY_PATTERN='_publication_issue_has_labels "$issue_json" "$desired_labels"'
 # shellcheck disable=SC2016
 SAFE_EDIT_PATTERN='gh_issue_edit_safe "$issue_num" --repo "$repo"'
 
@@ -24,10 +24,15 @@ task_line='- [ ] t9000 Reconcile publication #auto-dispatch #bug ~1h ref:GH#77 l
 desired_labels=$(_publication_desired_labels "$task_line")
 [[ ",${desired_labels}," == *",auto-dispatch,"* ]]
 [[ ",${desired_labels}," == *",bug,"* ]]
-[[ "$(_publication_status_label "$desired_labels")" == "status:available" ]]
+issue_json='{"labels":[{"name":"publication:pending"}]}'
+[[ "$(_publication_status_label "$desired_labels" 0 "$issue_json")" == "status:available" ]]
 issue_json='{"labels":[{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:available"}]}'
 _publication_issue_has_labels "$issue_json" 'auto-dispatch,bug,status:available'
 [[ -z "$(_publication_desired_labels '- [ ] t9001 Manual task ~1h ref:GH#78 logged:2026-08-11')" ]]
+blocked_task_line='- [ ] t9002 Blocked publication #auto-dispatch #bug ~1h blocked-by:t9000 ref:GH#79 logged:2026-08-11'
+_publication_task_has_dependency "$blocked_task_line"
+[[ "$(_publication_status_label "$desired_labels" 1 '{"labels":[{"name":"publication:pending"}]}')" == "status:blocked" ]]
+[[ -z "$(_publication_status_label "$desired_labels" 1 '{"labels":[{"name":"status:in-progress"}]}')" ]]
 printf 'PASS production helpers project and verify intended labels\n'
 
 grep -Fq '_publication_exact_default_snapshot' "$RECONCILER"
@@ -54,5 +59,86 @@ awk '
 	}
 ' "$WORKFLOW"
 
+grep -Fq 'continue-on-error: true' "$WORKFLOW"
+grep -Fq "if: always() && steps.check-author.outputs.skip != 'true'" "$WORKFLOW"
+awk '
+	/name: Reconcile pending planning publication/ { publication_line = NR }
+	/name: Reconcile issue relationships/ { relationship_line = NR }
+	/name: Report planning publication failure/ { failure_line = NR }
+	END { exit !(publication_line < relationship_line && relationship_line < failure_line) }
+' "$WORKFLOW"
+
+mutation_log=$(mktemp)
+cleanup() {
+	rm -f "$mutation_log"
+	return 0
+}
+trap cleanup EXIT
+
+_publication_validate_mapping() {
+	local task_id="$1"
+	local issue_num="$2"
+	printf -- '- [ ] %s Partial batch #auto-dispatch #bug blocked-by:t9000 ref:GH#%s\n' "$task_id" "$issue_num"
+	return 0
+}
+
+gh_issue_edit_safe() {
+	local issue_num="$1"
+	shift
+	printf '%s %s\n' "$issue_num" "$*" >>"$mutation_log"
+	if [[ "$issue_num" == "78" && "$*" == *"--add-label"* ]]; then
+		return 1
+	fi
+	if [[ "$issue_num" == "80" && "$*" == *"--remove-label status:available,status:blocked"* ]] && \
+		grep -q '^80 .*--remove-label publication:pending' "$mutation_log"; then
+		return 1
+	fi
+	return 0
+}
+
+gh() {
+	local command="$1"
+	local subcommand="$2"
+	local issue_num="$3"
+	local labels='[{"name":"publication:pending"}]'
+	: "$command" "$subcommand"
+	if grep -q "^${issue_num} .*--add-label" "$mutation_log"; then
+		labels='[{"name":"publication:pending"},{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:blocked"}]'
+	fi
+	if [[ "$issue_num" == "79" && "$labels" == *"status:blocked"* ]]; then
+		labels='[{"name":"publication:pending"},{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:blocked"},{"name":"status:in-progress"}]'
+	fi
+	if [[ "$issue_num" == "80" ]] && grep -q '^80 .*--remove-label publication:pending' "$mutation_log"; then
+		labels='[{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:blocked"},{"name":"status:in-progress"}]'
+	fi
+	if grep -q "^${issue_num} .*--remove-label status:available,status:blocked" "$mutation_log"; then
+		labels='[{"name":"publication:pending"},{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:in-progress"}]'
+	fi
+	if grep -q "^${issue_num} .*--remove-label publication:pending" "$mutation_log"; then
+		labels="${labels//\{\"name\":\"publication:pending\"\},/}"
+	fi
+	printf '{"number":%s,"title":"t%s: Partial batch","state":"OPEN","labels":%s}\n' \
+		"$issue_num" "$((8923 + issue_num))" "$labels"
+	return 0
+}
+
+failed=0
+_publication_reconcile_one example/repo t9000 77 || failed=$((failed + 1))
+_publication_reconcile_one example/repo t9002 79 || failed=$((failed + 1))
+_publication_reconcile_one example/repo t9003 80 || failed=$((failed + 1))
+_publication_reconcile_one example/repo t9001 78 || failed=$((failed + 1))
+[[ "$failed" -eq 2 ]]
+grep -q '^77 .*--add-label auto-dispatch,bug,status:blocked' "$mutation_log"
+grep -q '^77 .*--remove-label status:available' "$mutation_log"
+grep -q '^77 .*--remove-label publication:pending' "$mutation_log"
+grep -q '^79 .*--remove-label status:available,status:blocked' "$mutation_log"
+grep -q '^79 .*--remove-label publication:pending' "$mutation_log"
+grep -q '^80 .*--add-label publication:pending' "$mutation_log"
+grep -q '^80 .*--remove-label status:available,status:blocked' "$mutation_log"
+if grep -q '^78 .*--remove-label publication:pending' "$mutation_log"; then
+	exit 1
+fi
+
 printf 'PASS exact-SHA mapping validation precedes blocker removal\n'
 printf 'PASS default-branch workflow reconciles publication before maintenance\n'
+printf 'PASS partial batches leave earlier dependencies blocked and later failures pending\n'

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -280,7 +280,9 @@ jobs:
       # created above is current. Relationship and enrichment maintenance are
       # deliberately best-effort and must not queue dispatchable work.
       - name: Reconcile pending planning publication
+        id: planning-publication
         if: steps.check-author.outputs.skip != 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLICATION_SHA: ${{ github.sha }}
@@ -291,7 +293,7 @@ jobs:
 
       - name: Reconcile issue relationships
         id: relationship-sync
-        if: steps.check-author.outputs.skip != 'true'
+        if: always() && steps.check-author.outputs.skip != 'true'
         run: |
           echo "=== Reconciling issue relationships ==="
           set +e
@@ -315,6 +317,12 @@ jobs:
           # Cache entries are immutable, so each run writes a new revision-keyed
           # checkpoint and the next run restores the newest matching entry.
           key: issue-sync-relationships-${{ github.repository_id }}-${{ hashFiles('TODO.md') }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Report planning publication failure
+        if: steps.planning-publication.outcome == 'failure'
+        run: |
+          echo "::error::Planning publication failed; bounded relationship safety repair completed or was checkpointed for retry."
+          exit 1
 
       - name: Enrich plan-linked issues
         if: steps.check-author.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Project dependency-bearing tasks as blocked before removing publication:pending; preserve active lifecycle states across races; run bounded relationship repair after publication failure while retaining a failed job outcome

## Files Changed

.agents/scripts/planning-publication-reconcile.sh, .agents/scripts/tests/test-planning-publication-lifecycle.sh, .agents/scripts/tests/test-planning-publication-reconcile.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-planning-publication-reconcile.sh; bash .agents/scripts/tests/test-planning-publication-lifecycle.sh; bash .agents/scripts/tests/test-issue-sync-relationship-resume.sh; .agents/scripts/linters-local.sh --changed

Resolves #30501


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.279 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 15m and 264,759 tokens on this as a headless worker.