### PR TITLE
t18302: feat: add ranked local domain opportunity reports

### DIFF
--- a/.agents/scripts/domain-opportunity-helper.py
+++ b/.agents/scripts/domain-opportunity-helper.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from domain_opportunity_contract import DomainOpportunityContractError, normalize_listing
+from domain_opportunity_reporting import ReportOptions, ReportingError, build_report, pipeline_status, publish, render
 from domain_opportunity_store import DomainOpportunityStore, DomainOpportunityStoreError
 
 
@@ -32,6 +33,54 @@ def cmd_status(args: argparse.Namespace) -> int:
     else:
         print(f"schema v{status['schema_version']}: {status['counts']['listings']} listings")
     return 0
+
+
+def cmd_pipeline_status(args: argparse.Namespace) -> int:
+    """Report inventory and optional enrichment readiness."""
+    with DomainOpportunityStore(args.db) as store:
+        status = pipeline_status(store)
+    print(json.dumps(status, sort_keys=True) if args.json else "\n".join(
+        f"{stage}: {value}" for stage, value in status["stages"].items()
+    ))
+    return 0
+
+
+def _report(args: argparse.Namespace) -> dict[str, Any]:
+    with DomainOpportunityStore(args.db) as store:
+        return build_report(store, ReportOptions(
+            as_of=args.as_of, active_only=args.active_only,
+            eligible_only=args.eligible_only, limit=args.limit,
+        ))
+
+
+def cmd_candidates(args: argparse.Namespace) -> int:
+    """Print the ranked joined candidate projection as JSON."""
+    print(json.dumps(_report(args)["candidates"], sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    """Atomically publish one deterministic report projection."""
+    report = _report(args)
+    publish(args.output, render(report, args.format))
+    print(json.dumps({"exported": report["candidate_count"], "format": args.format, "output": args.output}, sort_keys=True))
+    return 0
+
+
+def cmd_analysis_packet(args: argparse.Namespace) -> int:
+    """Publish concise Markdown plus complete measured evidence."""
+    report = _report(args)
+    publish(args.output, render(report, "markdown"))
+    print(json.dumps({"exported": report["candidate_count"], "format": "markdown", "output": args.output}, sort_keys=True))
+    return 0
+
+
+def _add_report_filters(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--as-of")
+    parser.add_argument("--active-only", action="store_true")
+    parser.add_argument("--eligible-only", action="store_true")
+    parser.add_argument("--limit", type=int)
 
 
 def _load_jsonl(path: Path, provider: str) -> list[dict[str, Any]]:
@@ -99,6 +148,10 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser.add_argument("--db")
     status_parser.add_argument("--json", action="store_true")
     status_parser.set_defaults(handler=cmd_status)
+    pipeline_parser = subparsers.add_parser("pipeline-status", help="Show pipeline evidence readiness")
+    pipeline_parser.add_argument("--db", required=True)
+    pipeline_parser.add_argument("--json", action="store_true")
+    pipeline_parser.set_defaults(handler=cmd_pipeline_status)
     import_parser = subparsers.add_parser("import-jsonl", help="Import normalized JSONL evidence")
     import_parser.add_argument("--db")
     import_parser.add_argument("--input", required=True)
@@ -109,6 +162,18 @@ def build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--output", required=True)
     export_parser.add_argument("--active-only", action="store_true")
     export_parser.set_defaults(handler=cmd_export_csv)
+    candidates_parser = subparsers.add_parser("candidates", help="Print ranked joined candidates")
+    _add_report_filters(candidates_parser)
+    candidates_parser.set_defaults(handler=cmd_candidates)
+    report_parser = subparsers.add_parser("report", help="Publish ranked CSV, JSON, or Markdown")
+    _add_report_filters(report_parser)
+    report_parser.add_argument("--format", choices=("csv", "json", "markdown"), required=True)
+    report_parser.add_argument("--output", required=True)
+    report_parser.set_defaults(handler=cmd_report)
+    packet_parser = subparsers.add_parser("analysis-packet", help="Publish a Markdown decision packet")
+    _add_report_filters(packet_parser)
+    packet_parser.add_argument("--output", required=True)
+    packet_parser.set_defaults(handler=cmd_analysis_packet)
     return parser
 
 
@@ -117,7 +182,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return int(args.handler(args))
-    except (DomainOpportunityContractError, DomainOpportunityStoreError) as exc:
+    except (DomainOpportunityContractError, DomainOpportunityStoreError, ReportingError) as exc:
         print(f"domain-opportunity: {exc}", file=sys.stderr)
         return 1
     except (OSError, sqlite3.Error):

--- a/.agents/scripts/domain_opportunity_reporting.py
+++ b/.agents/scripts/domain_opportunity_reporting.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Read-only, deterministic projections of domain-opportunity evidence."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from domain_opportunity_contract import SCHEMA_VERSION
+from domain_opportunity_store import DomainOpportunityStore
+
+REPORT_VERSION = "domain-opportunity-report-v1"
+CSV_COLUMNS = (
+    "rank", "domain", "provider", "provider_listing_id", "status", "auction_type",
+    "current_price_micros", "current_price_currency", "bid_count", "deadline",
+    "listing_observed_at", "listing_source", "listing_unit", "listing_freshness",
+    "policy_version", "score_micros", "score_source", "score_unit", "score_observed_at", "score_freshness", "eligible",
+    "score_components_json", "google_ads_status", "google_ads_metrics_json",
+    "google_ads_source", "google_ads_unit", "google_ads_observed_at",
+    "google_ads_locale_json", "google_ads_retrieval_month", "google_ads_freshness",
+    "trends_status", "trends_batch_id", "trends_query", "trends_geography",
+    "trends_timeframe", "trends_direction", "trends_min", "trends_max",
+    "trends_source", "trends_unit", "trends_observed_at", "trends_freshness",
+    "missing_flags", "risk_flags",
+)
+
+
+class ReportingError(ValueError):
+    """Raised when a report request or local output is unsafe."""
+
+
+@dataclass(frozen=True)
+class ReportOptions:
+    """Stable report filters without a wide public function signature."""
+
+    as_of: str | None = None
+    active_only: bool = False
+    eligible_only: bool = False
+    limit: int | None = None
+
+
+def _parse_time(value: str) -> datetime:
+    """Parse one UTC evidence timestamp."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ReportingError(f"invalid UTC timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise ReportingError(f"timestamp lacks timezone: {value}")
+    return parsed.astimezone(timezone.utc)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _freshness(observed_at: str | None, as_of: datetime, days: int) -> str:
+    if not observed_at:
+        return "missing"
+    age = (as_of - _parse_time(observed_at)).total_seconds()
+    return ("stale", "fresh", "future")[int(age <= days * 86400) + int(age < 0)]
+
+
+def _latest_score(store: DomainOpportunityStore, listing_id: int) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    score = store.connection.execute(
+        """SELECT score_id,model,score_micros,observed_at FROM candidate_scores
+           WHERE listing_id=? ORDER BY observed_at DESC,score_id DESC LIMIT 1""", (listing_id,)
+    ).fetchone()
+    if score is None:
+        return None, {}
+    components: dict[str, Any] = {}
+    for component in store.connection.execute(
+        """SELECT name,value_micros,weight_micros,evidence_json FROM score_components
+           WHERE score_id=? ORDER BY name""", (score["score_id"],)
+    ).fetchall():
+        evidence = json.loads(component["evidence_json"] or "null")
+        components[component["name"]] = {
+            "value_micros": component["value_micros"],
+            "weight_micros": component["weight_micros"],
+            "source": score["model"],
+            "unit": "micros",
+            "observed_at": score["observed_at"],
+            "evidence": evidence,
+        }
+    return dict(score), components
+
+
+def _latest_ads(store: DomainOpportunityStore, listing_id: int) -> dict[str, Any]:
+    row = store.connection.execute(
+        """SELECT source,value_text,unit,observed_at,source_run_id FROM keyword_metrics
+           WHERE listing_id=? AND source='google-ads'
+           ORDER BY observed_at DESC,metric_id DESC LIMIT 1""", (listing_id,)
+    ).fetchone()
+    data = dict(row or {})
+    try:
+        value = json.loads(data.get("value_text", '{"status":"unavailable"}'))
+    except (TypeError, json.JSONDecodeError):
+        value = {"status": "invalid"}
+    return {**data, "value": value}
+
+
+def _latest_trends(store: DomainOpportunityStore, listing_id: int) -> dict[str, Any]:
+    row = store.connection.execute(
+        """SELECT series_id,source,source_run_id,query,geography,timeframe,observed_at
+           FROM trend_series WHERE listing_id=?
+           ORDER BY observed_at DESC,series_id DESC LIMIT 1""", (listing_id,)
+    ).fetchone()
+    data = dict(row or {})
+    points = store.connection.execute(
+        "SELECT point_time,value FROM trend_points WHERE series_id=? ORDER BY point_time", (data.get("series_id"),)
+    ).fetchall()
+    values = [int(point["value"]) for point in points]
+    direction = "unavailable"
+    if len(values) >= 2:
+        direction = "up" if values[-1] > values[0] else ("down" if values[-1] < values[0] else "flat")
+    return {**data, "values": values, "direction": direction}
+
+
+def _flags(components: dict[str, Any]) -> tuple[list[str], list[str], bool | None]:
+    structural = components.get("structural_readability", {}).get("evidence") or {}
+    risk = components.get("risk_quality", {}).get("evidence") or {}
+    hard_flags = structural.get("hard_filter_flags", [])
+    risk_flags = risk.get("flags", [])
+    return sorted(set(hard_flags)), sorted(set(risk_flags)), structural.get("eligible")
+
+
+def _snapshot_as_of(store: DomainOpportunityStore, requested: str | None) -> tuple[str, datetime]:
+    if requested:
+        parsed = _parse_time(requested)
+        return parsed.isoformat().replace("+00:00", "Z"), parsed
+    row = store.connection.execute(
+        """SELECT MAX(observed_at) FROM (
+               SELECT observed_at FROM listing_observations UNION ALL
+               SELECT observed_at FROM keyword_metrics UNION ALL
+               SELECT observed_at FROM trend_series UNION ALL
+               SELECT observed_at FROM candidate_scores
+           )"""
+    ).fetchone()
+    value = row[0] or "1970-01-01T00:00:00Z"
+    return value, _parse_time(value)
+
+
+def _missing_flags(
+    score: dict[str, Any] | None, ads_status: str, trends_status: str, currency: str,
+) -> list[str]:
+    """Describe unavailable evidence without coercing unknown values to zero."""
+    flags = {
+        "score": score is None,
+        "trends_optional": trends_status == "unavailable_optional",
+        "price_currency": not currency,
+    }
+    if ads_status == "unavailable":
+        flags["google_ads"] = True
+    elif ads_status != "found":
+        flags[f"google_ads_{ads_status}"] = True
+    return sorted(name for name, present in flags.items() if present)
+
+
+def build_report(
+    store: DomainOpportunityStore, options: ReportOptions | None = None,
+) -> dict[str, Any]:
+    """Build one joined report inside a consistent SQLite read transaction."""
+    options = options or ReportOptions()
+    if options.limit is not None and options.limit < 1:
+        raise ReportingError("limit must be positive")
+    store.connection.execute("BEGIN")
+    try:
+        as_of_text, as_of_time = _snapshot_as_of(store, options.as_of)
+        listings = store.connection.execute(
+            """SELECT l.listing_id,l.provider,l.provider_listing_id,l.fqdn,o.status,o.auction_type,
+                      o.current_price_micros,o.current_price_currency,o.bid_count,o.end_time,
+                      o.observed_at,o.source_run_id
+               FROM listings l JOIN listing_observations o ON o.observation_id=l.current_observation_id
+               WHERE (?=0 OR o.status='active') ORDER BY l.provider,l.provider_listing_id""",
+            (int(options.active_only),),
+        ).fetchall()
+        candidates: list[dict[str, Any]] = []
+        for listing in listings:
+            score, components = _latest_score(store, int(listing["listing_id"]))
+            ads = _latest_ads(store, int(listing["listing_id"]))
+            trends = _latest_trends(store, int(listing["listing_id"]))
+            hard_flags, risk_flags, eligible = _flags(components)
+            if options.eligible_only and eligible is not True:
+                continue
+            score_value = score or {}
+            ads_value = ads["value"]
+            ads_status = ads_value.get("status", "unavailable")
+            trends_status = "measured_batch_relative" if trends.get("series_id") else "unavailable_optional"
+            trends_values = trends["values"]
+            candidate = {
+                "domain": listing["fqdn"], "provider": listing["provider"],
+                "provider_listing_id": listing["provider_listing_id"], "status": listing["status"],
+                "auction_type": listing["auction_type"], "current_price_micros": listing["current_price_micros"],
+                "current_price_currency": listing["current_price_currency"], "bid_count": listing["bid_count"],
+                "deadline": listing["end_time"], "listing_observed_at": listing["observed_at"],
+                "listing_source": listing["provider"], "listing_unit": "currency_micros",
+                "listing_freshness": _freshness(listing["observed_at"], as_of_time, 7),
+                "policy_version": score_value.get("model"),
+                "score_micros": score_value.get("score_micros"),
+                "score_source": score_value.get("model"),
+                "score_unit": {True: "micros"}.get(score is not None),
+                "score_observed_at": score_value.get("observed_at"),
+                "score_freshness": _freshness(score_value.get("observed_at"), as_of_time, 35),
+                "eligible": eligible, "score_components": components,
+                "google_ads": {
+                    "status": ads_status, "metrics": ads_value.get("metrics"),
+                    "source": ads_value.get("metric_source"),
+                    "unit": {"found": "provider_metric_bundle"}.get(ads_status),
+                    "observed_at": ads.get("observed_at"),
+                    "locale": {key: ads_value.get(key) for key in ("language", "geographies", "network", "account_currency") if key in ads_value},
+                    "retrieval_month": ads_value.get("retrieval_month"),
+                    "freshness": _freshness(ads.get("observed_at"), as_of_time, 35),
+                },
+                "trends": {
+                    "status": trends_status,
+                    "batch_id": trends.get("source_run_id"),
+                    "query": trends.get("query"), "geography": trends.get("geography"),
+                    "timeframe": trends.get("timeframe"), "direction": trends.get("direction"),
+                    "minimum": min(trends_values, default=None),
+                    "maximum": max(trends_values, default=None),
+                    "source": trends.get("source"),
+                    "unit": {"measured_batch_relative": "batch_relative_index_0_100"}.get(trends_status),
+                    "observed_at": trends.get("observed_at"),
+                    "freshness": _freshness(trends.get("observed_at"), as_of_time, 14),
+                },
+                "missing_flags": _missing_flags(
+                    score, ads_status, trends_status, listing["current_price_currency"],
+                ),
+                "risk_flags": sorted(set(hard_flags + risk_flags)),
+            }
+            candidates.append(candidate)
+        candidates.sort(key=lambda item: (
+            item["score_micros"] is None, -(item["score_micros"] or 0),
+            item["domain"], item["provider"], item["provider_listing_id"],
+        ))
+        if options.limit is not None:
+            candidates = candidates[:options.limit]
+        for rank, candidate in enumerate(candidates, 1):
+            candidate["rank"] = rank
+        return {
+            "report_version": REPORT_VERSION, "schema_version": SCHEMA_VERSION,
+            "as_of": as_of_text, "candidate_count": len(candidates), "candidates": candidates,
+        }
+    finally:
+        store.connection.rollback()
+
+
+def _csv_row(item: dict[str, Any]) -> dict[str, Any]:
+    ads, trends = item["google_ads"], item["trends"]
+    row = {key: item.get(key) for key in CSV_COLUMNS}
+    row.update({
+        "score_components_json": _json(item["score_components"]),
+        "google_ads_status": ads["status"], "google_ads_metrics_json": _json(ads["metrics"]),
+        "google_ads_source": ads["source"], "google_ads_unit": ads["unit"],
+        "google_ads_observed_at": ads["observed_at"], "google_ads_locale_json": _json(ads["locale"]),
+        "google_ads_retrieval_month": ads["retrieval_month"], "google_ads_freshness": ads["freshness"],
+        "trends_status": trends["status"], "trends_batch_id": trends["batch_id"],
+        "trends_query": trends["query"], "trends_geography": trends["geography"],
+        "trends_timeframe": trends["timeframe"], "trends_direction": trends["direction"],
+        "trends_min": trends["minimum"], "trends_max": trends["maximum"],
+        "trends_source": trends["source"], "trends_unit": trends["unit"],
+        "trends_observed_at": trends["observed_at"], "trends_freshness": trends["freshness"],
+        "missing_flags": ";".join(item["missing_flags"]), "risk_flags": ";".join(item["risk_flags"]),
+    })
+    return row
+
+
+def _render_csv(report: dict[str, Any]) -> str:
+    target = io.StringIO(newline="")
+    writer = csv.DictWriter(target, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(_csv_row(item) for item in report["candidates"])
+    return target.getvalue()
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Domain opportunity report", "", f"As of: `{report['as_of']}`  ",
+        "Policy evidence: persisted version per candidate  ", "Trends values are batch-relative, not absolute demand.", "",
+        "| Rank | Domain | Score | Policy | Price | Deadline | Missing | Risk |", "|---:|---|---:|---|---:|---|---|---|",
+    ]
+    for item in report["candidates"]:
+        score = {None: "unknown"}.get(item["score_micros"], str(item["score_micros"]))
+        price = f"{item['current_price_micros']} {item['current_price_currency']} micros"
+        lines.append(
+            f"| {item['rank']} | {item['domain']} | {score} | {item['policy_version'] or 'unknown'} | "
+            f"{price} | {item['deadline']} | {', '.join(item['missing_flags']) or 'none'} | "
+            f"{', '.join(item['risk_flags']) or 'none'} |"
+        )
+    lines.extend(["", "## Evidence packet", "", "```json", _json(report["candidates"]), "```", ""])
+    return "\n".join(lines)
+
+
+def render(report: dict[str, Any], output_format: str) -> str:
+    """Render stable CSV, JSON, or concise Markdown."""
+    renderers = {
+        "csv": _render_csv,
+        "json": lambda value: _json(value) + "\n",
+        "markdown": _render_markdown,
+    }
+    try:
+        renderer = renderers[output_format]
+    except KeyError as exc:
+        raise ReportingError("format must be csv, json, or markdown") from exc
+    return renderer(report)
+
+
+def publish(output: str, content: str) -> None:
+    """Publish atomically without replacing through a symlink."""
+    destination = Path(output).expanduser().absolute()
+    if destination.is_symlink():
+        raise ReportingError("output must not be a symbolic link")
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def pipeline_status(store: DomainOpportunityStore) -> dict[str, Any]:
+    """Expose explicit non-fatal readiness for each optional evidence stage."""
+    status = store.status()
+    counts = status["counts"]
+    status["stages"] = {
+        name: "ready" if counts[count_name] else missing
+        for name, count_name, missing in (
+            ("inventory", "listings", "missing"),
+            ("scoring", "candidate_scores", "missing_non_fatal"),
+            ("google_ads", "keyword_metrics", "missing_non_fatal"),
+            ("trends", "trend_series", "missing_optional"),
+        )
+    }
+    return status

--- a/.agents/scripts/tests/test-domain-opportunity-reporting.py
+++ b/.agents/scripts/tests/test-domain-opportunity-reporting.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""End-to-end contracts for deterministic local opportunity reports."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from domain_opportunity_contract import CandidateScore, KeywordMetric, TrendSeries  # noqa: E402
+from domain_opportunity_reporting import ReportOptions, build_report, render  # noqa: E402
+from domain_opportunity_store import DomainOpportunityStore  # noqa: E402
+
+HELPER = SCRIPTS / "domain-opportunity-helper.py"
+AS_OF = "2026-08-21T12:00:00Z"
+
+
+class ReportingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.database = self.root / "evidence.sqlite"
+        self._build_store()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def listing(identity: str, domain: str, price: int) -> dict[str, object]:
+        return {
+            "provider": "fixture", "provider_listing_id": identity, "fqdn": domain,
+            "sld": domain.removesuffix(".com"), "tld": "com", "status": "active",
+            "auction_type": "auction", "current_price_micros": price,
+            "current_price_currency": "USD", "bid_count": 1,
+            "start_time": "2026-08-20T00:00:00Z", "end_time": "2026-08-23T00:00:00Z",
+            "source_url": f"https://example.invalid/{identity}", "observed_at": "2026-08-21T00:00:00Z",
+            "source_run_id": "fixture-inventory", "payload_hash": identity * 64,
+            "raw_json": {"phrase_evidence": []},
+        }
+
+    def _build_store(self) -> None:
+        with DomainOpportunityStore(self.database, initialize=True) as store:
+            with store.transaction():
+                store.begin_source_run("fixture-inventory", "fixture", started_at="2026-08-21T00:00:00Z")
+                store.upsert_listing_observation(self.listing("a", "alpha.com", 2_000_000))
+                store.upsert_listing_observation(self.listing("b", "beta.com", 1_000_000))
+                store.complete_source_run("fixture-inventory", 2)
+                store.begin_source_run("fixture-score", "domain-opportunity-scoring", started_at="2026-08-21T01:00:00Z")
+                store.insert_candidate_score(CandidateScore(
+                    provider="fixture", provider_listing_id="b", source_run_id="fixture-score",
+                    model="exact-match-com-v1", score_micros=800_000, observed_at="2026-08-21T01:00:00Z",
+                    components={
+                        "demand": {"value_micros": 700_000, "weight_micros": 100_000,
+                                   "evidence": {"status": "measured", "source": "google-ads"}},
+                        "structural_readability": {"value_micros": 900_000, "weight_micros": 200_000,
+                                                   "evidence": {"status": "measured", "eligible": True,
+                                                                "hard_filter_flags": []}},
+                        "risk_quality": {"value_micros": 1_000_000, "weight_micros": 150_000,
+                                         "evidence": {"status": "measured", "flags": []}},
+                    },
+                ))
+                ads = {
+                    "status": "found", "metrics": {"average_monthly_searches": 700},
+                    "metric_source": "google_ads.keyword_plan_idea.generate_historical_metrics",
+                    "language": "languageConstants/1000", "geographies": ["geoTargetConstants/2840"],
+                    "network": "GOOGLE_SEARCH_AND_PARTNERS", "account_currency": "USD",
+                    "retrieval_month": "2026-08", "input_phrase": "beta",
+                }
+                store.insert_keyword_metric(KeywordMetric(
+                    provider="fixture", provider_listing_id="b", source_run_id="fixture-score",
+                    source="google-ads", metric_name="historical_keyword_metrics", value=json.dumps(ads),
+                    unit="json", observed_at="2026-08-21T02:00:00Z", payload_hash="c" * 64,
+                ))
+                store.insert_trend_series(TrendSeries(
+                    provider="fixture", provider_listing_id="b", source_run_id="fixture-score",
+                    source="google-trends-manual-export", query="beta", geography="US",
+                    timeframe="2026-01-01 2026-02-28", observed_at="2026-08-21T03:00:00Z",
+                    points=(("2026-01-01T00:00:00Z", 20), ("2026-02-01T00:00:00Z", 30)),
+                ))
+                store.complete_source_run("fixture-score", 3)
+
+    def test_deterministic_ranked_projections_preserve_unknowns(self) -> None:
+        original_socket = socket.socket
+        socket.socket = lambda *_args, **_kwargs: self.fail("network access attempted")  # type: ignore[assignment]
+        try:
+            with DomainOpportunityStore(self.database) as store:
+                first = build_report(store, ReportOptions(as_of=AS_OF))
+            with DomainOpportunityStore(self.database) as store:
+                second = build_report(store, ReportOptions(as_of=AS_OF))
+        finally:
+            socket.socket = original_socket
+        self.assertEqual(first, second)
+        self.assertEqual([item["domain"] for item in first["candidates"]], ["beta.com", "alpha.com"])
+        self.assertIsNone(first["candidates"][1]["score_micros"])
+        self.assertIn("score", first["candidates"][1]["missing_flags"])
+        self.assertEqual(first["candidates"][0]["trends"]["direction"], "up")
+        self.assertEqual(first["candidates"][0]["google_ads"]["metrics"]["average_monthly_searches"], 700)
+        self.assertEqual(first["candidates"][0]["score_components"]["demand"]["unit"], "micros")
+        self.assertEqual(first["candidates"][0]["score_freshness"], "fresh")
+        json_output = render(first, "json")
+        markdown_output = render(first, "markdown")
+        csv_rows = list(csv.DictReader(io.StringIO(render(first, "csv"))))
+        self.assertEqual(json.loads(json_output)["candidates"][0]["domain"], "beta.com")
+        self.assertIn('"average_monthly_searches":700', markdown_output)
+        self.assertEqual(csv_rows[1]["score_micros"], "")
+
+    def test_cli_atomically_exports_all_formats(self) -> None:
+        environment = os.environ.copy()
+        guard = self.root / "guard"
+        guard.mkdir()
+        (guard / "sitecustomize.py").write_text(
+            "import socket\ndef denied(*args, **kwargs): raise AssertionError('network access attempted')\nsocket.socket=denied\n",
+            encoding="utf-8",
+        )
+        environment["PYTHONPATH"] = str(guard)
+        for output_format in ("csv", "json", "markdown"):
+            output = self.root / f"report.{output_format}"
+            completed = subprocess.run(  # nosec B603 -- fixed local helper and fixture paths
+                [sys.executable, str(HELPER), "report", "--db", str(self.database), "--format", output_format,
+                 "--output", str(output), "--as-of", AS_OF],
+                text=True, capture_output=True, check=False, env=environment,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertTrue(output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/seo.md
+++ b/.agents/seo.md
@@ -56,7 +56,7 @@ subagents:
 
 **Subagents** (`seo/` and `services/analytics/`):
 
-- **Research**: `conversational-search-intent` (user jobs, query forms, provenance, trends) | `keyword-research` (SERP weakness, 17 types, KeywordScore 0-100) | `ranking-opportunities` (quick wins, striking distance, cannibalization) | `query-fanout-research` (thematic fan-out) | `keyword-mapper` (placement/density) | `domain-research`
+- **Research**: `conversational-search-intent` (user jobs, query forms, provenance, trends) | `keyword-research` (SERP weakness, 17 types, KeywordScore 0-100) | `ranking-opportunities` (quick wins, striking distance, cannibalization) | `query-fanout-research` (thematic fan-out) | `keyword-mapper` (placement/density) | `domain-research` | `domain-opportunities` (ranked local auction evidence)
 - **Data providers**: `google-search-console` (queries, performance, index) | `dataforseo` (SERP, keywords, backlinks, on-page REST API) | `serper` (Google Search API) | `ahrefs` (backlinks, DR, REST API v3) | `semrush` (domain analytics, competitor research)
 - **Analytics**: `google-analytics` (GA4 reporting) | `analytics-tracking` (GA4 setup, events, UTM, attribution)
 - **Technical**: `site-crawler` (links, meta, redirects) | `screaming-frog` (SEO Spider CLI) | `contentking` (real-time monitoring) | `pagespeed`
@@ -72,6 +72,8 @@ subagents:
 ## SEO Workflow
 
 **Keyword and intent research**: Frame ambiguous, conversational, market, trend, or log-derived seeds with `seo/conversational-search-intent.md`, then run `/keyword-research "seed"` | `/autocomplete-research "question"` | `/keyword-research-extended "top keywords"`. Domain/Competitor/Gap modes: `seo/keyword-research.md`. GSC query evidence: `seo/google-search-console.md`.
+
+**Domain opportunities**: For provider-authorized auction inventory, deterministic SQLite scoring, optional Google Ads/Trends evidence, and local CSV/JSON/Markdown reports, use `seo/domain-opportunities.md`. This is separate from backlink-expiry reclamation.
 
 **AI search (GEO/SRO)**: intent evidence → baseline → fanout → GEO → SRO → hallucination defense → agent discovery. Focus: deterministic retrieval signals (clarity, structure, consistency, discoverability). Scorecard: `seo/ai-search-readiness.md`.
 

--- a/.agents/seo/backlink-checker.md
+++ b/.agents/seo/backlink-checker.md
@@ -21,11 +21,11 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Monitor backlinks, detect lost/broken links, find expired referring domains for purchase
-- **Data Sources**: Ahrefs API, DataForSEO Backlinks API, WHOIS lookups
+- **Purpose**: Monitor backlinks, detect lost/broken links, and flag expired referring domains for manual review
+- **Data Sources**: Authorized Ahrefs/DataForSEO exports and registry/registrar expiry evidence
 - **Helpers**: `scripts/seo-export-ahrefs.sh`, `scripts/seo-export-dataforseo.sh` (backlink data export)
 
-**Workflow**: Fetch backlink profile -> Identify lost/broken links -> Check domain expiry status -> Rank by DA/DR/traffic value -> Output purchase candidates
+**Workflow**: Export backlink profile -> Identify lost/broken links -> Verify expiry evidence -> Rank reclamation leads. For current auction inventory and local opportunity reports, use `seo/domain-opportunities.md`.
 
 <!-- AI-CONTEXT-END -->
 
@@ -49,7 +49,9 @@ DataForSEO endpoints:
 - `/v3/backlinks/referring_domains/live` - Referring domains
 - `/v3/backlinks/bulk_new_lost_backlinks/live` - Bulk new/lost
 
-## Expired Domain Detection
+## Backlink-expiry detection
+
+This workflow starts from a site's historical referring domains. It does not claim current marketplace availability and does not bid or purchase. Current official auction inventory is a separate evidence stream handled by `seo/domain-opportunities.md`.
 
 ### WHOIS Lookup
 
@@ -64,20 +66,7 @@ seo-helper.sh backlinks example.com --referring-domains-only | while read -r dom
 done
 ```
 
-### Domain Availability Tools
-
-| Tool | Type | Notes |
-|------|------|-------|
-| `whois` CLI | Free | Rate-limited, varies by TLD |
-| expired-domains.co | Web | Aggregates expired domain lists |
-| expireddomains.net | Web | Filters by DA, backlinks, age |
-| GoDaddy Auctions API | API | Auction/aftermarket domains |
-| Namecheap API | API | Registration availability check |
-
-### GitHub Tools for Expired Domain Discovery
-
-- [peterprototypes/expired-domains](https://github.com/peterprototypes/expired-domains) - Rust CLI for checking domain expiry
-- [Jeongseup/expired-domain-finder](https://github.com/Jeongseup/expired-domain-finder) - Python bulk checker
+WHOIS/RDAP output varies by registry and can be stale or rate-limited. Preserve source and observation time, treat ambiguity as unknown, and verify availability through an operator-authorized registrar path before any decision.
 
 ## Reclamation Workflow
 
@@ -89,11 +78,12 @@ done
    - Number of backlinks the domain had
    - Traffic estimate (Ahrefs/SimilarWeb)
    - Registration cost vs. link value
-5. **Output ranked list** of purchase candidates
+5. **Output ranked list** of manual reclamation leads with source, time, and missing/risk flags
 
 ## Related
 
 - `seo/ahrefs.md` - Ahrefs API (primary data source)
 - `seo/dataforseo.md` - DataForSEO API (alternative data source)
 - `seo/domain-research.md` - DNS reconnaissance on candidates
+- `seo/domain-opportunities.md` - current official auction inventory and deterministic local reports
 - `seo/link-building.md` - Link-building strategies

--- a/.agents/seo/domain-opportunities.md
+++ b/.agents/seo/domain-opportunities.md
@@ -1,0 +1,87 @@
+---
+description: Ranked local domain-auction research with explicit evidence provenance
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Local Domain Opportunities
+
+Use this workflow to rank auction inventory locally without a web interface. SQLite is canonical; CSV, JSON, and Markdown are deterministic read-only projections. It does not bid, purchase, scrape marketplaces, or provide legal/trademark clearance.
+
+## Data and permission model
+
+| Source | Role | Permission/credential | Missing behavior |
+|---|---|---|---|
+| Namecheap Market | Current official auction listings | Read-only API credentials | Import step is skipped; existing evidence remains usable |
+| Provider bulk files | GoDaddy/SnapNames inventory | Operator-authorized local download | File is inspected and archived locally; never commit it |
+| Google Ads | Primary quantitative demand metrics | Read-only Ads account access; `GOOGLE_ADS_ACCESS_TOKEN` and `GOOGLE_ADS_DEVELOPER_TOKEN` via `aidevops secret set` | `google_ads` missing flag; no zero is invented |
+| Google Trends | Optional relative direction/seasonality | Visible operator browser session | `trends_optional` flag; scoring remains valid without it |
+| Provider/history evidence | Appraisal, comparable, backlink/history observations | Provider-specific permission | Corresponding score component stays unknown with zero weight |
+
+Trends values are relative only within their exported comparison batch. Google Ads historical metrics retain language, geography, network, account currency, retrieval month, source, and observation time.
+
+## Setup and local paths
+
+Copy `configs/domain-opportunities-config.json.txt` to the ignored working file `configs/domain-opportunities-config.json`, replace placeholders, and keep all runtime data under:
+
+```text
+~/.aidevops/.agent-workspace/work/domain-opportunities/
+  evidence.sqlite
+  imports/
+  exports/
+  trends/
+```
+
+Templates contain aliases and resource placeholders only. Never commit the working config, SQLite store, provider files, exports, account/customer IDs, tokens, bids, purchases, or browser download paths.
+
+## Operating sequence
+
+Choose the appropriate official inventory importer; the commands below show the stable local sequence after an inventory file has been obtained with permission.
+
+```bash
+DB="$HOME/.aidevops/.agent-workspace/work/domain-opportunities/evidence.sqlite"
+OUT="$HOME/.aidevops/.agent-workspace/work/domain-opportunities/exports"
+
+python3 .agents/scripts/domain-opportunity-helper.py init --db "$DB"
+python3 .agents/scripts/domain-opportunity-files.py import --db "$DB" --provider godaddy --input "$HOME/Downloads/authorized-inventory.csv"
+python3 .agents/scripts/domain-opportunity-google-ads.py plan --db "$DB" --currency USD --language languageConstants/REPLACE_ME --geography geoTargetConstants/REPLACE_ME
+python3 .agents/scripts/domain-opportunity-google-ads.py sync --db "$DB" --currency USD --language languageConstants/REPLACE_ME --geography geoTargetConstants/REPLACE_ME --customer-id LOCAL_ACCOUNT_ID
+python3 .agents/scripts/domain-opportunity-score.py score --db "$DB"
+python3 .agents/scripts/domain-opportunity-helper.py pipeline-status --db "$DB" --json
+python3 .agents/scripts/domain-opportunity-helper.py report --db "$DB" --format csv --output "$OUT/opportunities.csv" --as-of 2026-08-21T12:00:00Z --active-only
+python3 .agents/scripts/domain-opportunity-helper.py report --db "$DB" --format json --output "$OUT/opportunities.json" --as-of 2026-08-21T12:00:00Z --active-only
+python3 .agents/scripts/domain-opportunity-helper.py analysis-packet --db "$DB" --output "$OUT/opportunities.md" --as-of 2026-08-21T12:00:00Z --active-only --limit 25
+```
+
+Use the actual current UTC `--as-of` value for an operating run. Holding the SQLite snapshot, policy, filters, and `--as-of` constant produces the same order and evidence. Without `--as-of`, the newest stored observation is used so offline reruns remain deterministic.
+
+### Optional Trends handoff
+
+```bash
+python3 .agents/scripts/domain-opportunity-trends.py queue --db "$DB" --output "$HOME/.aidevops/.agent-workspace/work/domain-opportunities/trends"
+python3 .agents/scripts/domain-opportunity-trends.py inspect --manifest MANIFEST.json --input multiTimeline.csv
+python3 .agents/scripts/domain-opportunity-trends.py import --manifest MANIFEST.json --input multiTimeline.csv --db "$DB"
+```
+
+Follow each generated manifest in a visible browser, use the official Trends site, retain the share URL/export time, and inspect before import. No automated Trends browser scraping is provided.
+
+## Reading a report
+
+- `score_micros` and every component come from the persisted versioned scoring policy; reports never create a second composite.
+- Current price uses currency micros and retains provider and observation time. Deadline is the provider auction deadline.
+- `fresh`, `stale`, `future`, and `missing` are explicit evidence states. The report defaults are 7 days for inventory, 35 for Ads, and 14 for Trends.
+- `missing_flags` identifies absent/invalid optional evidence. Unknown values remain null/blank and are never presented as measured zero.
+- `risk_flags` combines scoring hard-filter and review flags. A clear flag is not legal clearance.
+- Markdown embeds the complete JSON evidence packet after its concise ranking table. Any business model, audience, monetization, or positioning ideas derived from it are generated hypotheses—not measured evidence—and must cite candidate fields and list assumptions/risks.
+
+## Recovery and scheduling
+
+- Run `pipeline-status --json` first. Missing Ads credentials/providers/Trends are non-fatal readiness states.
+- If a provider sync fails, keep the prior completed evidence and retry only that adapter. Reporting never migrates or rewrites the database.
+- An unsupported future SQLite schema fails with an actionable compatibility error. Upgrade the runtime; do not edit the store manually.
+- Atomic publication preserves the last complete export if rendering or replacement fails.
+- For scheduled research, run official inventory sync/enrichment/scoring first, then report with one recorded UTC `--as-of`. Keep schedules local and respect provider quotas and terms.
+
+Before acting on a candidate, review evidence freshness, source permissions, score components, phrase ambiguity, trademark/legal risk, historical/backlink quality, current price/deadline, and all missing flags. Human authorization is always required for bids or purchases.

--- a/configs/domain-opportunities-config.json.txt
+++ b/configs/domain-opportunities-config.json.txt
@@ -1,0 +1,15 @@
+{
+  "database": "~/.aidevops/.agent-workspace/work/domain-opportunities/evidence.sqlite",
+  "exports_directory": "~/.aidevops/.agent-workspace/work/domain-opportunities/exports",
+  "locale": {
+    "language_resource": "languageConstants/REPLACE_ME",
+    "geography_resources": ["geoTargetConstants/REPLACE_ME"],
+    "currency": "USD"
+  },
+  "account_aliases": {"google_ads": "REPLACE_WITH_LOCAL_ALIAS"},
+  "freshness_days": {"inventory": 7, "google_ads": 35, "trends": 14},
+  "filters": {"active_only": true, "eligible_only": true, "limit": 100},
+  "scoring_policy": {"version": "exact-match-com-v1"},
+  "sources": {"google_ads": "optional_read_only", "google_trends": "optional_browser_assisted"},
+  "report_fields": ["price", "deadline", "score_components", "provenance", "freshness", "missing_flags", "risk_flags"]
+}


### PR DESCRIPTION
## Summary

Add deterministic read-only CSV, JSON, and Markdown domain-opportunity projections, pipeline readiness commands, placeholder configuration, SEO operating guidance, and provenance-preserving end-to-end coverage without new Qlty smells.

## Files Changed

.agents/scripts/domain-opportunity-helper.py, .agents/scripts/domain_opportunity_reporting.py, .agents/scripts/tests/test-domain-opportunity-reporting.py, .agents/seo.md, .agents/seo/backlink-checker.md, .agents/seo/domain-opportunities.md, configs/domain-opportunities-config.json.txt

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — All seven domain-opportunity test suites; production pipeline-status and CSV report smoke; qlty new-file gate (0 smells); qlty regression gate (base 46, head 46); changed lint. Absolute Qlty threshold remains pre-existing at base/head 50 versus configured 49.

Resolves #30499


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.282 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 40m and 184,927 tokens on this as a headless worker.