### PR TITLE
GH#30533: fix: explain cross-runner CI repair routing

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -26,6 +26,7 @@
 #   PULSE_DIAGNOSE_THREAD_RESPONSE_STATE_DIR — override ancillary worker state
 #   PULSE_DIAGNOSE_DISPATCH_LEDGER_FILE — override dispatch ledger path
 #   PULSE_DIAGNOSE_WORKTREE_REGISTRY_DB — override worktree registry database
+#   PULSE_DIAGNOSE_CI_REPAIR_STATE_DIR — override CI PR repair lease directory
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
@@ -58,10 +59,15 @@ readonly DEFAULT_SYSTEMD_TIMER_FILE="${HOME}/.config/systemd/user/aidevops-super
 readonly DEFAULT_THREAD_RESPONSE_STATE_DIR="${HOME}/.aidevops/.agent-workspace/pr-review-thread-response"
 readonly DEFAULT_DISPATCH_LEDGER_FILE="${HOME}/.aidevops/.agent-workspace/tmp/dispatch-ledger.jsonl"
 readonly DEFAULT_WORKTREE_REGISTRY_DB="${HOME}/.aidevops/.agent-workspace/worktree-registry.db"
+readonly DEFAULT_CI_REPAIR_STATE_DIR="${HOME}/.aidevops/.agent-workspace/ci-pr-repair"
 readonly _UNKNOWN="unknown"
 readonly _UNCLASSIFIED="unclassified"
 readonly _PR_HEAD_REF_JSON_PATH=".headRefName"
 readonly _BOOL_TRUE="true"
+readonly _JSON_NULL="null"
+readonly _JSON_ARRAY_TYPE="array"
+readonly _CI_REPAIR_RETRY_ACTION="retry_repair"
+readonly _CI_REPAIR_NO_ACTION="not_applicable"
 # =============================================================================
 # Rule Inventory (Phase A)
 #
@@ -446,7 +452,7 @@ _fetch_pr_metadata() {
 
 	local pr_json="" gh_rc=0
 	pr_json=$(_gh_with_timeout read gh pr view "$pr_number" --repo "$repo_slug" \
-		--json number,title,state,author,mergedAt,closedAt,createdAt,labels,reviewDecision,mergeStateStatus,headRefName,baseRefName,isDraft 2>/dev/null) || gh_rc=$?
+		--json number,title,state,author,mergedAt,closedAt,createdAt,labels,reviewDecision,mergeStateStatus,headRefName,headRefOid,baseRefName,isDraft 2>/dev/null) || gh_rc=$?
 	if [[ "$gh_rc" -ne 0 ]]; then
 		if [[ "$gh_rc" -eq 124 ]]; then
 			print_warning "gh pr view timed out after ${AIDEVOPS_GH_READ_TIMEOUT:-15}s for PR #${pr_number} in ${repo_slug}"
@@ -517,6 +523,8 @@ _CMD_PR_EVENTS=()
 _CMD_PR_EVENT_COUNT=0
 _CMD_PR_ANCILLARY_EMPTY_JSON='{"present":false,"kind":"thread-response"}'
 _CMD_PR_ANCILLARY_JSON="$_CMD_PR_ANCILLARY_EMPTY_JSON"
+_CMD_PR_CI_REPAIR_EMPTY_JSON='{"present":false,"remote_route":null,"local_state":null,"next_action":"none"}'
+_CMD_PR_CI_REPAIR_JSON="$_CMD_PR_CI_REPAIR_EMPTY_JSON"
 
 # Parse cmd_pr CLI arguments into _CMD_PR_* module globals.
 # Returns 1 on validation error.
