### PR TITLE
t18300: add Google Ads demand enrichment

### DIFF
--- a/.agents/scripts/domain-opportunity-google-ads.py
+++ b/.agents/scripts/domain-opportunity-google-ads.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Plan or read Google Ads historical keyword metrics into local evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+from domain_opportunity_google_ads import (
+    DEFAULT_API_MAJOR,
+    GoogleAdsClient,
+    GoogleAdsCredentials,
+    GoogleAdsError,
+    GoogleAdsRequest,
+    plan,
+    sync,
+)
+from domain_opportunity_store import DomainOpportunityStore, DomainOpportunityStoreError
+
+
+def _load_fixture(path: str) -> dict[str, Any]:
+    """Load a synthetic response fixture and reject symlinked input."""
+    fixture_path = Path(path).expanduser()
+    if fixture_path.is_symlink() or not fixture_path.is_file():
+        raise GoogleAdsError("fixture must be a regular JSON file")
+    try:
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GoogleAdsError("fixture is not valid JSON") from exc
+    if not isinstance(fixture, dict) or not isinstance(fixture.get("response"), Mapping):
+        raise GoogleAdsError("fixture must contain a response object")
+    return fixture
+
+
+def _fixture_request(fixture: Mapping[str, Any], currency: str) -> GoogleAdsRequest:
+    """Read fixture request context without accepting credentials from a file."""
+    metadata = fixture.get("request_metadata")
+    if not isinstance(metadata, Mapping):
+        raise GoogleAdsError("fixture must contain request_metadata")
+    geographies = metadata.get("geographies")
+    return GoogleAdsRequest(
+        api_major=str(metadata.get("api_major", DEFAULT_API_MAJOR)), language=str(metadata.get("language", "")),
+        geographies=tuple(item for item in geographies if isinstance(item, str)) if isinstance(geographies, list) else (),
+        network=str(metadata.get("network", "")), currency=currency.upper(),
+    )
+
+
+def _request_from_args(args: argparse.Namespace) -> GoogleAdsRequest:
+    if args.fixture:
+        return _fixture_request(_load_fixture(args.fixture), args.currency)
+    return GoogleAdsRequest(
+        api_major=args.api_major,
+        language=args.language,
+        geographies=tuple(args.geography),
+        network=args.network,
+        currency=args.currency.upper(),
+    )
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    """Print the local, read-only request plan."""
+    request = _request_from_args(args)
+    with DomainOpportunityStore(args.db, initialize=True) as store:
+        print(json.dumps(plan(store, request), sort_keys=True))
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    """Synchronize either a synthetic fixture or a configured live read request."""
+    request = _request_from_args(args)
+    fixture = _load_fixture(args.fixture) if args.fixture else None
+    if fixture is not None:
+        fetch = lambda _phrases: fixture["response"]
+    else:
+        client = GoogleAdsClient(
+            request,
+            GoogleAdsCredentials(
+                access_token=os.environ.get("GOOGLE_ADS_ACCESS_TOKEN", ""),
+                developer_token=os.environ.get("GOOGLE_ADS_DEVELOPER_TOKEN", ""),
+                customer_id=args.customer_id,
+                login_customer_id=args.login_customer_id,
+            ),
+        )
+        fetch = client.historical_metrics
+    with DomainOpportunityStore(args.db, initialize=True) as store:
+        print(json.dumps(sync(store, request, fetch), sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the read-only CLI without accepting credentials as arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--db")
+    common.add_argument("--fixture")
+    common.add_argument("--currency", required=True)
+    common.add_argument("--api-major", default=DEFAULT_API_MAJOR)
+    common.add_argument("--language", default="")
+    common.add_argument("--geography", action="append", default=[])
+    common.add_argument("--network", default="GOOGLE_SEARCH_AND_PARTNERS")
+    common.add_argument("--customer-id", default="")
+    common.add_argument("--login-customer-id")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan_parser = subparsers.add_parser("plan", parents=[common])
+    plan_parser.set_defaults(handler=cmd_plan)
+    sync_parser = subparsers.add_parser("sync", parents=[common])
+    sync_parser.set_defaults(handler=cmd_sync)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one deterministic local request plan or sync."""
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (GoogleAdsError, DomainOpportunityStoreError):
+        print("domain-opportunity-google-ads: request could not be completed", file=sys.stderr)
+        return 1
+    except (OSError, sqlite3.Error):
+        print("domain-opportunity-google-ads: local storage operation failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/domain_opportunity_google_ads.py
+++ b/.agents/scripts/domain_opportunity_google_ads.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Read-only Google Ads historical-keyword-metrics collection helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping
+
+from domain_opportunity_contract import KeywordMetric, canonical_json, content_hash, utc_now
+from domain_opportunity_store import DomainOpportunityStore
+
+GOOGLE_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
+DEFAULT_API_MAJOR = "v25"
+MAX_BATCH_SIZE = 10_000
+MAX_BATCHES = 100
+_API_VERSION_RE = re.compile(r"^v[0-9]+$")
+_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+
+
+class GoogleAdsError(RuntimeError):
+    """Raised for a sanitized, recoverable Google Ads batch failure."""
+
+
+@dataclass(frozen=True)
+class GoogleAdsRequest:
+    """The explicit, auditable non-secret request context."""
+
+    api_major: str
+    language: str
+    geographies: tuple[str, ...]
+    network: str
+    currency: str
+
+    def __post_init__(self) -> None:
+        if not _API_VERSION_RE.fullmatch(self.api_major):
+            raise GoogleAdsError("Google Ads API major must be formatted like v25")
+        if not self.language.startswith("languageConstants/"):
+            raise GoogleAdsError("language must be a Google Ads language resource name")
+        if not self.geographies or any(not item.startswith("geoTargetConstants/") for item in self.geographies):
+            raise GoogleAdsError("at least one Google Ads geo target resource name is required")
+        if not self.network:
+            raise GoogleAdsError("keyword plan network is required")
+        if not _CURRENCY_RE.fullmatch(self.currency):
+            raise GoogleAdsError("currency must be an ISO 4217 code")
+
+
+@dataclass(frozen=True)
+class GoogleAdsCredentials:
+    """Ephemeral live-read credentials kept outside stored request evidence."""
+
+    access_token: str
+    developer_token: str
+    customer_id: str
+    login_customer_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.access_token or not self.developer_token or not self.customer_id:
+            raise GoogleAdsError("Google Ads live sync requires configured credentials and a customer target")
+
+
+def normalized_phrase(value: str) -> str:
+    """Return one stable phrase identity without applying linguistic guesses."""
+    return " ".join(value.casefold().split())
+
+
+def retrieval_month(now: datetime | None = None) -> str:
+    """Return the UTC monthly partition used for cache identity."""
+    moment = now or datetime.now(timezone.utc)
+    return f"{moment.astimezone(timezone.utc).year:04d}-{moment.astimezone(timezone.utc).month:02d}"
+
+
+def request_identity(phrases: Iterable[str], request: GoogleAdsRequest, month: str) -> str:
+    """Hash all factors that make a monthly historical-metrics result distinct."""
+    return content_hash(
+        {
+            "phrases": sorted({normalized_phrase(phrase) for phrase in phrases}),
+            "language": request.language,
+            "geographies": sorted(request.geographies),
+            "network": request.network,
+            "currency": request.currency,
+            "api_major": request.api_major,
+            "retrieval_month": month,
+        }
+    )
+
+
+def _integer_or_none(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise GoogleAdsError(f"{field} must be an integer when supplied")
+    try:
+        converted = int(value)
+    except (TypeError, ValueError) as exc:
+        raise GoogleAdsError(f"{field} must be an integer when supplied") from exc
+    if converted < 0:
+        raise GoogleAdsError(f"{field} must not be negative")
+    return converted
+
+
+def _month_value(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    year = _integer_or_none(value.get("year"), "monthlySearchVolumes.year")
+    raw_month = value.get("month")
+    if year is None or not isinstance(raw_month, str):
+        return None
+    months = {
+        "JANUARY": 1, "FEBRUARY": 2, "MARCH": 3, "APRIL": 4, "MAY": 5, "JUNE": 6,
+        "JULY": 7, "AUGUST": 8, "SEPTEMBER": 9, "OCTOBER": 10, "NOVEMBER": 11, "DECEMBER": 12,
+    }
+    month = months.get(raw_month.upper())
+    return None if month is None else f"{year:04d}-{month:02d}"
+
+
+def normalize_metrics(raw: Any) -> dict[str, Any]:
+    """Preserve documented Google Ads units and absent values as JSON null."""
+    metrics = raw if isinstance(raw, Mapping) else {}
+    volumes: list[dict[str, Any]] = []
+    raw_volumes = metrics.get("monthlySearchVolumes")
+    if isinstance(raw_volumes, list):
+        for item in raw_volumes:
+            if not isinstance(item, Mapping):
+                continue
+            volumes.append(
+                {
+                    "month": _month_value(item),
+                    "searches": _integer_or_none(item.get("monthlySearches"), "monthlySearchVolumes.monthlySearches"),
+                }
+            )
+    return {
+        "average_monthly_searches": _integer_or_none(metrics.get("avgMonthlySearches"), "avgMonthlySearches"),
+        "monthly_search_volumes": volumes,
+        "competition": metrics.get("competition") if isinstance(metrics.get("competition"), str) else None,
+        "competition_index": _integer_or_none(metrics.get("competitionIndex"), "competitionIndex"),
+        "low_top_of_page_bid_micros": _integer_or_none(metrics.get("lowTopOfPageBidMicros"), "lowTopOfPageBidMicros"),
+        "high_top_of_page_bid_micros": _integer_or_none(metrics.get("highTopOfPageBidMicros"), "highTopOfPageBidMicros"),
+        "units": {
+            "average_monthly_searches": "searches",
+            "monthly_search_volumes.searches": "searches",
+            "competition_index": "index_0_100",
+            "low_top_of_page_bid_micros": "currency_micros",
+            "high_top_of_page_bid_micros": "currency_micros",
+        },
+    }
+
+
+def response_groups(response: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Map response groups by returned text and close variants, never array position."""
+    raw_results = response.get("results")
+    if not isinstance(raw_results, list):
+        raise GoogleAdsError("Google Ads response does not contain a results array")
+    groups: list[dict[str, Any]] = []
+    for raw_result in raw_results:
+        if not isinstance(raw_result, Mapping) or not isinstance(raw_result.get("text"), str):
+            continue
+        variants = [raw_result["text"]]
+        if isinstance(raw_result.get("closeVariants"), list):
+            variants.extend(item for item in raw_result["closeVariants"] if isinstance(item, str))
+        groups.append(
+            {
+                "returned_text": raw_result["text"],
+                "close_variants": sorted(set(variants[1:])),
+                "identities": {normalized_phrase(item) for item in variants},
+                "metrics": normalize_metrics(raw_result.get("keywordMetrics")),
+            }
+        )
+    return groups
+
+
+def map_phrases_to_groups(phrases: Iterable[str], response: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return explicit found, missing, or ambiguous outcomes for each input phrase."""
+    groups = response_groups(response)
+    mapped: dict[str, dict[str, Any]] = {}
+    for phrase in sorted({normalized_phrase(item) for item in phrases if normalized_phrase(item)}):
+        matched = [group for group in groups if phrase in group["identities"]]
+        if len(matched) == 1:
+            group = matched[0]
+            mapped[phrase] = {
+                "status": "found",
+                "returned_text": group["returned_text"],
+                "close_variants": group["close_variants"],
+                "metrics": group["metrics"],
+            }
+        elif not matched:
+            mapped[phrase] = {"status": "missing", "returned_text": None, "close_variants": [], "metrics": None}
+        else:
+            mapped[phrase] = {"status": "ambiguous", "returned_text": None, "close_variants": [], "metrics": None}
+    return mapped
+
+
+class GoogleAdsClient:
+    """Minimal read-only REST client for one historical-metrics request stream."""
+
+    def __init__(
+        self,
+        request: GoogleAdsRequest,
+        credentials: GoogleAdsCredentials,
+        *,
+        opener: Callable[..., Any] = urllib.request.urlopen,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.request = request
+        self.credentials = credentials
+        self.opener = opener
+        self.sleep = sleep
+        self.monotonic = monotonic
+        self._last_request_at: float | None = None
+
+    def _wait_for_request_slot(self) -> None:
+        """Keep this customer stream at the documented one request per second."""
+        if self._last_request_at is None:
+            return
+        remaining = 1.0 - (self.monotonic() - self._last_request_at)
+        if remaining > 0:
+            self.sleep(remaining)
+
+    @staticmethod
+    def _retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
+        """Honor a bounded provider delay before one of two retry attempts."""
+        header = error.headers.get("Retry-After") if error.headers else None
+        try:
+            provider_delay = float(header) if header is not None else 0.0
+        except ValueError:
+            provider_delay = 0.0
+        return min(60.0, max(1.0, provider_delay, float(2**attempt)))
+
+    def historical_metrics(self, phrases: list[str]) -> dict[str, Any]:
+        """Perform only the documented read-only historical metrics method."""
+        if not phrases or len(phrases) > MAX_BATCH_SIZE:
+            raise GoogleAdsError("Google Ads batch size is invalid")
+        payload = canonical_json(
+            {
+                "keywords": phrases,
+                "language": self.request.language,
+                "geoTargetConstants": list(self.request.geographies),
+                "keywordPlanNetwork": self.request.network,
+            }
+        ).encode("utf-8")
+        endpoint = (
+            f"https://googleads.googleapis.com/{self.request.api_major}/customers/"
+            f"{self.credentials.customer_id}:generateKeywordHistoricalMetrics"
+        )
+        headers = {
+            "Authorization": f"Bearer {self.credentials.access_token}",
+            "developer-token": self.credentials.developer_token,
+            "Content-Type": "application/json",
+        }
+        if self.credentials.login_customer_id:
+            headers["login-customer-id"] = self.credentials.login_customer_id
+        request = urllib.request.Request(endpoint, data=payload, headers=headers, method="POST")
+        for attempt in range(3):
+            try:
+                self._wait_for_request_slot()
+                self._last_request_at = self.monotonic()
+                with self.opener(request, timeout=30) as response:
+                    decoded = json.loads(response.read().decode("utf-8"))
+            except urllib.error.HTTPError as exc:
+                if exc.code in {401, 403}:
+                    raise GoogleAdsError("Google Ads authentication or access was denied") from exc
+                if exc.code not in {429, 500, 502, 503, 504} or attempt == 2:
+                    raise GoogleAdsError("Google Ads quota or transient request failure") from exc
+                self.sleep(self._retry_delay(exc, attempt))
+                continue
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                raise GoogleAdsError("Google Ads historical metrics response was invalid") from exc
+            if not isinstance(decoded, dict):
+                raise GoogleAdsError("Google Ads historical metrics response was invalid")
+            return decoded
+        raise GoogleAdsError("Google Ads historical metrics request failed")
+
+
+def candidate_phrases(store: DomainOpportunityStore) -> dict[str, list[dict[str, str]]]:
+    """Use each listing's SLD as its conservative candidate phrase identity."""
+    candidates: dict[str, list[dict[str, str]]] = {}
+    for listing in store.current_listings(active_only=True):
+        phrase = normalized_phrase(str(listing["sld"]))
+        if phrase:
+            candidates.setdefault(phrase, []).append(
+                {"provider": str(listing["provider"]), "provider_listing_id": str(listing["provider_listing_id"])}
+            )
+    return candidates
+
+
+def plan(store: DomainOpportunityStore, request: GoogleAdsRequest, *, month: str | None = None) -> dict[str, Any]:
+    """Report bounded batches without issuing a Google Ads request."""
+    candidates = candidate_phrases(store)
+    phrases = sorted(candidates)
+    period = month or retrieval_month()
+    identity = request_identity(phrases, request, period)
+    batches = [phrases[index : index + MAX_BATCH_SIZE] for index in range(0, len(phrases), MAX_BATCH_SIZE)]
+    if len(batches) > MAX_BATCHES:
+        raise GoogleAdsError("Google Ads batch fuse exceeded")
+    return {"batch_count": len(batches), "batch_ids": [content_hash(batch)[:12] for batch in batches], "candidate_count": len(phrases), "input_hash": identity, "retrieval_month": period}
+
+
+def sync(
+    store: DomainOpportunityStore,
+    request: GoogleAdsRequest,
+    fetch: Callable[[list[str]], Mapping[str, Any]],
+    *,
+    month: str | None = None,
+) -> dict[str, Any]:
+    """Fetch bounded batches and retain completed evidence when a later batch fails."""
+    candidates = candidate_phrases(store)
+    phrases = sorted(candidates)
+    period = month or retrieval_month()
+    identity = request_identity(phrases, request, period)
+    batches = [phrases[index : index + MAX_BATCH_SIZE] for index in range(0, len(phrases), MAX_BATCH_SIZE)]
+    if len(batches) > MAX_BATCHES:
+        raise GoogleAdsError("Google Ads batch fuse exceeded")
+    run_id = f"google-ads-{identity[:32]}"
+    inserted = 0
+    completed_batches = 0
+    try:
+        with store.transaction():
+            store.begin_source_run(run_id, "google-ads")
+        for batch in batches:
+            response = fetch(batch)
+            mapped = map_phrases_to_groups(batch, response)
+            with store.transaction():
+                for phrase, outcome in mapped.items():
+                    payload = {
+                        "api_major": request.api_major,
+                        "language": request.language,
+                        "geographies": list(request.geographies),
+                        "network": request.network,
+                        "account_currency": request.currency,
+                        "input_phrase": phrase,
+                        "input_hash": identity,
+                        "retrieval_month": period,
+                        "metric_source": "google_ads.keyword_plan_idea.generate_historical_metrics",
+                        **outcome,
+                    }
+                    digest = content_hash(payload)
+                    for listing in candidates[phrase]:
+                        inserted += int(
+                            store.insert_keyword_metric(
+                                KeywordMetric(
+                                    provider=listing["provider"],
+                                    provider_listing_id=listing["provider_listing_id"],
+                                    source_run_id=run_id,
+                                    source="google-ads",
+                                    metric_name="historical_keyword_metrics",
+                                    value=canonical_json(payload),
+                                    unit="json",
+                                    observed_at=utc_now(),
+                                    payload_hash=digest,
+                                )
+                            )
+                        )
+                completed_batches += 1
+        with store.transaction():
+            store.complete_source_run(run_id, inserted)
+    except Exception:
+        with store.transaction():
+            store.fail_source_run(run_id, "batch_failed")
+        raise
+    return {"batches_completed": completed_batches, "input_hash": identity, "inserted": inserted, "records": len(phrases), "retrieval_month": period, "run_id": run_id}

--- a/.agents/scripts/tests/fixtures/domain-opportunity/google-ads-historical-metrics.json
+++ b/.agents/scripts/tests/fixtures/domain-opportunity/google-ads-historical-metrics.json
@@ -1,0 +1,31 @@
+{
+  "request_metadata": {
+    "api_major": "v25",
+    "language": "languageConstants/1000",
+    "geographies": ["geoTargetConstants/2840"],
+    "network": "GOOGLE_SEARCH_AND_PARTNERS"
+  },
+  "response": {
+    "results": [
+      {
+        "text": "example",
+        "closeVariants": ["examples"],
+        "keywordMetrics": {
+          "avgMonthlySearches": "1200",
+          "monthlySearchVolumes": [
+            {"year": "2026", "month": "JANUARY", "monthlySearches": "1100"},
+            {"year": "2025", "month": "DECEMBER", "monthlySearches": "1300"}
+          ],
+          "competition": "MEDIUM",
+          "competitionIndex": "47",
+          "lowTopOfPageBidMicros": "250000",
+          "highTopOfPageBidMicros": "1200000"
+        }
+      },
+      {
+        "text": "missing metrics",
+        "closeVariants": []
+      }
+    ]
+  }
+}

--- a/.agents/scripts/tests/test-domain-opportunity-google-ads.py
+++ b/.agents/scripts/tests/test-domain-opportunity-google-ads.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Focused offline coverage for Google Ads historical metric enrichment."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import urllib.error
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from domain_opportunity_contract import content_hash
+from domain_opportunity_google_ads import (
+    GoogleAdsClient,
+    GoogleAdsCredentials,
+    GoogleAdsError,
+    GoogleAdsRequest,
+    map_phrases_to_groups,
+    request_identity,
+    sync,
+)
+from domain_opportunity_store import DomainOpportunityStore
+
+
+class GoogleAdsHistoricalMetricsTest(unittest.TestCase):
+    """Keep fixture, grouping, retry boundary, and persistence semantics local."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.database = Path(self.temporary.name) / "metrics.sqlite"
+        self.request = GoogleAdsRequest(
+            api_major="v25",
+            language="languageConstants/1000",
+            geographies=("geoTargetConstants/2840",),
+            network="GOOGLE_SEARCH_AND_PARTNERS",
+            currency="USD",
+        )
+        self.response = json.loads(
+            (Path(__file__).parent / "fixtures/domain-opportunity/google-ads-historical-metrics.json").read_text()
+        )["response"]
+        with DomainOpportunityStore(self.database, initialize=True) as store:
+            with store.transaction():
+                store.begin_source_run("seed", "fixture", started_at="2026-08-21T00:00:00Z")
+                for listing_id, fqdn in (("one", "example.com"), ("two", "examples.net"), ("three", "unreturned.org")):
+                    sld, tld = fqdn.split(".", 1)
+                    store.upsert_listing_observation(
+                        {
+                            "provider": "fixture", "provider_listing_id": listing_id, "fqdn": fqdn,
+                            "sld": sld, "tld": tld, "status": "active", "auction_type": "auction",
+                            "current_price_micros": 1, "current_price_currency": "USD", "bid_count": 0,
+                            "start_time": "2026-08-20T00:00:00Z", "end_time": "2026-08-22T00:00:00Z",
+                            "source_url": "https://example.invalid/listing", "observed_at": "2026-08-21T00:00:00Z",
+                            "source_run_id": "seed", "payload_hash": content_hash({"listing": listing_id}),
+                        }
+                    )
+                store.complete_source_run("seed", 3)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_grouping_is_matched_by_text_and_preserves_units_and_nulls(self) -> None:
+        mapped = map_phrases_to_groups(["examples", "unreturned", "missing metrics"], self.response)
+        self.assertEqual(mapped["examples"]["returned_text"], "example")
+        self.assertEqual(mapped["unreturned"]["status"], "missing")
+        metrics = mapped["examples"]["metrics"]
+        self.assertEqual(metrics["low_top_of_page_bid_micros"], 250000)
+        self.assertEqual(metrics["monthly_search_volumes"][0], {"month": "2026-01", "searches": 1100})
+        self.assertIsNone(mapped["missing metrics"]["metrics"]["average_monthly_searches"])
+        self.assertEqual(metrics["units"]["high_top_of_page_bid_micros"], "currency_micros")
+
+    def test_ambiguous_group_is_not_assigned_by_position(self) -> None:
+        response = {"results": [
+            {"text": "first", "closeVariants": ["shared"], "keywordMetrics": {}},
+            {"text": "second", "closeVariants": ["shared"], "keywordMetrics": {}},
+        ]}
+        self.assertEqual(map_phrases_to_groups(["shared"], response)["shared"]["status"], "ambiguous")
+
+    def test_same_month_replay_is_idempotent_and_later_month_is_distinct(self) -> None:
+        with DomainOpportunityStore(self.database) as store:
+            first = sync(store, self.request, lambda _phrases: self.response, month="2026-08")
+            replay = sync(store, self.request, lambda _phrases: self.response, month="2026-08")
+            later = sync(store, self.request, lambda _phrases: self.response, month="2026-09")
+            self.assertEqual(first["inserted"], 3)
+            self.assertEqual(replay["inserted"], 0)
+            self.assertEqual(later["inserted"], 3)
+            self.assertEqual(store.status()["counts"]["keyword_metrics"], 6)
+
+    def test_partial_failure_keeps_prior_batch_and_marks_run_failed(self) -> None:
+        calls = 0
+
+        def fetch(_phrases: list[str]) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return self.response
+            raise GoogleAdsError("quota")
+
+        with DomainOpportunityStore(self.database) as store:
+            original = __import__("domain_opportunity_google_ads").MAX_BATCH_SIZE
+            __import__("domain_opportunity_google_ads").MAX_BATCH_SIZE = 1
+            try:
+                with self.assertRaises(GoogleAdsError):
+                    sync(store, self.request, fetch, month="2026-08")
+            finally:
+                __import__("domain_opportunity_google_ads").MAX_BATCH_SIZE = original
+            self.assertGreater(store.status()["counts"]["keyword_metrics"], 0)
+            status = store.connection.execute("SELECT status,error_code FROM source_runs WHERE provider='google-ads'").fetchone()
+            self.assertEqual(tuple(status), ("failed", "batch_failed"))
+
+    def test_request_identity_changes_with_month_and_never_contains_credentials(self) -> None:
+        august = request_identity(["example"], self.request, "2026-08")
+        september = request_identity(["example"], self.request, "2026-09")
+        self.assertNotEqual(august, september)
+        self.assertEqual(len(august), 64)
+
+    def test_live_client_throttles_and_sanitizes_auth_and_quota_failures(self) -> None:
+        with self.assertRaisesRegex(GoogleAdsError, "credentials"):
+            GoogleAdsCredentials(access_token="", developer_token="dev", customer_id="customer")
+
+        sleeps: list[float] = []
+
+        def quota_opener(*_args: object, **_kwargs: object) -> object:
+            error = urllib.error.HTTPError("https://example.invalid", 429, "quota", {}, None)
+            error.close()
+            raise error
+
+        placeholder_access_token = "access" + "-token"
+        placeholder_developer_token = "developer" + "-token"
+        client = GoogleAdsClient(
+            self.request,
+            GoogleAdsCredentials(
+                access_token=placeholder_access_token,
+                developer_token=placeholder_developer_token,
+                customer_id="customer-id",
+            ),
+            opener=quota_opener, sleep=sleeps.append, monotonic=lambda: 0.0,
+        )
+        with self.assertRaises(GoogleAdsError) as raised:
+            client.historical_metrics(["example"])
+        self.assertNotIn("customer-id", str(raised.exception))
+        self.assertNotIn(placeholder_access_token, str(raised.exception))
+        self.assertEqual(sleeps, [1.0, 1.0, 2.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds read-only Google Ads historical keyword metric planning and fixture/live sync with provenance, grouping, throttling, retries, and idempotent SQLite evidence.

## Files Changed

.agents/scripts/domain-opportunity-google-ads.py, .agents/scripts/domain_opportunity_google_ads.py, .agents/scripts/tests/fixtures/domain-opportunity/google-ads-historical-metrics.json, .agents/scripts/tests/test-domain-opportunity-google-ads.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: python3 .agents/scripts/tests/test-domain-opportunity-google-ads.py; fixture plan and sync; .agents/scripts/linters-local.sh --changed

Resolves #30497


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.279 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-terra spent 21m and 184,853 tokens on this as a headless worker.