### PR TITLE
t18298: refactor: reduce inventory parser complexity

### DIFF
--- a/.agents/scripts/domain-opportunity-files.py
+++ b/.agents/scripts/domain-opportunity-files.py
@@ -11,7 +11,7 @@ import sqlite3
 import sys
 
 from domain_opportunity_contract import DomainOpportunityContractError
-from domain_opportunity_files import DomainOpportunityFileError, import_inventory, inspect
+from domain_opportunity_files import DomainOpportunityFileError, ImportOptions, import_inventory, inspect
 from domain_opportunity_store import DomainOpportunityStoreError
 
 
@@ -31,7 +31,7 @@ def build_parser() -> argparse.ArgumentParser:
     import_parser.add_argument("--observed-at")
     import_parser.set_defaults(
         handler=lambda args: import_inventory(
-            args.input, args.provider, args.db, rejects_path=args.rejects, observed_at=args.observed_at
+            args.input, args.provider, args.db, ImportOptions(rejects_path=args.rejects, observed_at=args.observed_at)
         )
     )
     return parser

--- a/.agents/scripts/domain-opportunity-files.py
+++ b/.agents/scripts/domain-opportunity-files.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Inspect and import authorized local auction inventory files without network access."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+
+from domain_opportunity_contract import DomainOpportunityContractError
+from domain_opportunity_files import DomainOpportunityFileError, import_inventory, inspect
+from domain_opportunity_store import DomainOpportunityStoreError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the local-only inventory import command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    inspect_parser = commands.add_parser("inspect", help="Report headers and safety diagnostics without writes")
+    inspect_parser.add_argument("--provider", required=True)
+    inspect_parser.add_argument("--input", required=True)
+    inspect_parser.set_defaults(handler=lambda args: inspect(args.input, args.provider))
+    import_parser = commands.add_parser("import", help="Import one authorized local inventory file")
+    import_parser.add_argument("--provider", required=True)
+    import_parser.add_argument("--input", required=True)
+    import_parser.add_argument("--db", required=True)
+    import_parser.add_argument("--rejects")
+    import_parser.add_argument("--observed-at")
+    import_parser.set_defaults(
+        handler=lambda args: import_inventory(
+            args.input, args.provider, args.db, rejects_path=args.rejects, observed_at=args.observed_at
+        )
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one deterministic local inspection or import."""
+    args = build_parser().parse_args(argv)
+    try:
+        print(json.dumps(args.handler(args), sort_keys=True, separators=(",", ":")))
+        return 0
+    except (DomainOpportunityFileError, DomainOpportunityContractError, DomainOpportunityStoreError, OSError, sqlite3.Error) as exc:
+        print(f"domain-opportunity-files: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/domain_opportunity_file_archive.py
+++ b/.agents/scripts/domain_opportunity_file_archive.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded readers for local auction inventory archives."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import os
+import stat
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
+MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+NESTED_ARCHIVE_SUFFIXES = frozenset({".zip", ".gz", ".tgz", ".bz2", ".xz"})
+
+
+class DomainOpportunityFileError(ValueError):
+    """Raised when a local inventory file is unsafe or incompatible."""
+
+
+def _read_limited(handle: Any, limit: int = MAX_UNCOMPRESSED_BYTES) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = handle.read(1024 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        total += len(chunk)
+        if total > limit:
+            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
+        chunks.append(chunk)
+
+
+def _regular_input(path: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise DomainOpportunityFileError("input must be a regular local file")
+    if path.stat().st_size > MAX_COMPRESSED_BYTES:
+        raise DomainOpportunityFileError("input exceeds compressed size limit")
+
+
+def _check_ratio(compressed: int, uncompressed: int, message: str) -> None:
+    if uncompressed > compressed * MAX_COMPRESSION_RATIO:
+        raise DomainOpportunityFileError(message)
+
+
+def _read_gzip(raw: bytes) -> tuple[bytes, str]:
+    with gzip.GzipFile(fileobj=io.BytesIO(raw)) as handle:
+        content = _read_limited(handle)
+    _check_ratio(len(raw), len(content), "gzip compression ratio exceeds limit")
+    return content, "gzip"
+
+
+def _zip_entry_is_safe(entry: zipfile.ZipInfo) -> bool:
+    member = PurePosixPath(entry.filename)
+    unsafe_markers = (
+        member.is_absolute(),
+        ".." in member.parts,
+        entry.is_dir(),
+        bool(entry.flag_bits & 0x1),
+        stat.S_ISLNK(entry.external_attr >> 16),
+        member.suffix.casefold() in NESTED_ARCHIVE_SUFFIXES,
+    )
+    return not any(unsafe_markers)
+
+
+def _only_zip_entry(archive: zipfile.ZipFile) -> zipfile.ZipInfo:
+    entries = archive.infolist()
+    if not entries:
+        raise DomainOpportunityFileError("ZIP archive contains no files")
+    if not all(_zip_entry_is_safe(entry) for entry in entries):
+        raise DomainOpportunityFileError("ZIP archive contains unsafe, encrypted, linked, or nested content")
+    if len(entries) != 1:
+        raise DomainOpportunityFileError("ZIP archive must contain exactly one inventory file")
+    return entries[0]
+
+
+def _read_zip(raw: bytes) -> tuple[bytes, str]:
+    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        entry = _only_zip_entry(archive)
+        if entry.file_size > MAX_UNCOMPRESSED_BYTES:
+            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
+        if entry.compress_size:
+            _check_ratio(entry.compress_size, entry.file_size, "ZIP compression ratio exceeds limit")
+        with archive.open(entry) as handle:
+            return _read_limited(handle), "zip"
+
+
+def _read_plain(raw: bytes) -> tuple[bytes, str]:
+    if len(raw) > MAX_UNCOMPRESSED_BYTES:
+        raise DomainOpportunityFileError("input exceeds uncompressed size limit")
+    return raw, "plain"
+
+
+def read_inventory(path: str | os.PathLike[str]) -> tuple[bytes, str]:
+    """Read one bounded plain, gzip, or safe single-file ZIP inventory."""
+    source = Path(path).expanduser()
+    _regular_input(source)
+    raw = source.read_bytes()
+    readers = ((b"\x1f\x8b", _read_gzip), (b"PK\x03\x04", _read_zip))
+    reader = next((candidate for magic, candidate in readers if raw.startswith(magic)), _read_plain)
+    return reader(raw)

--- a/.agents/scripts/domain_opportunity_files.py
+++ b/.agents/scripts/domain_opportunity_files.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, local-only auction inventory parsing and normalized-store writes."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import io
+import json
+import os
+import stat
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+from domain_opportunity_contract import DomainOpportunityContractError, canonical_json, utc_now, utc_timestamp
+from domain_opportunity_store import DomainOpportunityStore
+
+MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
+MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+PROFILE_VERSION = "auction-file-v1"
+
+
+class DomainOpportunityFileError(ValueError):
+    """Raised when a local inventory file is unsafe or incompatible."""
+
+
+@dataclass(frozen=True)
+class Profile:
+    """One explicit provider header profile."""
+
+    name: str
+    fields: dict[str, tuple[str, ...]]
+    required: frozenset[str]
+
+
+PROFILES = {
+    "godaddy": Profile(
+        "godaddy",
+        {
+            "fqdn": ("domain name", "domain"),
+            "provider_listing_id": ("auction id", "listing id", "id"),
+            "current_price": ("current bid", "current price", "price"),
+            "bid_count": ("bid count", "bids"),
+            "start_time": ("start date", "start time"),
+            "end_time": ("end date", "end time", "auction end"),
+            "status": ("status",),
+            "source_url": ("url", "listing url"),
+        },
+        frozenset({"fqdn", "current_price", "start_time", "end_time", "source_url"}),
+    ),
+    "snapnames": Profile(
+        "snapnames",
+        {
+            "fqdn": ("domain", "domain name"),
+            "provider_listing_id": ("auction id", "listing id", "id"),
+            "current_price": ("current bid", "current price", "price"),
+            "bid_count": ("bids", "bid count"),
+            "start_time": ("auction start", "start date", "start time"),
+            "end_time": ("auction end", "end date", "end time"),
+            "status": ("status",),
+            "source_url": ("url", "listing url"),
+        },
+        frozenset({"fqdn", "current_price", "start_time", "end_time", "source_url"}),
+    ),
+    "namejet": Profile(
+        "namejet",
+        {
+            "fqdn": ("domain", "domain name"),
+            "provider_listing_id": ("auction id", "listing id", "id"),
+            "current_price": ("current bid", "current price", "price"),
+            "bid_count": ("bids", "bid count"),
+            "start_time": ("auction start", "start date", "start time"),
+            "end_time": ("auction end", "end date", "end time"),
+            "status": ("status",),
+            "source_url": ("url", "listing url"),
+        },
+        frozenset({"fqdn", "current_price", "start_time", "end_time", "source_url"}),
+    ),
+    "generic": Profile(
+        "generic",
+        {name: (name.replace("_", " "), name) for name in (
+            "provider_listing_id", "fqdn", "status", "auction_type", "current_price_micros",
+            "current_price_currency", "bid_count", "start_time", "end_time", "source_url", "observed_at",
+        )},
+        frozenset({
+            "fqdn", "status", "auction_type", "current_price_micros", "current_price_currency",
+            "bid_count", "start_time", "end_time", "source_url", "observed_at",
+        }),
+    ),
+}
+
+
+def _header(value: str) -> str:
+    return " ".join(value.strip().casefold().replace("_", " ").split())
+
+
+def _read_limited(handle: Any, limit: int = MAX_UNCOMPRESSED_BYTES) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = handle.read(1024 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        total += len(chunk)
+        if total > limit:
+            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
+        chunks.append(chunk)
+
+
+def _regular_input(path: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise DomainOpportunityFileError("input must be a regular local file")
+    if path.stat().st_size > MAX_COMPRESSED_BYTES:
+        raise DomainOpportunityFileError("input exceeds compressed size limit")
+
+
+def read_inventory(path: str | os.PathLike[str]) -> tuple[bytes, str]:
+    """Read one bounded plain, gzip, or safe single-file ZIP inventory."""
+    source = Path(path).expanduser()
+    _regular_input(source)
+    raw = source.read_bytes()
+    if raw.startswith(b"\x1f\x8b"):
+        with gzip.GzipFile(fileobj=io.BytesIO(raw)) as handle:
+            content = _read_limited(handle)
+        if len(content) > len(raw) * MAX_COMPRESSION_RATIO:
+            raise DomainOpportunityFileError("gzip compression ratio exceeds limit")
+        return content, "gzip"
+    if raw.startswith(b"PK\x03\x04"):
+        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+            entries = archive.infolist()
+            if not entries:
+                raise DomainOpportunityFileError("ZIP archive contains no files")
+            candidates = []
+            for entry in entries:
+                member = PurePosixPath(entry.filename)
+                if member.is_absolute() or ".." in member.parts or entry.is_dir():
+                    raise DomainOpportunityFileError("ZIP archive contains an unsafe path")
+                if entry.flag_bits & 0x1 or stat.S_ISLNK(entry.external_attr >> 16):
+                    raise DomainOpportunityFileError("ZIP archive contains encrypted or linked content")
+                if member.suffix.casefold() in {".zip", ".gz", ".tgz", ".bz2", ".xz"}:
+                    raise DomainOpportunityFileError("nested archives are not supported")
+                candidates.append(entry)
+            if len(candidates) != 1:
+                raise DomainOpportunityFileError("ZIP archive must contain exactly one inventory file")
+            entry = candidates[0]
+            if entry.file_size > MAX_UNCOMPRESSED_BYTES:
+                raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
+            if entry.compress_size and entry.file_size > entry.compress_size * MAX_COMPRESSION_RATIO:
+                raise DomainOpportunityFileError("ZIP compression ratio exceeds limit")
+            with archive.open(entry) as handle:
+                return _read_limited(handle), "zip"
+    if len(raw) > MAX_UNCOMPRESSED_BYTES:
+        raise DomainOpportunityFileError("input exceeds uncompressed size limit")
+    return raw, "plain"
+
+
+def _mapping(profile: Profile, headers: Iterable[str]) -> tuple[dict[str, str], list[str], list[str]]:
+    canonical = {_header(header): header for header in headers if header is not None}
+    mapping: dict[str, str] = {}
+    for field, aliases in profile.fields.items():
+        for alias in aliases:
+            source = canonical.get(_header(alias))
+            if source is not None:
+                mapping[field] = source
+                break
+    recognized = {_header(value) for value in mapping.values()}
+    missing = sorted(profile.required - mapping.keys())
+    unknown = sorted(header for header in canonical if header not in recognized)
+    return mapping, missing, unknown
+
+
+def _decode_rows(content: bytes, *, allow_jsonl: bool = False) -> tuple[list[str], list[dict[str, str]]]:
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise DomainOpportunityFileError("input must be UTF-8 text") from exc
+    if allow_jsonl and text.lstrip().startswith("{"):
+        rows: list[dict[str, str]] = []
+        headers: set[str] = set()
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise DomainOpportunityFileError(f"JSONL record {line_number} is invalid") from exc
+            if not isinstance(item, dict) or any(not isinstance(key, str) for key in item):
+                raise DomainOpportunityFileError(f"JSONL record {line_number} must be an object")
+            headers.update(item)
+            rows.append({key: "" if value is None else str(value) for key, value in item.items()})
+        if not rows:
+            raise DomainOpportunityFileError("input contains no JSONL records")
+        return sorted(headers), rows
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise DomainOpportunityFileError("input has no CSV header")
+    headers = [header for header in reader.fieldnames if header is not None]
+    if len(headers) != len(set(headers)):
+        raise DomainOpportunityFileError("input has duplicate CSV headers")
+    return headers, list(reader)
+
+
+def inspect(path: str | os.PathLike[str], provider: str) -> dict[str, Any]:
+    """Return parser diagnostics without mutating a store."""
+    profile = _profile(provider)
+    content, archive_format = read_inventory(path)
+    headers, rows = _decode_rows(content, allow_jsonl=profile.name == "generic")
+    _, missing, unknown = _mapping(profile, headers)
+    return {
+        "archive_format": archive_format,
+        "content_sha256": hashlib.sha256(content).hexdigest(),
+        "headers": headers,
+        "missing_required_headers": missing,
+        "provider": profile.name,
+        "row_count": len(rows),
+        "unknown_headers": unknown,
+    }
+
+
+def _profile(provider: str) -> Profile:
+    normalized = provider.strip().casefold()
+    if normalized not in PROFILES:
+        raise DomainOpportunityFileError("provider must be godaddy, snapnames, namejet, or generic")
+    return PROFILES[normalized]
+
+
+def _price_micros(value: str) -> int:
+    cleaned = value.strip().replace(",", "").replace("$", "")
+    try:
+        amount = Decimal(cleaned)
+    except InvalidOperation as exc:
+        raise DomainOpportunityFileError("price is invalid") from exc
+    if not amount.is_finite() or amount < 0 or amount.as_tuple().exponent < -6:
+        raise DomainOpportunityFileError("price is invalid")
+    return int(amount * Decimal(1_000_000))
+
+
+def _text(row: dict[str, str], mapping: dict[str, str], field: str, default: str = "") -> str:
+    source = mapping.get(field)
+    return (row.get(source, default) if source else default).strip()
+
+
+def _normalized_row(
+    row: dict[str, str], profile: Profile, mapping: dict[str, str], source_hash: str, line_number: int, observed_at: str
+) -> dict[str, Any]:
+    if profile.name == "generic":
+        record = {field: _text(row, mapping, field) for field in mapping}
+        record["provider"] = "generic"
+        record["current_price_micros"] = int(record["current_price_micros"])
+        record["bid_count"] = int(record["bid_count"])
+    else:
+        fqdn = _text(row, mapping, "fqdn").rstrip(".").lower()
+        if "." not in fqdn:
+            raise DomainOpportunityFileError("domain must contain a registrable suffix")
+        sld, tld = fqdn.split(".", 1)
+        end_time = utc_timestamp(_text(row, mapping, "end_time"), "end_time")
+        provider_listing_id = _text(row, mapping, "provider_listing_id")
+        if not provider_listing_id:
+            provider_listing_id = hashlib.sha256(f"{profile.name}\0{fqdn}\0{end_time}".encode()).hexdigest()[:32]
+        record = {
+            "provider": profile.name,
+            "provider_listing_id": provider_listing_id,
+            "fqdn": fqdn,
+            "sld": sld,
+            "tld": tld,
+            "status": _text(row, mapping, "status", "active").casefold() or "active",
+            "auction_type": "auction",
+            "current_price_micros": _price_micros(_text(row, mapping, "current_price")),
+            "current_price_currency": "USD",
+            "bid_count": int(_text(row, mapping, "bid_count", "0") or "0"),
+            "start_time": _text(row, mapping, "start_time"),
+            "end_time": end_time,
+            "source_url": _text(row, mapping, "source_url"),
+            "observed_at": observed_at,
+        }
+    fqdn = record["fqdn"].rstrip(".").lower()
+    if "." not in fqdn:
+        raise DomainOpportunityFileError("domain must contain a registrable suffix")
+    sld, tld = fqdn.split(".", 1)
+    record["fqdn"], record["sld"], record["tld"] = fqdn, sld, tld
+    if not record.get("provider_listing_id"):
+        record["provider_listing_id"] = hashlib.sha256(
+            f"{record['provider']}\0{fqdn}\0{record['end_time']}".encode()
+        ).hexdigest()[:32]
+    record["source_run_id"] = f"{record['provider']}-{source_hash}"
+    record["raw_json"] = {"profile": PROFILE_VERSION, "row": row}
+    record["payload_hash"] = hashlib.sha256(canonical_json(record["raw_json"]).encode()).hexdigest()
+    return record
+
+
+def _write_rejects(path: str | os.PathLike[str], rejects: list[dict[str, Any]]) -> None:
+    destination = Path(path).expanduser()
+    if destination.exists() and destination.is_symlink():
+        raise DomainOpportunityFileError("rejects output must not be a symbolic link")
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            for reject in rejects:
+                handle.write(canonical_json(reject) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def import_inventory(
+    path: str | os.PathLike[str], provider: str, database: str | os.PathLike[str], *, rejects_path: str | None = None,
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Import valid rows atomically, retaining only sanitized optional rejects."""
+    profile = _profile(provider)
+    content, archive_format = read_inventory(path)
+    source_hash = hashlib.sha256(content).hexdigest()
+    headers, rows = _decode_rows(content, allow_jsonl=profile.name == "generic")
+    mapping, missing, unknown = _mapping(profile, headers)
+    if missing:
+        raise DomainOpportunityFileError(f"missing required headers: {', '.join(missing)}")
+    timestamp = utc_timestamp(observed_at, "observed_at") if observed_at else utc_now()
+    records: list[dict[str, Any]] = []
+    rejects: list[dict[str, Any]] = []
+    for line_number, row in enumerate(rows, start=2):
+        try:
+            records.append(_normalized_row(row, profile, mapping, source_hash, line_number, timestamp))
+        except (DomainOpportunityFileError, DomainOpportunityContractError, ValueError) as exc:
+            rejects.append({"line": line_number, "reason": str(exc)[:256]})
+    if not records:
+        raise DomainOpportunityFileError("input contains no valid listing records")
+    run_id = records[0]["source_run_id"]
+    with DomainOpportunityStore(database, initialize=True) as store:
+        with store.transaction():
+            store.begin_source_run(run_id, profile.name, started_at=timestamp)
+            inserted = sum(store.upsert_listing_observation(record) for record in records)
+            store.complete_source_run(run_id, len(records))
+    if rejects_path is not None:
+        _write_rejects(rejects_path, rejects)
+    return {
+        "archive_format": archive_format,
+        "content_sha256": source_hash,
+        "imported": inserted,
+        "provider": profile.name,
+        "records": len(records),
+        "rejected": len(rejects),
+        "unknown_headers": unknown,
+    }

--- a/.agents/scripts/domain_opportunity_files.py
+++ b/.agents/scripts/domain_opportunity_files.py
@@ -15,7 +15,6 @@ import stat
 import tempfile
 import zipfile
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable

--- a/.agents/scripts/domain_opportunity_files.py
+++ b/.agents/scripts/domain_opportunity_files.py
@@ -42,6 +42,24 @@ class Profile:
     required: frozenset[str]
 
 
+@dataclass(frozen=True)
+class NormalizationContext:
+    """Stable provenance shared by every row in one import."""
+
+    profile: Profile
+    mapping: dict[str, str]
+    source_hash: str
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    """Optional local import outputs and observation timing."""
+
+    rejects_path: str | None = None
+    observed_at: str | None = None
+
+
 PROFILES = {
     "godaddy": Profile(
         "godaddy",
@@ -123,44 +141,66 @@ def _regular_input(path: Path) -> None:
         raise DomainOpportunityFileError("input exceeds compressed size limit")
 
 
+def _check_ratio(compressed: int, uncompressed: int, message: str) -> None:
+    if uncompressed > compressed * MAX_COMPRESSION_RATIO:
+        raise DomainOpportunityFileError(message)
+
+
+def _read_gzip(raw: bytes) -> tuple[bytes, str]:
+    with gzip.GzipFile(fileobj=io.BytesIO(raw)) as handle:
+        content = _read_limited(handle)
+    _check_ratio(len(raw), len(content), "gzip compression ratio exceeds limit")
+    return content, "gzip"
+
+
+def _zip_entry_is_safe(entry: zipfile.ZipInfo) -> bool:
+    member = PurePosixPath(entry.filename)
+    return not (
+        member.is_absolute()
+        or ".." in member.parts
+        or entry.is_dir()
+        or entry.flag_bits & 0x1
+        or stat.S_ISLNK(entry.external_attr >> 16)
+        or member.suffix.casefold() in {".zip", ".gz", ".tgz", ".bz2", ".xz"}
+    )
+
+
+def _only_zip_entry(archive: zipfile.ZipFile) -> zipfile.ZipInfo:
+    entries = archive.infolist()
+    if not entries:
+        raise DomainOpportunityFileError("ZIP archive contains no files")
+    if not all(_zip_entry_is_safe(entry) for entry in entries):
+        raise DomainOpportunityFileError("ZIP archive contains unsafe, encrypted, linked, or nested content")
+    if len(entries) != 1:
+        raise DomainOpportunityFileError("ZIP archive must contain exactly one inventory file")
+    return entries[0]
+
+
+def _read_zip(raw: bytes) -> tuple[bytes, str]:
+    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        entry = _only_zip_entry(archive)
+        if entry.file_size > MAX_UNCOMPRESSED_BYTES:
+            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
+        if entry.compress_size:
+            _check_ratio(entry.compress_size, entry.file_size, "ZIP compression ratio exceeds limit")
+        with archive.open(entry) as handle:
+            return _read_limited(handle), "zip"
+
+
+def _read_plain(raw: bytes) -> tuple[bytes, str]:
+    if len(raw) > MAX_UNCOMPRESSED_BYTES:
+        raise DomainOpportunityFileError("input exceeds uncompressed size limit")
+    return raw, "plain"
+
+
 def read_inventory(path: str | os.PathLike[str]) -> tuple[bytes, str]:
     """Read one bounded plain, gzip, or safe single-file ZIP inventory."""
     source = Path(path).expanduser()
     _regular_input(source)
     raw = source.read_bytes()
-    if raw.startswith(b"\x1f\x8b"):
-        with gzip.GzipFile(fileobj=io.BytesIO(raw)) as handle:
-            content = _read_limited(handle)
-        if len(content) > len(raw) * MAX_COMPRESSION_RATIO:
-            raise DomainOpportunityFileError("gzip compression ratio exceeds limit")
-        return content, "gzip"
-    if raw.startswith(b"PK\x03\x04"):
-        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
-            entries = archive.infolist()
-            if not entries:
-                raise DomainOpportunityFileError("ZIP archive contains no files")
-            candidates = []
-            for entry in entries:
-                member = PurePosixPath(entry.filename)
-                if member.is_absolute() or ".." in member.parts or entry.is_dir():
-                    raise DomainOpportunityFileError("ZIP archive contains an unsafe path")
-                if entry.flag_bits & 0x1 or stat.S_ISLNK(entry.external_attr >> 16):
-                    raise DomainOpportunityFileError("ZIP archive contains encrypted or linked content")
-                if member.suffix.casefold() in {".zip", ".gz", ".tgz", ".bz2", ".xz"}:
-                    raise DomainOpportunityFileError("nested archives are not supported")
-                candidates.append(entry)
-            if len(candidates) != 1:
-                raise DomainOpportunityFileError("ZIP archive must contain exactly one inventory file")
-            entry = candidates[0]
-            if entry.file_size > MAX_UNCOMPRESSED_BYTES:
-                raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
-            if entry.compress_size and entry.file_size > entry.compress_size * MAX_COMPRESSION_RATIO:
-                raise DomainOpportunityFileError("ZIP compression ratio exceeds limit")
-            with archive.open(entry) as handle:
-                return _read_limited(handle), "zip"
-    if len(raw) > MAX_UNCOMPRESSED_BYTES:
-        raise DomainOpportunityFileError("input exceeds uncompressed size limit")
-    return raw, "plain"
+    readers = ((b"\x1f\x8b", _read_gzip), (b"PK\x03\x04", _read_zip))
+    reader = next((candidate for magic, candidate in readers if raw.startswith(magic)), _read_plain)
+    return reader(raw)
 
 
 def _mapping(profile: Profile, headers: Iterable[str]) -> tuple[dict[str, str], list[str], list[str]]:
@@ -178,28 +218,31 @@ def _mapping(profile: Profile, headers: Iterable[str]) -> tuple[dict[str, str], 
     return mapping, missing, unknown
 
 
-def _decode_rows(content: bytes, *, allow_jsonl: bool = False) -> tuple[list[str], list[dict[str, str]]]:
+def _decode_text(content: bytes) -> str:
     try:
-        text = content.decode("utf-8-sig")
+        return content.decode("utf-8-sig")
     except UnicodeDecodeError as exc:
         raise DomainOpportunityFileError("input must be UTF-8 text") from exc
-    if allow_jsonl and text.lstrip().startswith("{"):
-        rows: list[dict[str, str]] = []
-        headers: set[str] = set()
-        for line_number, line in enumerate(text.splitlines(), start=1):
-            if not line.strip():
-                continue
-            try:
-                item = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise DomainOpportunityFileError(f"JSONL record {line_number} is invalid") from exc
-            if not isinstance(item, dict) or any(not isinstance(key, str) for key in item):
-                raise DomainOpportunityFileError(f"JSONL record {line_number} must be an object")
-            headers.update(item)
-            rows.append({key: "" if value is None else str(value) for key, value in item.items()})
-        if not rows:
-            raise DomainOpportunityFileError("input contains no JSONL records")
-        return sorted(headers), rows
+
+
+def _jsonl_record(line: str, line_number: int) -> dict[str, str]:
+    try:
+        item = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise DomainOpportunityFileError(f"JSONL record {line_number} is invalid") from exc
+    if not isinstance(item, dict) or any(not isinstance(key, str) for key in item):
+        raise DomainOpportunityFileError(f"JSONL record {line_number} must be an object")
+    return {key: "" if value is None else str(value) for key, value in item.items()}
+
+
+def _decode_jsonl(text: str) -> tuple[list[str], list[dict[str, str]]]:
+    rows = [_jsonl_record(line, line_number) for line_number, line in enumerate(text.splitlines(), start=1) if line.strip()]
+    if not rows:
+        raise DomainOpportunityFileError("input contains no JSONL records")
+    return sorted({header for row in rows for header in row}), rows
+
+
+def _decode_csv(text: str) -> tuple[list[str], list[dict[str, str]]]:
     reader = csv.DictReader(io.StringIO(text))
     if not reader.fieldnames:
         raise DomainOpportunityFileError("input has no CSV header")
@@ -207,6 +250,13 @@ def _decode_rows(content: bytes, *, allow_jsonl: bool = False) -> tuple[list[str
     if len(headers) != len(set(headers)):
         raise DomainOpportunityFileError("input has duplicate CSV headers")
     return headers, list(reader)
+
+
+def _decode_rows(content: bytes, *, allow_jsonl: bool = False) -> tuple[list[str], list[dict[str, str]]]:
+    text = _decode_text(content)
+    if allow_jsonl and text.lstrip().startswith("{"):
+        return _decode_jsonl(text)
+    return _decode_csv(text)
 
 
 def inspect(path: str | os.PathLike[str], provider: str) -> dict[str, Any]:
@@ -249,49 +299,60 @@ def _text(row: dict[str, str], mapping: dict[str, str], field: str, default: str
     return (row.get(source, default) if source else default).strip()
 
 
-def _normalized_row(
-    row: dict[str, str], profile: Profile, mapping: dict[str, str], source_hash: str, line_number: int, observed_at: str
-) -> dict[str, Any]:
-    if profile.name == "generic":
-        record = {field: _text(row, mapping, field) for field in mapping}
-        record["provider"] = "generic"
-        record["current_price_micros"] = int(record["current_price_micros"])
-        record["bid_count"] = int(record["bid_count"])
-    else:
-        fqdn = _text(row, mapping, "fqdn").rstrip(".").lower()
-        if "." not in fqdn:
-            raise DomainOpportunityFileError("domain must contain a registrable suffix")
-        sld, tld = fqdn.split(".", 1)
-        end_time = utc_timestamp(_text(row, mapping, "end_time"), "end_time")
-        provider_listing_id = _text(row, mapping, "provider_listing_id")
-        if not provider_listing_id:
-            provider_listing_id = hashlib.sha256(f"{profile.name}\0{fqdn}\0{end_time}".encode()).hexdigest()[:32]
-        record = {
-            "provider": profile.name,
-            "provider_listing_id": provider_listing_id,
-            "fqdn": fqdn,
-            "sld": sld,
-            "tld": tld,
-            "status": _text(row, mapping, "status", "active").casefold() or "active",
-            "auction_type": "auction",
-            "current_price_micros": _price_micros(_text(row, mapping, "current_price")),
-            "current_price_currency": "USD",
-            "bid_count": int(_text(row, mapping, "bid_count", "0") or "0"),
-            "start_time": _text(row, mapping, "start_time"),
-            "end_time": end_time,
-            "source_url": _text(row, mapping, "source_url"),
-            "observed_at": observed_at,
-        }
-    fqdn = record["fqdn"].rstrip(".").lower()
+def _generic_record(row: dict[str, str], context: NormalizationContext) -> dict[str, Any]:
+    record = {field: _text(row, context.mapping, field) for field in context.mapping}
+    record["provider"] = "generic"
+    record["current_price_micros"] = int(record["current_price_micros"])
+    record["bid_count"] = int(record["bid_count"])
+    return record
+
+
+def _provider_record(row: dict[str, str], context: NormalizationContext) -> dict[str, Any]:
+    profile, mapping = context.profile, context.mapping
+    fqdn = _text(row, mapping, "fqdn").rstrip(".").lower()
     if "." not in fqdn:
         raise DomainOpportunityFileError("domain must contain a registrable suffix")
     sld, tld = fqdn.split(".", 1)
-    record["fqdn"], record["sld"], record["tld"] = fqdn, sld, tld
+    end_time = utc_timestamp(_text(row, mapping, "end_time"), "end_time")
+    provider_listing_id = _text(row, mapping, "provider_listing_id")
+    if not provider_listing_id:
+        provider_listing_id = hashlib.sha256(f"{profile.name}\0{fqdn}\0{end_time}".encode()).hexdigest()[:32]
+    return {
+        "provider": profile.name,
+        "provider_listing_id": provider_listing_id,
+        "fqdn": fqdn,
+        "sld": sld,
+        "tld": tld,
+        "status": _text(row, mapping, "status", "active").casefold() or "active",
+        "auction_type": "auction",
+        "current_price_micros": _price_micros(_text(row, mapping, "current_price")),
+        "current_price_currency": "USD",
+        "bid_count": int(_text(row, mapping, "bid_count", "0") or "0"),
+        "start_time": _text(row, mapping, "start_time"),
+        "end_time": end_time,
+        "source_url": _text(row, mapping, "source_url"),
+        "observed_at": context.observed_at,
+    }
+
+
+def _normalized_domain(record: dict[str, Any]) -> None:
+    fqdn = record["fqdn"].rstrip(".").lower()
+    if "." not in fqdn:
+        raise DomainOpportunityFileError("domain must contain a registrable suffix")
+    record["fqdn"], record["sld"], record["tld"] = (fqdn, *fqdn.split(".", 1))
+
+
+def _normalized_row(row: dict[str, str], context: NormalizationContext) -> dict[str, Any]:
+    if context.profile.name == "generic":
+        record = _generic_record(row, context)
+    else:
+        record = _provider_record(row, context)
+    _normalized_domain(record)
     if not record.get("provider_listing_id"):
         record["provider_listing_id"] = hashlib.sha256(
-            f"{record['provider']}\0{fqdn}\0{record['end_time']}".encode()
+            f"{record['provider']}\0{record['fqdn']}\0{record['end_time']}".encode()
         ).hexdigest()[:32]
-    record["source_run_id"] = f"{record['provider']}-{source_hash}"
+    record["source_run_id"] = f"{record['provider']}-{context.source_hash}"
     record["raw_json"] = {"profile": PROFILE_VERSION, "row": row}
     record["payload_hash"] = hashlib.sha256(canonical_json(record["raw_json"]).encode()).hexdigest()
     return record
@@ -320,8 +381,7 @@ def _write_rejects(path: str | os.PathLike[str], rejects: list[dict[str, Any]]) 
 
 
 def import_inventory(
-    path: str | os.PathLike[str], provider: str, database: str | os.PathLike[str], *, rejects_path: str | None = None,
-    observed_at: str | None = None,
+    path: str | os.PathLike[str], provider: str, database: str | os.PathLike[str], options: ImportOptions | None = None
 ) -> dict[str, Any]:
     """Import valid rows atomically, retaining only sanitized optional rejects."""
     profile = _profile(provider)
@@ -331,12 +391,14 @@ def import_inventory(
     mapping, missing, unknown = _mapping(profile, headers)
     if missing:
         raise DomainOpportunityFileError(f"missing required headers: {', '.join(missing)}")
-    timestamp = utc_timestamp(observed_at, "observed_at") if observed_at else utc_now()
+    settings = options or ImportOptions()
+    timestamp = utc_timestamp(settings.observed_at, "observed_at") if settings.observed_at else utc_now()
+    context = NormalizationContext(profile, mapping, source_hash, timestamp)
     records: list[dict[str, Any]] = []
     rejects: list[dict[str, Any]] = []
     for line_number, row in enumerate(rows, start=2):
         try:
-            records.append(_normalized_row(row, profile, mapping, source_hash, line_number, timestamp))
+            records.append(_normalized_row(row, context))
         except (DomainOpportunityFileError, DomainOpportunityContractError, ValueError) as exc:
             rejects.append({"line": line_number, "reason": str(exc)[:256]})
     if not records:
@@ -347,8 +409,8 @@ def import_inventory(
             store.begin_source_run(run_id, profile.name, started_at=timestamp)
             inserted = sum(store.upsert_listing_observation(record) for record in records)
             store.complete_source_run(run_id, len(records))
-    if rejects_path is not None:
-        _write_rejects(rejects_path, rejects)
+    if settings.rejects_path is not None:
+        _write_rejects(settings.rejects_path, rejects)
     return {
         "archive_format": archive_format,
         "content_sha256": source_hash,

--- a/.agents/scripts/domain_opportunity_files.py
+++ b/.agents/scripts/domain_opportunity_files.py
@@ -6,30 +6,21 @@
 from __future__ import annotations
 
 import csv
-import gzip
 import hashlib
 import io
 import json
 import os
-import stat
 import tempfile
-import zipfile
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Iterable
 
 from domain_opportunity_contract import DomainOpportunityContractError, canonical_json, utc_now, utc_timestamp
+from domain_opportunity_file_archive import DomainOpportunityFileError, read_inventory
 from domain_opportunity_store import DomainOpportunityStore
 
-MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
-MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024
-MAX_COMPRESSION_RATIO = 100
 PROFILE_VERSION = "auction-file-v1"
-
-
-class DomainOpportunityFileError(ValueError):
-    """Raised when a local inventory file is unsafe or incompatible."""
 
 
 @dataclass(frozen=True)
@@ -118,88 +109,6 @@ PROFILES = {
 
 def _header(value: str) -> str:
     return " ".join(value.strip().casefold().replace("_", " ").split())
-
-
-def _read_limited(handle: Any, limit: int = MAX_UNCOMPRESSED_BYTES) -> bytes:
-    chunks: list[bytes] = []
-    total = 0
-    while True:
-        chunk = handle.read(1024 * 1024)
-        if not chunk:
-            return b"".join(chunks)
-        total += len(chunk)
-        if total > limit:
-            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
-        chunks.append(chunk)
-
-
-def _regular_input(path: Path) -> None:
-    if path.is_symlink() or not path.is_file():
-        raise DomainOpportunityFileError("input must be a regular local file")
-    if path.stat().st_size > MAX_COMPRESSED_BYTES:
-        raise DomainOpportunityFileError("input exceeds compressed size limit")
-
-
-def _check_ratio(compressed: int, uncompressed: int, message: str) -> None:
-    if uncompressed > compressed * MAX_COMPRESSION_RATIO:
-        raise DomainOpportunityFileError(message)
-
-
-def _read_gzip(raw: bytes) -> tuple[bytes, str]:
-    with gzip.GzipFile(fileobj=io.BytesIO(raw)) as handle:
-        content = _read_limited(handle)
-    _check_ratio(len(raw), len(content), "gzip compression ratio exceeds limit")
-    return content, "gzip"
-
-
-def _zip_entry_is_safe(entry: zipfile.ZipInfo) -> bool:
-    member = PurePosixPath(entry.filename)
-    return not (
-        member.is_absolute()
-        or ".." in member.parts
-        or entry.is_dir()
-        or entry.flag_bits & 0x1
-        or stat.S_ISLNK(entry.external_attr >> 16)
-        or member.suffix.casefold() in {".zip", ".gz", ".tgz", ".bz2", ".xz"}
-    )
-
-
-def _only_zip_entry(archive: zipfile.ZipFile) -> zipfile.ZipInfo:
-    entries = archive.infolist()
-    if not entries:
-        raise DomainOpportunityFileError("ZIP archive contains no files")
-    if not all(_zip_entry_is_safe(entry) for entry in entries):
-        raise DomainOpportunityFileError("ZIP archive contains unsafe, encrypted, linked, or nested content")
-    if len(entries) != 1:
-        raise DomainOpportunityFileError("ZIP archive must contain exactly one inventory file")
-    return entries[0]
-
-
-def _read_zip(raw: bytes) -> tuple[bytes, str]:
-    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
-        entry = _only_zip_entry(archive)
-        if entry.file_size > MAX_UNCOMPRESSED_BYTES:
-            raise DomainOpportunityFileError("archive content exceeds uncompressed size limit")
-        if entry.compress_size:
-            _check_ratio(entry.compress_size, entry.file_size, "ZIP compression ratio exceeds limit")
-        with archive.open(entry) as handle:
-            return _read_limited(handle), "zip"
-
-
-def _read_plain(raw: bytes) -> tuple[bytes, str]:
-    if len(raw) > MAX_UNCOMPRESSED_BYTES:
-        raise DomainOpportunityFileError("input exceeds uncompressed size limit")
-    return raw, "plain"
-
-
-def read_inventory(path: str | os.PathLike[str]) -> tuple[bytes, str]:
-    """Read one bounded plain, gzip, or safe single-file ZIP inventory."""
-    source = Path(path).expanduser()
-    _regular_input(source)
-    raw = source.read_bytes()
-    readers = ((b"\x1f\x8b", _read_gzip), (b"PK\x03\x04", _read_zip))
-    reader = next((candidate for magic, candidate in readers if raw.startswith(magic)), _read_plain)
-    return reader(raw)
 
 
 def _mapping(profile: Profile, headers: Iterable[str]) -> tuple[dict[str, str], list[str], list[str]]:

--- a/.agents/scripts/tests/fixtures/domain-opportunity/godaddy-inventory.csv
+++ b/.agents/scripts/tests/fixtures/domain-opportunity/godaddy-inventory.csv
@@ -1,0 +1,2 @@
+Domain Name,Auction ID,Current Bid,Bid Count,Start Date,End Date,Status,URL
+example.com,gd-100,$12.50,3,2026-08-20T10:00:00Z,2026-08-22T10:00:00Z,active,https://auctions.example.test/gd-100

--- a/.agents/scripts/tests/fixtures/domain-opportunity/snapnames-inventory.csv
+++ b/.agents/scripts/tests/fixtures/domain-opportunity/snapnames-inventory.csv
@@ -1,0 +1,2 @@
+Domain,Auction ID,Current Bid,Bids,Auction Start,Auction End,Status,URL
+example.net,sn-200,25.00,1,2026-08-20T10:00:00Z,2026-08-22T10:00:00Z,active,https://auctions.example.test/sn-200

--- a/.agents/scripts/tests/test-domain-opportunity-files.py
+++ b/.agents/scripts/tests/test-domain-opportunity-files.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hermetic coverage for bounded local auction-inventory ingestion."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from domain_opportunity_files import DomainOpportunityFileError, import_inventory, inspect  # noqa: E402
+from domain_opportunity_store import DomainOpportunityStore  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "domain-opportunity"
+
+
+class DomainOpportunityFileTests(unittest.TestCase):
+    """Exercise provider mapping, archive fuses, rejects, and repeat import safety."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.database = self.root / "inventory.sqlite"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_inspect_reports_headers_without_creating_database(self) -> None:
+        result = inspect(FIXTURES / "godaddy-inventory.csv", "godaddy")
+        self.assertEqual(result["missing_required_headers"], [])
+        self.assertEqual(result["archive_format"], "plain")
+        self.assertFalse(self.database.exists())
+
+    def test_plain_gzip_and_zip_normalize_to_one_observation(self) -> None:
+        plain = (FIXTURES / "snapnames-inventory.csv").read_bytes()
+        compressed = self.root / "inventory.csv.gz"
+        compressed.write_bytes(gzip.compress(plain))
+        archive = self.root / "inventory.zip"
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as output:
+            output.writestr("inventory.csv", plain)
+        first = import_inventory(FIXTURES / "snapnames-inventory.csv", "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
+        second = import_inventory(compressed, "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
+        third = import_inventory(archive, "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
+        self.assertEqual((first["imported"], second["imported"], third["imported"]), (1, 0, 0))
+        with DomainOpportunityStore(self.database) as store:
+            self.assertEqual(store.status()["counts"]["listing_observations"], 1)
+
+    def test_bad_rows_are_isolated_and_rejects_are_atomic(self) -> None:
+        source = self.root / "rows.csv"
+        source.write_text(
+            (FIXTURES / "godaddy-inventory.csv").read_text(encoding="utf-8")
+            + "bad,gd-101,nope,0,2026-08-20T10:00:00Z,2026-08-22T10:00:00Z,active,https://auctions.example.test/gd-101\n",
+            encoding="utf-8",
+        )
+        rejects = self.root / "rejects.jsonl"
+        result = import_inventory(source, "godaddy", self.database, rejects_path=str(rejects))
+        self.assertEqual((result["records"], result["rejected"]), (1, 1))
+        self.assertEqual(json.loads(rejects.read_text(encoding="utf-8"))["line"], 3)
+
+    def test_generic_normalized_jsonl_requires_explicit_profile(self) -> None:
+        source = self.root / "normalized.jsonl"
+        source.write_text(
+            json.dumps(
+                {
+                    "fqdn": "authorized.example",
+                    "status": "active",
+                    "auction_type": "auction",
+                    "current_price_micros": 1_000_000,
+                    "current_price_currency": "USD",
+                    "bid_count": 0,
+                    "start_time": "2026-08-20T10:00:00Z",
+                    "end_time": "2026-08-22T10:00:00Z",
+                    "source_url": "https://export.example.test/one",
+                    "observed_at": "2026-08-21T10:00:00Z",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        result = import_inventory(source, "generic", self.database)
+        self.assertEqual(result["imported"], 1)
+
+    def test_unsafe_archives_and_missing_headers_fail_before_store_creation(self) -> None:
+        archive = self.root / "unsafe.zip"
+        with zipfile.ZipFile(archive, "w") as output:
+            output.writestr("../escape.csv", "Domain\nexample.com\n")
+        with self.assertRaisesRegex(DomainOpportunityFileError, "unsafe path"):
+            import_inventory(archive, "godaddy", self.database)
+        missing = self.root / "missing.csv"
+        missing.write_text("Domain Name,Current Bid\nexample.com,1\n", encoding="utf-8")
+        with self.assertRaisesRegex(DomainOpportunityFileError, "missing required"):
+            import_inventory(missing, "godaddy", self.database)
+        self.assertFalse(self.database.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-domain-opportunity-files.py
+++ b/.agents/scripts/tests/test-domain-opportunity-files.py
@@ -16,7 +16,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from domain_opportunity_files import DomainOpportunityFileError, import_inventory, inspect  # noqa: E402
+from domain_opportunity_files import DomainOpportunityFileError, ImportOptions, import_inventory, inspect  # noqa: E402
 from domain_opportunity_store import DomainOpportunityStore  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "domain-opportunity"
@@ -46,9 +46,10 @@ class DomainOpportunityFileTests(unittest.TestCase):
         archive = self.root / "inventory.zip"
         with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as output:
             output.writestr("inventory.csv", plain)
-        first = import_inventory(FIXTURES / "snapnames-inventory.csv", "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
-        second = import_inventory(compressed, "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
-        third = import_inventory(archive, "snapnames", self.database, observed_at="2026-08-21T10:00:00Z")
+        options = ImportOptions(observed_at="2026-08-21T10:00:00Z")
+        first = import_inventory(FIXTURES / "snapnames-inventory.csv", "snapnames", self.database, options)
+        second = import_inventory(compressed, "snapnames", self.database, options)
+        third = import_inventory(archive, "snapnames", self.database, options)
         self.assertEqual((first["imported"], second["imported"], third["imported"]), (1, 0, 0))
         with DomainOpportunityStore(self.database) as store:
             self.assertEqual(store.status()["counts"]["listing_observations"], 1)
@@ -61,7 +62,7 @@ class DomainOpportunityFileTests(unittest.TestCase):
             encoding="utf-8",
         )
         rejects = self.root / "rejects.jsonl"
-        result = import_inventory(source, "godaddy", self.database, rejects_path=str(rejects))
+        result = import_inventory(source, "godaddy", self.database, ImportOptions(rejects_path=str(rejects)))
         self.assertEqual((result["records"], result["rejected"]), (1, 1))
         self.assertEqual(json.loads(rejects.read_text(encoding="utf-8"))["line"], 3)
 
@@ -92,7 +93,7 @@ class DomainOpportunityFileTests(unittest.TestCase):
         archive = self.root / "unsafe.zip"
         with zipfile.ZipFile(archive, "w") as output:
             output.writestr("../escape.csv", "Domain\nexample.com\n")
-        with self.assertRaisesRegex(DomainOpportunityFileError, "unsafe path"):
+        with self.assertRaisesRegex(DomainOpportunityFileError, "unsafe"):
             import_inventory(archive, "godaddy", self.database)
         missing = self.root / "missing.csv"
         missing.write_text("Domain Name,Current Bid\nexample.com,1\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Refactors the inventory parser into bounded archive, decode, and normalization helpers to address Qlty complexity and parameter findings while preserving import behavior.

## Files Changed

.agents/scripts/domain-opportunity-files.py, .agents/scripts/domain_opportunity_files.py, .agents/scripts/tests/fixtures/domain-opportunity/godaddy-inventory.csv, .agents/scripts/tests/fixtures/domain-opportunity/snapnames-inventory.csv, .agents/scripts/tests/test-domain-opportunity-files.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-domain-opportunity-files.py; python3 .agents/scripts/tests/test-domain-opportunity.py; .agents/scripts/linters-local.sh --changed

Resolves #30495


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.279 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 26m and 252,919 tokens on this as a headless worker.