@@ -527,6 +535,7 @@ _cmd_pr_parse_args() {
 	_CMD_PR_JSON_OUTPUT=0
 	_CMD_PR_LOGFILE_OVERRIDE=""
 	_CMD_PR_ANCILLARY_JSON="$_CMD_PR_ANCILLARY_EMPTY_JSON"
+	_CMD_PR_CI_REPAIR_JSON="$_CMD_PR_CI_REPAIR_EMPTY_JSON"
 
 	while [[ $# -gt 0 ]]; do
 		case "${1}" in
@@ -783,6 +792,108 @@ _render_pr_ancillary_text() {
 	return 0
 }
 
+_diagnose_pr_comments() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	if [[ "${PULSE_DIAGNOSE_GH_OFFLINE:-0}" == "1" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" --paginate --slurp 2>/dev/null \
+		| jq -c --arg array_type "$_JSON_ARRAY_TYPE" \
+			'if type == $array_type and ((.[0]? | type) == $array_type) then add else . end // []' \
+			2>/dev/null || printf '[]\n'
+	return 0
+}
+
+_diagnose_latest_ci_repair_state() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local state_dir="${PULSE_DIAGNOSE_CI_REPAIR_STATE_DIR:-$DEFAULT_CI_REPAIR_STATE_DIR}"
+	local state_file=""
+	local states='[]'
+
+	[[ -d "$state_dir" ]] || {
+		printf '%s\n' "$_JSON_NULL"
+		return 0
+	}
+	for state_file in "$state_dir"/*/state.json "$state_dir"/*/state-attempt-*.json; do
+		[[ -f "$state_file" ]] || continue
+		states=$(jq -c --arg repo "$repo_slug" --argjson pr "$pr_number" --argjson states "$states" \
+			'if .repo == $repo and .pr == $pr then $states + [.] else $states end' "$state_file" 2>/dev/null) || true
+	done
+	printf '%s' "$states" | jq -c 'sort_by(.terminal_at // .updated_at // 0) | last // null' 2>/dev/null || printf '%s\n' "$_JSON_NULL"
+	return 0
+}
+
+_cmd_pr_collect_ci_repair() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local expected_head="$3"
+	local comments_json='[]' route_json="$_JSON_NULL" local_state="$_JSON_NULL"
+	local linked_issue="" issue_json='{}' issue_body="" route_marker="" next_action="$_CI_REPAIR_NO_ACTION"
+	local issue_state="" issue_labels="" route_complete=false
+
+	comments_json=$(_diagnose_pr_comments "$repo_slug" "$pr_number")
+	# #aidevops:trust-boundary — remote route evidence is accepted only from a
+	# trusted collaborator and remains exact-head bound.
+	route_json=$(printf '%s' "$comments_json" | jq -c --arg pr "$pr_number" --arg head "$expected_head" '
+		[.[] | select((.author_association // "") as $a | ["OWNER","MEMBER","COLLABORATOR"] | index($a))
+		 | (.body // "") as $body
+		 | select($body | test("feedback-route:start:(ci|review|conflict):PR" + $pr + ":SHA" + $head))
+		 | {kind: ($body | capture("feedback-route:start:(?<kind>ci|review|conflict):").kind),
+		    head: $head, author: (.user.login // "unknown"), body: $body}] | last // null' 2>/dev/null) || route_json="$_JSON_NULL"
+	if [[ "$route_json" != "$_JSON_NULL" ]]; then
+		issue_body=$(printf '%s' "$route_json" | jq -r '.body // ""' 2>/dev/null || true)
+		linked_issue=$(printf '%s' "$issue_body" | sed -n 's/.*[Ii]ssue #\([0-9][0-9]*\).*/\1/p' | sed -n '1p')
+		route_marker=$(printf '%s' "$issue_body" | sed -n 's/.*\(<!-- feedback-route:start:[^>]* -->\).*/\1/p' | sed -n '1p')
+		if [[ "$linked_issue" =~ ^[0-9]+$ ]]; then
+			issue_json=$(gh api "repos/${repo_slug}/issues/${linked_issue}" 2>/dev/null || printf '{}')
+			issue_body=$(printf '%s' "$issue_json" | jq -r '.body // ""' 2>/dev/null || true)
+			issue_state=$(printf '%s' "$issue_json" | jq -r '.state // "unknown"')
+			issue_labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(",")')
+			if [[ -n "$route_marker" ]] && printf '%s' "$issue_body" | grep -qF "${route_marker/start:/complete:}"; then
+				route_complete=true
+			fi
+			route_json=$(printf '%s' "$route_json" | jq -c --argjson issue "$linked_issue" \
+				--arg state "$issue_state" --arg labels "$issue_labels" --argjson complete "$route_complete" \
+				'del(.body) + {linked_issue:$issue,issue_state:$state,issue_labels:$labels,complete:$complete}')
+		else
+			route_json=$(printf '%s' "$route_json" | jq -c 'del(.body) + {linked_issue:null,issue_state:"unknown",issue_labels:"",complete:false}')
+		fi
+	fi
+	local_state=$(_diagnose_latest_ci_repair_state "$repo_slug" "$pr_number")
+	if [[ "$local_state" != "$_JSON_NULL" ]]; then
+		next_action=$(printf '%s' "$local_state" | jq -r --arg retry "$_CI_REPAIR_RETRY_ACTION" '
+			if ((.failure_reason // "") | test("rate_limit|quota")) then
+				if (.quota_reset_at // "") != "" then "retry_after_quota_reset:" + .quota_reset_at else "retry_after_quota_reset:unknown" end
+			elif (.next_action // "") != "" then .next_action
+			elif (.status // "") == "dispatched" then "reconcile_worker_terminal_outcome"
+			else $retry end' 2>/dev/null || printf '%s' "$_CI_REPAIR_RETRY_ACTION")
+	elif [[ "$route_json" != "$_JSON_NULL" ]]; then
+		next_action="reconcile_remote_route_and_linked_issue"
+	fi
+	jq -cn --argjson remote "$route_json" --argjson local "$local_state" --arg next "$next_action" \
+		'{present:($remote != null or $local != null),remote_route:$remote,local_state:$local,next_action:$next}'
+	return 0
+}
+
+_render_pr_ci_repair_text() {
+	local repair_json="$1"
+	[[ "$(printf '%s' "$repair_json" | jq -r '.present // false')" == "true" ]] || return 0
+	printf 'CI repair / feedback routing:\n'
+	printf '%s' "$repair_json" | jq -r '
+		if .remote_route != null then
+			"  remote route: kind=\(.remote_route.kind) head=\(.remote_route.head) author=\(.remote_route.author) complete=\(.remote_route.complete)\n  linked issue: #\(.remote_route.linked_issue // "unknown") state=\(.remote_route.issue_state) labels=\(.remote_route.issue_labels)"
+		else "  remote route: none" end,
+		if .local_state != null then
+			"  local repair: status=\(.local_state.status // "unknown") attempt=\(.local_state.attempt // "unknown") terminal=\(.local_state.terminal_result // "unknown") reason=\(.local_state.failure_reason // "") quota_reset=\(.local_state.quota_reset_at // "")"
+		else "  local repair: unavailable (remote evidence remains authoritative)" end,
+		"  next action: \(.next_action)"'
+	printf '\n\n'
+	return 0
+}
+
 # Classify log lines into the _CMD_PR_EVENTS array and set _CMD_PR_EVENT_COUNT.
 # Args: $1=log_lines  $2=verbose (0|1)
 _cmd_pr_build_events() {
@@ -908,7 +1019,7 @@ cmd_pr() {
 	local pr_json
 	pr_json=$(_fetch_pr_metadata "$_CMD_PR_NUMBER" "$_CMD_PR_REPO_SLUG")
 
-	local pr_author="" pr_state="" pr_merged_at="" pr_closed_at="" pr_created_at="" pr_title="" pr_review_decision="" pr_mss="" pr_head_ref=""
+	local pr_author="" pr_state="" pr_merged_at="" pr_closed_at="" pr_created_at="" pr_title="" pr_review_decision="" pr_mss="" pr_head_ref="" pr_head_oid=""
 	pr_author=$(_jq_field "$pr_json" ".author.login" "$_UNKNOWN")
 	pr_state=$(_jq_field "$pr_json" ".state" "$_UNKNOWN")
 	pr_merged_at=$(_jq_field "$pr_json" ".mergedAt" "")
@@ -918,6 +1029,7 @@ cmd_pr() {
 	pr_review_decision=$(_jq_field "$pr_json" ".reviewDecision" "")
 	pr_mss=$(_jq_field "$pr_json" ".mergeStateStatus" "")
 	pr_head_ref=$(_jq_field "$pr_json" "$_PR_HEAD_REF_JSON_PATH" "")
+	pr_head_oid=$(_jq_field "$pr_json" ".headRefOid" "")
 
 	local merged_flag="no"
 	[[ -n "$pr_merged_at" ]] && merged_flag="yes"
@@ -925,6 +1037,8 @@ cmd_pr() {
 	_cmd_pr_build_events "$log_lines" "$_CMD_PR_VERBOSE"
 	_CMD_PR_ANCILLARY_JSON=$(_cmd_pr_collect_ancillary "$_CMD_PR_REPO_SLUG" "$_CMD_PR_NUMBER" "$pr_head_ref") || \
 		_CMD_PR_ANCILLARY_JSON="$_CMD_PR_ANCILLARY_EMPTY_JSON"
+	_CMD_PR_CI_REPAIR_JSON=$(_cmd_pr_collect_ci_repair "$_CMD_PR_REPO_SLUG" "$_CMD_PR_NUMBER" "$pr_head_oid") || \
+		_CMD_PR_CI_REPAIR_JSON="$_CMD_PR_CI_REPAIR_EMPTY_JSON"
 
 	if [[ "$_CMD_PR_JSON_OUTPUT" -eq 1 ]]; then
 		_render_json "$_CMD_PR_NUMBER" "$_CMD_PR_REPO_SLUG" "$pr_author" "$pr_state" "$merged_flag" \
@@ -939,6 +1053,7 @@ cmd_pr() {
 		"$pr_review_decision" "$pr_mss" "$_CMD_PR_EVENT_COUNT" \
 		"${_CMD_PR_EVENTS[@]+"${_CMD_PR_EVENTS[@]}"}"
 	_render_pr_ancillary_text "$_CMD_PR_ANCILLARY_JSON"
+	_render_pr_ci_repair_text "$_CMD_PR_CI_REPAIR_JSON"
 	return 0
 }
 
@@ -997,7 +1112,8 @@ _render_json() {
 	done
 
 	printf '\n  ],\n'
-	printf '  "ancillary": %s\n' "$_CMD_PR_ANCILLARY_JSON"
+	printf '  "ancillary": %s,\n' "$_CMD_PR_ANCILLARY_JSON"
+	printf '  "ci_repair": %s\n' "$_CMD_PR_CI_REPAIR_JSON"
 	printf '}\n'
 	return 0
 }
@@ -2265,6 +2381,7 @@ ENVIRONMENT:
   PULSE_DIAGNOSE_GH_API_LOG     Override gh-api-calls.log path
   PULSE_DIAGNOSE_BLOCKER_LOG    Override worker-progress-blockers.jsonl path
   PULSE_DIAGNOSE_SYSTEMD_TIMER_FILE Override systemd timer unit path
+  PULSE_DIAGNOSE_CI_REPAIR_STATE_DIR Override CI PR repair lease directory
 
 EXAMPLES:
   pulse-diagnose-helper.sh pr 20329 --repo marcusquinn/aidevops

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -13,6 +13,8 @@ PULSE_FEEDBACK_ROUTE_CLOSED_STATE="CLOSED"
 PULSE_FEEDBACK_ROUTE_HOLD_LABEL="hold-for-review"
 PULSE_FEEDBACK_ROUTE_NMR_LABEL="needs-maintainer-review"
 PULSE_FEEDBACK_ROUTE_OPEN_STATE="OPEN"
+PULSE_FEEDBACK_ROUTE_HOLD_MARKER="feedback-route:automation-hold"
+PULSE_FEEDBACK_ROUTE_JSON_ARRAY_TYPE="array"
 
 _feedback_route_gh_write() {
 	if declare -F _gh_with_timeout >/dev/null 2>&1; then
@@ -101,7 +103,7 @@ _feedback_route_release_comments() {
 	# win release-marker convergence; copied markers from untrusted users do not.
 	# shellcheck disable=SC2016 # $marker is a jq variable supplied below.
 	local filter='[
-		(if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]?
+		(if type == $array_type and ((.[0]? | type) == $array_type) then .[] else . end)[]?
 		| select((.author_association // "") as $association
 			| ["OWNER", "MEMBER", "COLLABORATOR"] | index($association))
 		| select((.body // "") | startswith("CLAIM_RELEASED reason=feedback_route_") and contains($marker))
@@ -113,7 +115,8 @@ _feedback_route_release_comments() {
 	else
 		comments_json=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
 	fi
-	printf '%s' "$comments_json" | jq -c --arg marker "$marker" "$filter" 2>/dev/null
+	printf '%s' "$comments_json" | jq -c --arg marker "$marker" \
+		--arg array_type "$PULSE_FEEDBACK_ROUTE_JSON_ARRAY_TYPE" "$filter" 2>/dev/null
 	return $?
 }
 
@@ -170,6 +173,52 @@ ${marker}"
 	[[ "$comment_status" -eq 0 ]] || return "$comment_status"
 	_feedback_route_reconcile_release_comments "$linked_issue" "$repo_slug" "$marker" || true
 	return 0
+}
+
+_feedback_route_kind_from_reason() {
+	local reason="$1"
+	case "$reason" in
+	*review*) printf 'review' ;;
+	*conflict*) printf 'conflict' ;;
+	*ci* | *CI*) printf 'ci' ;;
+	*) printf '%s' "${_PULSE_FEEDBACK_ROUTE_ACTIVE_KIND:-unknown}" ;;
+	esac
+	return 0
+}
+
+_feedback_route_system_hold_marker() {
+	local kind="$1"
+	local pr_number="$2"
+	local expected_head="$3"
+	printf '<!-- %s:%s:PR%s:SHA%s -->' "$PULSE_FEEDBACK_ROUTE_HOLD_MARKER" "$kind" "$pr_number" "$expected_head"
+	return 0
+}
+
+_feedback_route_system_hold_exists() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local kind="$3"
+	local pr_number="$4"
+	local expected_head="$5"
+	local marker=""
+	local endpoint="repos/${repo_slug}/issues/${linked_issue}/comments?per_page=100"
+	local comments_json=""
+
+	marker=$(_feedback_route_system_hold_marker "$kind" "$pr_number" "$expected_head")
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		comments_json=$(_gh_with_timeout read gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	else
+		comments_json=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	fi
+	# #aidevops:trust-boundary — only a trusted exact-head automation marker
+	# authorizes clearing a hold; a human or copied marker never does.
+	printf '%s' "$comments_json" | jq -e --arg marker "$marker" \
+		--arg array_type "$PULSE_FEEDBACK_ROUTE_JSON_ARRAY_TYPE" '
+		any((if type == $array_type and ((.[0]? | type) == $array_type) then .[] else . end)[]?;
+			((.author_association // "") as $a | ["OWNER","MEMBER","COLLABORATOR"] | index($a))
+			and ((.body // "") | startswith("PULSE_ROUTE_HOLD ") and contains("automation=pulse") and contains($marker)))' \
+		>/dev/null 2>&1
+	return $?
 }
 
 _feedback_route_marker() {
@@ -307,6 +356,15 @@ _feedback_route_hold_for_maintainer() {
 	local reason="$4"
 	local issue_hold_rc=0
 	local pr_hold_rc=0
+	local issue_snapshot="" issue_labels="" issue_assignees="" pr_snapshot="" pr_state="" expected_head="" pr_labels=""
+	local kind="" marker="" safe_reason="" hold_was_present=0 comment_body=""
+
+	issue_snapshot=$(_feedback_route_issue_snapshot "$linked_issue" "$repo_slug" 2>/dev/null) || issue_snapshot=""
+	IFS=$'\t' read -r issue_labels issue_assignees <<<"$issue_snapshot"
+	_feedback_route_labels_include "$issue_labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" && hold_was_present=1
+	pr_snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug" 2>/dev/null) || pr_snapshot=""
+	IFS=$'\t' read -r pr_state expected_head pr_labels <<<"$pr_snapshot"
+	kind=$(_feedback_route_kind_from_reason "$reason")
 
 	if declare -F set_issue_status >/dev/null 2>&1; then
 		set_issue_status "$linked_issue" "$repo_slug" "in-review" \
@@ -318,6 +376,18 @@ _feedback_route_hold_for_maintainer() {
 	fi
 	_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" \
 		--add-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || pr_hold_rc=$?
+	if [[ "$issue_hold_rc" -eq 0 && "$pr_hold_rc" -eq 0 && "$hold_was_present" -eq 0 \
+		&& "$expected_head" =~ ^[0-9A-Za-z]{7,64}$ ]]; then
+		marker=$(_feedback_route_system_hold_marker "$kind" "$pr_number" "$expected_head")
+		safe_reason=$(printf '%s' "$reason" | tr '\n\r\t' ' ' | tr -cd '[:alnum:] _.,:;()/#=-' | cut -c1-160)
+		comment_body="PULSE_ROUTE_HOLD kind=${kind} reason=${safe_reason:-unspecified} automation=pulse
+${marker}"
+		if declare -F gh_issue_comment >/dev/null 2>&1; then
+			gh_issue_comment "$linked_issue" --repo "$repo_slug" --body "$comment_body" >/dev/null 2>&1 || true
+		else
+			_feedback_route_gh_write issue comment "$linked_issue" --repo "$repo_slug" --body "$comment_body" >/dev/null 2>&1 || true
+		fi
+	fi
 	echo "[pulse-wrapper] feedback finalizer: preserving PR #${pr_number} and issue #${linked_issue} in ${repo_slug} for maintainer review — ${reason} (issue_hold_rc=${issue_hold_rc}, pr_hold_rc=${pr_hold_rc})" >>"$LOGFILE"
 	return "$PULSE_FEEDBACK_ROUTE_MAINTAINER_RC"
 }
@@ -336,7 +406,14 @@ _feedback_route_transition_and_verify() {
 	local repo_slug="$2"
 	local source_label="$3"
 	local clear_hold="${4:-0}"
+	local pr_number="${5:-}"
+	local kind="${6:-}"
+	local expected_head="${7:-}"
 
+	if [[ "$clear_hold" == "1" ]] && ! _feedback_route_system_hold_exists \
+		"$linked_issue" "$repo_slug" "$kind" "$pr_number" "$expected_head"; then
+		return 1
+	fi
 	_transition_issue_for_redispatch "$linked_issue" "$repo_slug" "$source_label" "$clear_hold" || return 1
 	_feedback_route_issue_is_ready "$linked_issue" "$repo_slug" "$source_label"
 	return $?
@@ -347,6 +424,8 @@ _feedback_route_apply_terminal_label() {
 	local repo_slug="$2"
 	local expected_head="$3"
 	local terminal_label="$4"
+	local linked_issue="${5:-}"
+	local kind="${6:-}"
 	local snapshot=""
 	local pr_state=""
 	local current_head=""
@@ -357,7 +436,10 @@ _feedback_route_apply_terminal_label() {
 	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
 	[[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" && "$current_head" == "$expected_head" ]] || return 1
 	_feedback_route_labels_include "$labels" "$terminal_label" || return 1
-	_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" --remove-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || true
+	if [[ -n "$linked_issue" ]] && _feedback_route_system_hold_exists \
+		"$linked_issue" "$repo_slug" "$kind" "$pr_number" "$expected_head"; then
+		_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" --remove-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || true
+	fi
 	return 0
 }
 
@@ -462,7 +544,7 @@ _feedback_route_finish_closed() {
 		return $?
 	fi
 
-	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then
+	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label" "$linked_issue" "$kind"; then
 		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
 			"completed ${kind} route could not apply and verify terminal label ${terminal_label}"
 		return $?
@@ -498,7 +580,8 @@ _feedback_route_resume_completed() {
 				"$linked_issue" "$expected_head" || return "$PULSE_FEEDBACK_ROUTE_DEFERRED_RC"
 			return 0
 		fi
-		if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
+		if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1 \
+			"$pr_number" "$kind" "$expected_head"; then
 			_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not restore redispatch issue state"
 			return $?
 		fi
@@ -506,7 +589,8 @@ _feedback_route_resume_completed() {
 			"$linked_issue" "$expected_head" || return "$PULSE_FEEDBACK_ROUTE_DEFERRED_RC"
 		return 0
 	fi
-	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
+	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1 \
+		"$pr_number" "$kind" "$expected_head"; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not re-verify redispatch issue state"
 		return $?
 	fi
@@ -516,7 +600,7 @@ _feedback_route_resume_completed() {
 			"completed ${kind} route could not retire the prior dispatch claim"
 		return $?
 	fi
-	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then
+	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label" "$linked_issue" "$kind"; then
 		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
 			"completed ${kind} route could not recover terminal label ${terminal_label}"
 		return $?
@@ -662,6 +746,7 @@ _finalize_feedback_route() {
 	local labels=""
 	local issue_body=""
 	local evidence_gate_rc=0
+	_PULSE_FEEDBACK_ROUTE_ACTIVE_KIND="$kind"
 
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "dry-run forbids ${kind} finalization writes"

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -469,7 +469,7 @@ _ci_actionable_failed_checks_markdown() {
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	[[ "$count" -gt 0 ]] || return 0
 
-	local idx=0 name="" conclusion="" link=""
+	local idx=0 name="" conclusion="" link="" context=""
 	while [[ "$idx" -lt "$count" ]]; do
 		name=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].name // empty' 2>/dev/null) || name=""
 		conclusion=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].conclusion // empty' 2>/dev/null) || conclusion=""
@@ -482,7 +482,13 @@ _ci_actionable_failed_checks_markdown() {
 				echo "[pulse-wrapper] _dispatch_ci_fix_worker: bounded infrastructure rerun unavailable for PR #${pr_number} check '${name}' — preserving PR for a later merge pass" >>"$LOGFILE"
 			fi
 		else
-			printf -- '- **%s**: %s — [check URL](%s)\n' "$name" "$conclusion" "$link"
+			context=""
+			case "$name" in
+			*"Smell Threshold"* | *"Absolute"*"Threshold"*)
+				context=" — contextual absolute baseline debt; PR-specific regression gates remain authoritative"
+				;;
+			esac
+			printf -- '- **%s**: %s — [check URL](%s)%s\n' "$name" "$conclusion" "$link" "$context"
 		fi
 		idx=$((idx + 1))
 	done
@@ -860,6 +866,47 @@ _ci_repair_result_retryable() {
 	return 0
 }
 
+_ci_repair_next_retry() {
+	printf 'retry_repair'
+	return 0
+}
+
+#######################################
+# Persist the sanitized terminal result of a repair worker before retrying it.
+# The metrics stream is append-only and may be written by another runner, so
+# only the exact session key is accepted and only bounded scalar fields survive.
+#######################################
+_ci_repair_record_terminal_outcome() {
+	local state_file="$1"
+	local session_key="$2"
+	local next_action="$3"
+	local metrics_file="${AIDEVOPS_CI_REPAIR_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+	local outcome='{}'
+	local tmp_file="${state_file}.terminal.$$"
+
+	[[ -f "$state_file" ]] || return 1
+	if [[ -f "$metrics_file" ]]; then
+		outcome=$(jq -Rsc --arg session "$session_key" '
+			[split("\n")[] | select(length > 0) | try fromjson catch empty
+			 | select((.session_key // "") == $session)] | last // {}
+			| {terminal_result: ((.result // "unknown") | tostring | gsub("[^A-Za-z0-9_.:-]"; "_") | .[0:80]),
+			   failure_reason: ((.failure_reason // "") | tostring | gsub("[^A-Za-z0-9_.:-]"; "_") | .[0:120]),
+			   exit_code: (if (.exit_code | type) == "number" then .exit_code else null end),
+			   quota_reset_at: ((.reset_at // .quota_reset_at // .retry_at // "") | tostring | gsub("[^A-Za-z0-9_.:+-]"; "") | .[0:80])}' \
+			"$metrics_file" 2>/dev/null) || outcome='{}'
+	fi
+	jq --argjson outcome "$outcome" --arg next_action "$next_action" --argjson terminal_at "$(date +%s 2>/dev/null || printf '0')" \
+		'. + $outcome + {terminal_at:$terminal_at,next_action:$next_action}' "$state_file" >"$tmp_file" 2>/dev/null || {
+		rm -f "$tmp_file"
+		return 1
+	}
+	mv "$tmp_file" "$state_file" 2>/dev/null || {
+		rm -f "$tmp_file"
+		return 1
+	}
+	return 0
+}
+
 #######################################
 # Atomically claim the first unconsumed bounded repair attempt.
 #######################################
@@ -1047,12 +1094,14 @@ _ci_repair_claim_lease() {
 		return 0
 	fi
 	if [[ "$claim_result" == "$exhausted_result" ]]; then
+		_ci_repair_record_terminal_outcome "$state_file" "$session_key" "route_feedback_fallback" || true
 		echo "[pulse-wrapper] _dispatch_ci_repair_session: stale repair exhausted ${max_attempts} attempts for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint}" >>"$LOGFILE"
 		printf '%s' "$exhausted_result"
 		return 0
 	fi
 	[[ "$claim_result" =~ ^[0-9]+$ ]] || return 1
 	next_attempt="$claim_result"
+		_ci_repair_record_terminal_outcome "$state_file" "$session_key" "$(_ci_repair_next_retry)" || true
 	if ! mv "$state_file" "${lease_dir}/state-attempt-${existing_attempt}.json" 2>/dev/null; then
 		printf '%s' "$active_result"
 		return 0
@@ -1406,6 +1455,7 @@ _dispatch_ci_repair_session() {
 	if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then
 		_ci_repair_write_state "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
 			"$failure_fingerprint" "" "0" "" "$attempt" "worktree_failed" "$session_key" || true
+		_ci_repair_record_terminal_outcome "${lease_dir}/state.json" "$session_key" "$(_ci_repair_next_retry)" || true
 		return 1
 	fi
 	_ci_repair_prepare_attempt "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
@@ -1416,6 +1466,7 @@ _dispatch_ci_repair_session() {
 		"$pr_head_ref" "$failure_fingerprint" "$failing_checks" || return 1
 	if ! _ci_repair_launch_worker "$lease_dir" "$helper" "$repo_slug" "$pr_number" "$linked_issue" \
 		"$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" "$prompt_file"; then
+		_ci_repair_record_terminal_outcome "${lease_dir}/state.json" "$session_key" "$(_ci_repair_next_retry)" || true
 		return 1
 	fi
 	_CI_REPAIR_DISPATCH_RESULT="$dispatched_status"

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -91,17 +91,19 @@ FIXTURE_BLOCKERS="${TMPDIR_TEST}/worker-progress-blockers.jsonl"
 FIXTURE_THREAD_STATE_DIR="${TMPDIR_TEST}/pr-review-thread-response"
 FIXTURE_DISPATCH_LEDGER="${TMPDIR_TEST}/dispatch-ledger.jsonl"
 FIXTURE_WORKTREE_REGISTRY="${TMPDIR_TEST}/worktree-registry.db"
+FIXTURE_CI_REPAIR_STATE_DIR="${TMPDIR_TEST}/ci-pr-repair"
 FIXTURE_ANCILLARY_REMOTE="${TMPDIR_TEST}/ancillary-remote.git"
 FIXTURE_ANCILLARY_WORKTREE="${TMPDIR_TEST}/ancillary-worktree"
 export PULSE_DIAGNOSE_BLOCKER_LOG="$FIXTURE_BLOCKERS"
 export PULSE_DIAGNOSE_THREAD_RESPONSE_STATE_DIR="$FIXTURE_THREAD_STATE_DIR"
 export PULSE_DIAGNOSE_DISPATCH_LEDGER_FILE="$FIXTURE_DISPATCH_LEDGER"
 export PULSE_DIAGNOSE_WORKTREE_REGISTRY_DB="$FIXTURE_WORKTREE_REGISTRY"
+export PULSE_DIAGNOSE_CI_REPAIR_STATE_DIR="$FIXTURE_CI_REPAIR_STATE_DIR"
 export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="$WRAPPER_GH_COOLDOWN"
 export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="$WRAPPER_GH_COOLDOWN_EVENTS"
 unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
 
-mkdir -p "$FIXTURE_THREAD_STATE_DIR"
+mkdir -p "$FIXTURE_THREAD_STATE_DIR" "$FIXTURE_CI_REPAIR_STATE_DIR"
 git init --bare -q "$FIXTURE_ANCILLARY_REMOTE"
 git clone -q "$FIXTURE_ANCILLARY_REMOTE" "$FIXTURE_ANCILLARY_WORKTREE" 2>/dev/null
 git -C "$FIXTURE_ANCILLARY_WORKTREE" config user.name "aidevops-test"
@@ -237,7 +239,7 @@ JSON
 fi
 if [[ "$*" == *"pr view"*"20340"* ]]; then
   cat <<'JSON'
-{"number":20340,"title":"t2711: add rate limit guard","state":"OPEN","author":{"login":"marcusquinn"},"mergedAt":null,"closedAt":null,"createdAt":"2026-04-21T18:50:00Z","labels":[{"name":"origin:worker"}],"reviewDecision":"","mergeStateStatus":"BLOCKED","headRefName":"feature/t2711","baseRefName":"main","isDraft":false}
+{"number":20340,"title":"t2711: add rate limit guard","state":"OPEN","author":{"login":"marcusquinn"},"mergedAt":null,"closedAt":null,"createdAt":"2026-04-21T18:50:00Z","labels":[{"name":"origin:worker"}],"reviewDecision":"","mergeStateStatus":"BLOCKED","headRefName":"feature/t2711","headRefOid":"abc20340remotehead","baseRefName":"main","isDraft":false}
 JSON
   exit 0
 fi
@@ -298,6 +300,18 @@ if [[ "$*" == *"api"*"issues/21860/comments"* ]]; then
   [[ "$*" == *"--paginate"*"--slurp"* ]] || exit 1
   cat <<'JSON'
 [[{"created_at":"2026-04-27T10:00:00Z","user":{"login":"alex-solovyev"},"body":"WORKER_BRANCH_ORPHAN: existing PR #21876 for branch feature/auto-20260427-gh21860 already open\n<!-- ops:start -->\nworker-orphan comment\n<!-- ops:end -->"},{"created_at":"2026-04-27T10:05:00Z","user":{"login":"alex-solovyev"},"body":"WORKER_BRANCH_ORPHAN: second re-dispatch attempt detected on same branch"},{"created_at":"2026-04-27T10:06:00Z","user":{"login":"marcusquinn"},"body":"CLAIM_RELEASED reason=worker_worktree_continuation_state_rejected runner=runner-a exit=1 session_count=0"},{"created_at":"2026-04-27T10:07:00Z","user":{"login":"marcusquinn"},"body":"CLAIM_RELEASED reason=worker_worktree_owner_concurrent_mutation runner=runner-a exit=1 session_count=0"},{"created_at":"2026-04-27T10:10:00Z","user":{"login":"marcusquinn"},"body":"Looks like the pulse is looping on this one"}]]
+JSON
+  exit 0
+fi
+if [[ "$*" == *"api"*"issues/20340/comments"* ]]; then
+  cat <<'JSON'
+[[{"created_at":"2026-04-21T19:01:00Z","author_association":"COLLABORATOR","user":{"login":"remote-runner"},"body":"## CI repair feedback routed to issue #20300\n<!-- feedback-route:start:ci:PR20340:SHAabc20340remotehead -->"}]]
+JSON
+  exit 0
+fi
+if [[ "$*" == *"api"*"issues/20300"* ]]; then
+  cat <<'JSON'
+{"state":"open","labels":[{"name":"status:available"},{"name":"source:ci-feedback"}],"body":"Repair queued.\n<!-- feedback-route:start:ci:PR20340:SHAabc20340remotehead -->\n<!-- feedback-route:complete:ci:PR20340:SHAabc20340remotehead -->"}
 JSON
   exit 0
 fi
@@ -447,6 +461,10 @@ assert_contains "shows ancillary attempts and outcome" "thread-response  attempt
 assert_contains "shows dead ancillary registry owner" "owner_status=dead" "$output"
 assert_contains "shows dirty ancillary worktree without inventing a blocker" "dirty_files=1  blocked_reason=" "$output"
 assert_contains "shows bounded dirty path evidence" "diagnostic.txt" "$output"
+assert_contains "shows durable remote CI feedback route" "remote route: kind=ci head=abc20340remotehead author=remote-runner complete=true" "$output"
+assert_contains "shows linked issue recovery state" "linked issue: #20300 state=open labels=status:available,source:ci-feedback" "$output"
+assert_contains "uses remote evidence when local repair logs are incomplete" "local repair: unavailable (remote evidence remains authoritative)" "$output"
+assert_contains "reports the remote recovery next action" "next action: reconcile_remote_route_and_linked_issue" "$output"
 
 sqlite3 "$FIXTURE_WORKTREE_REGISTRY" \
 	"UPDATE worktree_owners SET owner_session='unrelated-worker-session' WHERE worktree_path='${FIXTURE_ANCILLARY_WORKTREE}';"
@@ -456,6 +474,9 @@ output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
 	"$HELPER" pr 20340 --repo marcusquinn/aidevops --json 2>&1) || true
 assert_eq "JSON rejects mismatched ancillary registry ownership" "mismatch" "$(printf '%s' "$output" | jq -r '.ancillary.registry.owner_status')"
 assert_eq "JSON marks ancillary registry session mismatch" "false" "$(printf '%s' "$output" | jq -r '.ancillary.registry.matches_session')"
+assert_eq "JSON records remote route kind" "ci" "$(printf '%s' "$output" | jq -r '.ci_repair.remote_route.kind')"
+assert_eq "JSON records completed linked-issue recovery" "true" "$(printf '%s' "$output" | jq -r '.ci_repair.remote_route.complete')"
+assert_eq "JSON keeps missing local repair state explicit" "null" "$(printf '%s' "$output" | jq -r '.ci_repair.local_state')"
 sqlite3 "$FIXTURE_WORKTREE_REGISTRY" \
 	"UPDATE worktree_owners SET owner_session='pr-review-thread-response-marcusquinn-aidevops-20340' WHERE worktree_path='${FIXTURE_ANCILLARY_WORKTREE}';"
 

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -477,6 +477,8 @@ define_feedback_helpers() {
 		_ci_repair_result_active
 		_ci_repair_result_exhausted
 		_ci_repair_result_retryable
+		_ci_repair_next_retry
+		_ci_repair_record_terminal_outcome
 		_ci_repair_claim_next_attempt
 		_ci_repair_latest_archive
 		_ci_repair_prepare_attempt
@@ -1353,6 +1355,27 @@ test_ci_repair_waits_for_prelock_startup_before_retry() {
 	return 0
 }
 
+test_ci_repair_persists_sanitized_quota_terminal_outcome() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines terminal outcome helper" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local state_file="${TEST_ROOT}/repair-terminal.json"
+	local metrics_file="${TEST_ROOT}/repair-metrics.jsonl"
+	_ci_repair_write_state "$state_file" "owner/repo" "100" "$TEST_PR_HEAD_SHA" "feature/repair" \
+		"fingerprint" "${TEST_ROOT}/worktrees/repair" "999999" "stale" "1" "dispatched" "ci-repair-test"
+	printf '%s\n' '{"session_key":"ci-repair-test","result":"rate_limit","failure_reason":"quota exhausted; retry later","exit_code":143,"reset_at":"2026-08-21T18:00:00Z"}' >"$metrics_file"
+	AIDEVOPS_CI_REPAIR_METRICS_FILE="$metrics_file" _ci_repair_record_terminal_outcome \
+		"$state_file" "ci-repair-test" "retry_repair"
+
+	if ! jq -e '.terminal_result == "rate_limit" and .failure_reason == "quota_exhausted__retry_later" and .exit_code == 143 and .quota_reset_at == "2026-08-21T18:00:00Z" and .next_action == "retry_repair"' "$state_file" >/dev/null; then
+		print_result "CI repair terminal outcome is durable and sanitized" 1 "state=$(<"$state_file")"
+	else
+		print_result "CI repair persists terminal result, quota reset, and next action" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_ci_feedback_skips_advisory_failure_when_required_clean() {
 	setup_test_env
 	TEST_CHECK_SCENARIO="advisory_failure"
@@ -1432,6 +1455,7 @@ main() {
 	test_ci_repair_recovers_one_stale_lease_then_exhausts
 	test_ci_repair_consumes_abandoned_append_only_claim
 	test_ci_repair_waits_for_prelock_startup_before_retry
+	test_ci_repair_persists_sanitized_quota_terminal_outcome
 	test_ci_feedback_skips_advisory_failure_when_required_clean
 	test_missing_merge_gate_dependency_fails_harness
 

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -1330,6 +1330,46 @@ EOF
 	return 0
 }
 
+test_system_hold_records_exact_head_provenance() {
+	reset_mock_state
+	_PULSE_FEEDBACK_ROUTE_ACTIVE_KIND="review"
+	local hold_rc=0
+	_feedback_route_hold_for_maintainer "100" "owner/repo" "42" \
+		"PR ownership labels changed during finalization" || hold_rc=$?
+
+	if [[ "$hold_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]] \
+		|| ! jq -e 'any(.[]; (.body // "") | startswith("PULSE_ROUTE_HOLD kind=review reason=") and contains("automation=pulse") and contains("feedback-route:automation-hold:review:PR100:SHAabc123repairsha"))' \
+			"${TEST_ROOT}/issue-comments.json" >/dev/null; then
+		print_result "system-created hold records exact-head route provenance" 1 \
+			"rc=${hold_rc}; comments=$(<"${TEST_ROOT}/issue-comments.json")"
+		return 0
+	fi
+	print_result "system-created hold records route kind, reason, automation, and exact head" 0
+	return 0
+}
+
+test_human_hold_is_never_claimed_or_cleared_by_automation() {
+	reset_mock_state
+	printf 'status:in-review,origin:worker,hold-for-review\n' >"${TEST_ROOT}/issue-labels.txt"
+	printf 'origin:worker,hold-for-review\n' >"${TEST_ROOT}/pr-labels.txt"
+	_PULSE_FEEDBACK_ROUTE_ACTIVE_KIND="ci"
+	_feedback_route_hold_for_maintainer "100" "owner/repo" "42" "ci route needs review" >/dev/null 2>&1 || true
+	local transition_rc=0
+	_feedback_route_transition_and_verify "42" "owner/repo" "source:ci-feedback" 1 \
+		"100" "ci" "abc123repairsha" || transition_rc=$?
+
+	if [[ "$transition_rc" -eq 0 ]] \
+		|| [[ "$(<"${TEST_ROOT}/issue-labels.txt")" != *"hold-for-review"* ]] \
+		|| [[ "$(<"${TEST_ROOT}/pr-labels.txt")" != *"hold-for-review"* ]] \
+		|| jq -e 'any(.[]; (.body // "") | contains("feedback-route:automation-hold"))' "${TEST_ROOT}/issue-comments.json" >/dev/null; then
+		print_result "human hold is never claimed or cleared by automation" 1 \
+			"transition_rc=${transition_rc}; issue_labels=$(<"${TEST_ROOT}/issue-labels.txt"); comments=$(<"${TEST_ROOT}/issue-comments.json")"
+		return 0
+	fi
+	print_result "human hold remains authoritative without automation provenance" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -1369,6 +1409,8 @@ main() {
 	test_dispatch_clears_in_progress_labels_as_fallback
 	test_ci_dispatch_dedupes_by_pr_head_marker
 	test_feedback_release_reconciles_cross_runner_duplicates
+	test_system_hold_records_exact_head_provenance
+	test_human_hold_is_never_claimed_or_cleared_by_automation
 	test_dispatch_skips_body_edit_on_issue_view_failure
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Reconcile trusted exact-head GitHub feedback routes with local CI repair state, persist sanitized worker terminal outcomes and quota resets, annotate contextual absolute baseline debt, and preserve human holds through explicit automation provenance.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: all three focused shell suites passed (141 diagnose, 39 CI repair, 33 feedback-finalizer tests); ShellCheck passed on all six changed shell files; .agents/scripts/linters-local.sh --changed passed

Resolves #30533


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.282 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 24m and 259,095 tokens on this as a headless worker.