### PR TITLE
GH#30492: Fix pulse CI repair lifecycle races

### DIFF
--- a/.agents/scripts/headless-runtime-worker-prepare.sh
+++ b/.agents/scripts/headless-runtime-worker-prepare.sh
@@ -65,8 +65,9 @@ _hrw_ownership_log() {
 #######################################
 # Verify that a worker still owns its exact dispatch target. Issue workers use
 # their live assignment, direct PR workers use the exact open head, and draft
-# checkpoints use the complete PR/linkage/assignee envelope. A legacy linked-
-# issue CI repair must explicitly request both exact-head and issue fences.
+# checkpoints use the complete PR/linkage/assignee envelope. Linked-issue CI
+# repairs use the exact PR head and closing linkage because any trusted Pulse
+# runner may repair the branch after the implementation worker hands it off.
 # This helper is read-only and fail-closed.
 #######################################
 _hrw_verify_dispatch_ownership() {
@@ -141,6 +142,7 @@ _hrw_verify_dispatch_ownership() {
 				return 1
 			fi
 			_hrw_ownership_log info "$target_output"
+			return 0
 		else
 			_hrw_ownership_log error "unclassified PR repair ownership contract issue=${issue_number} pr=${repair_pr_number} repo=${repo_slug} mode=${repair_ownership_mode:-missing}"
 			return 1

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -91,22 +91,57 @@ _feedback_route_release_marker() {
 	return 0
 }
 
-_feedback_route_release_exists() {
+_feedback_route_release_comments() {
 	local linked_issue="$1"
 	local repo_slug="$2"
 	local marker="$3"
 	local endpoint="repos/${repo_slug}/issues/${linked_issue}/comments?per_page=100"
 	local comments_json=""
+	# #aidevops:trust-boundary — only trusted automation comments can satisfy or
+	# win release-marker convergence; copied markers from untrusted users do not.
 	# shellcheck disable=SC2016 # $marker is a jq variable supplied below.
-	local filter='any((if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]?; (.body // "") | contains($marker))'
+	local filter='[
+		(if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]?
+		| select((.author_association // "") as $association
+			| ["OWNER", "MEMBER", "COLLABORATOR"] | index($association))
+		| select((.body // "") | startswith("CLAIM_RELEASED reason=feedback_route_") and contains($marker))
+		| {id, created_at}
+	] | sort_by([.created_at, .id])'
 
 	if declare -F _gh_with_timeout >/dev/null 2>&1; then
 		comments_json=$(_gh_with_timeout read gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
 	else
 		comments_json=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
 	fi
-	printf '%s' "$comments_json" | jq -e --arg marker "$marker" "$filter" >/dev/null 2>&1
+	printf '%s' "$comments_json" | jq -c --arg marker "$marker" "$filter" 2>/dev/null
 	return $?
+}
+
+_feedback_route_release_exists() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local comments_json=""
+
+	comments_json=$(_feedback_route_release_comments "$linked_issue" "$repo_slug" "$marker") || return 1
+	printf '%s' "$comments_json" | jq -e 'length > 0' >/dev/null 2>&1
+	return $?
+}
+
+_feedback_route_reconcile_release_comments() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local comments_json=""
+	local duplicate_id=""
+
+	comments_json=$(_feedback_route_release_comments "$linked_issue" "$repo_slug" "$marker") || return 1
+	while IFS= read -r duplicate_id; do
+		[[ "$duplicate_id" =~ ^[0-9]+$ ]] || continue
+		_feedback_route_gh_write api "repos/${repo_slug}/issues/comments/${duplicate_id}" \
+			--method DELETE >/dev/null 2>&1 || true
+	done < <(printf '%s' "$comments_json" | jq -r '.[1:][]?.id' 2>/dev/null)
+	return 0
 }
 
 _feedback_route_release_dispatch_claim() {
@@ -117,18 +152,24 @@ _feedback_route_release_dispatch_claim() {
 	local expected_head="$5"
 	local marker=""
 	local comment_body=""
+	local comment_status=0
 
 	marker=$(_feedback_route_release_marker "$kind" "$pr_number" "$expected_head")
-	_feedback_route_release_exists "$linked_issue" "$repo_slug" "$marker" && return 0
+	if _feedback_route_release_exists "$linked_issue" "$repo_slug" "$marker"; then
+		_feedback_route_reconcile_release_comments "$linked_issue" "$repo_slug" "$marker" || true
+		return 0
+	fi
 	comment_body="CLAIM_RELEASED reason=feedback_route_${kind} runner=pulse ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 ${marker}"
 	if declare -F gh_issue_comment >/dev/null 2>&1; then
-		gh_issue_comment "$linked_issue" --repo "$repo_slug" --body "$comment_body" >/dev/null 2>&1
-		return $?
+		gh_issue_comment "$linked_issue" --repo "$repo_slug" --body "$comment_body" >/dev/null 2>&1 || comment_status=$?
+	else
+		_feedback_route_gh_write issue comment "$linked_issue" --repo "$repo_slug" \
+			--body "$comment_body" >/dev/null 2>&1 || comment_status=$?
 	fi
-	_feedback_route_gh_write issue comment "$linked_issue" --repo "$repo_slug" \
-		--body "$comment_body" >/dev/null 2>&1
-	return $?
+	[[ "$comment_status" -eq 0 ]] || return "$comment_status"
+	_feedback_route_reconcile_release_comments "$linked_issue" "$repo_slug" "$marker" || true
+	return 0
 }
 
 _feedback_route_marker() {

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -221,7 +221,7 @@ run_runtime_ownership_fence_tests() {
 	test_direct_pr_runtime_target_fence_uses_exact_head_without_runner
 	test_direct_pr_runtime_target_fence_fails_closed
 	test_pr_checkpoint_runtime_fence_uses_exact_envelope
-	test_linked_issue_pr_repair_keeps_issue_ownership_fence
+	test_linked_issue_pr_repair_allows_trusted_peer_runner
 	test_mismatched_pr_repair_contract_fails_closed
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-worktree-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-worktree-tests.sh
@@ -1103,7 +1103,7 @@ EOF
 	return 0
 }
 
-test_linked_issue_pr_repair_keeps_issue_ownership_fence() {
+test_linked_issue_pr_repair_allows_trusted_peer_runner() {
 	local ownership_helper="${TEST_ROOT}/linked-issue-ownership-helper.sh"
 	local calls_file="${TEST_ROOT}/linked-issue-ownership-calls"
 	cat >"$ownership_helper" <<'EOF'
@@ -1111,7 +1111,6 @@ test_linked_issue_pr_repair_keeps_issue_ownership_fence() {
 printf '%s\n' "$*" >>"${LINKED_ISSUE_OWNERSHIP_CALLS:?}"
 case "${1:-}" in
 verify-pr-repair-target) printf 'PR_REPAIR_TARGET_VALID: exact open head\n'; exit 0 ;;
-verify-worker-ownership) printf 'WORKER_OWNERSHIP_VALID: linked issue assignment\n'; exit 0 ;;
 esac
 exit 1
 EOF
@@ -1137,12 +1136,12 @@ EOF
 
 	if [[ "$status" -eq 0 ]] &&
 		grep -Fxq 'verify-pr-repair-target 77 owner/repo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa feature/review 42' "$calls_file" &&
-		grep -Fxq 'verify-worker-ownership 42 owner/repo expected-runner' "$calls_file" &&
-		[[ "$output" == *"PR_REPAIR_TARGET_VALID"* && "$output" == *"WORKER_OWNERSHIP_VALID"* ]]; then
-		print_result "linked-issue PR repair requires exact head and live issue ownership" 0
+		! grep -q 'verify-worker-ownership' "$calls_file" &&
+		[[ "$output" == *"PR_REPAIR_TARGET_VALID"* ]]; then
+		print_result "linked-issue PR repair allows trusted peer runner after exact target fence" 0
 		return 0
 	fi
-	print_result "linked-issue PR repair requires exact head and live issue ownership" 1 \
+	print_result "linked-issue PR repair allows trusted peer runner after exact target fence" 1 \
 		"status=$status output=${output:-<empty>}"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -168,7 +168,7 @@ case "$_subcmd" in
 			break
 		fi
 	done
-	jq --arg body "$_body" '. + [{body:$body}]' "${TEST_ROOT}/issue-comments.json" \
+	jq --arg body "$_body" '. + [{id: ((map(.id // 0) | max // 0) + 1), body:$body, created_at:"2026-08-21T02:38:02Z", author_association:"MEMBER"}]' "${TEST_ROOT}/issue-comments.json" \
 		>"${TEST_ROOT}/issue-comments.json.tmp"
 	mv "${TEST_ROOT}/issue-comments.json.tmp" "${TEST_ROOT}/issue-comments.json"
 	exit 0
@@ -1311,6 +1311,25 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 	return 0
 }
 
+test_feedback_release_reconciles_cross_runner_duplicates() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/issue-comments.json" <<'EOF'
+[{"id":11,"created_at":"2026-08-21T02:38:02Z","author_association":"MEMBER","body":"CLAIM_RELEASED reason=feedback_route_ci runner=pulse ts=2026-08-21T02:37:59Z\n<!-- feedback-route:dispatch-release:ci:PR100:SHAabc123repairsha -->"},{"id":12,"created_at":"2026-08-21T02:38:04Z","author_association":"COLLABORATOR","body":"CLAIM_RELEASED reason=feedback_route_ci runner=pulse ts=2026-08-21T02:38:00Z\n<!-- feedback-route:dispatch-release:ci:PR100:SHAabc123repairsha -->"}]
+EOF
+
+	_feedback_route_release_dispatch_claim "ci" "100" "owner/repo" "42" "abc123repairsha"
+
+	if ! grep -qF 'gh api repos/owner/repo/issues/comments/12 --method DELETE' "$GH_LOG" ||
+		grep -qF 'gh api repos/owner/repo/issues/comments/11 --method DELETE' "$GH_LOG" ||
+		grep -qF 'gh issue comment 42' "$GH_LOG"; then
+		print_result "feedback release converges cross-runner duplicate comments" 1 \
+			"Expected only newer comment 12 to be deleted. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "feedback release converges cross-runner duplicate comments" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -1349,6 +1368,7 @@ main() {
 	test_dispatch_noop_on_invalid_inputs
 	test_dispatch_clears_in_progress_labels_as_fallback
 	test_ci_dispatch_dedupes_by_pr_head_marker
+	test_feedback_release_reconciles_cross_runner_duplicates
 	test_dispatch_skips_body_edit_on_issue_view_failure
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Allow exact-head CI repair handoff across trusted Pulse runners and reconcile duplicate cross-runner claim-release comments

## Files Changed

.agents/scripts/headless-runtime-worker-prepare.sh, .agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-headless-runtime-worktree-tests.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck passed; 31 feedback-routing tests and the headless runtime suite passed; local changed-file quality gates passed

For #30492


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.279 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 11m and 439,035 tokens on this with the user in an interactive session.