### PR TITLE
GH#30546: bound stats GitHub operations

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -168,9 +168,10 @@ _gh_audit_fetch_issue_state_json() {
 	fi
 	# REST-first routing can be locally unavailable while GitHub's GraphQL
 	# transport remains healthy. Audit capture must try the independent native
-	# read before declaring the state unavailable.
+	# read before declaring the state unavailable, while preserving the caller's
+	# aggregate deadline and the standard per-read timeout.
 	if [[ -z "$data" ]]; then
-		data=$(gh issue view "$issue_num" --repo "$repo" \
+		data=$(_gh_with_timeout read gh issue view "$issue_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
 	# The routed wrapper's fallback decision can itself be stale or unavailable.
@@ -220,9 +221,10 @@ _gh_audit_fetch_pr_state_json() {
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
 	# Mirror issue capture: a failed REST-capable wrapper is not proof that the
-	# native GraphQL read is unavailable.
+	# native GraphQL read is unavailable. Keep this independent transport bounded
+	# by the same timeout and aggregate-deadline path as issue capture.
 	if [[ -z "$data" ]]; then
-		data=$(gh pr view "$pr_num" --repo "$repo" \
+		data=$(_gh_with_timeout read gh pr view "$pr_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
 	if [[ -z "$data" ]] && command -v _rest_pr_view >/dev/null 2>&1; then

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -221,13 +221,13 @@ _cache_health_issue_number() {
 #   $1 - health issue number
 #   $2 - repo slug
 #   $3 - rendered issue body
-# Returns: 0 on success, 1 when the body edit fails
+# Returns: 0 on success, wrapped command status when the body edit fails
 #######################################
 _update_health_issue_body_or_fail() {
 	local health_issue_number="$1"
 	local repo_slug="$2"
 	local body="$3"
-	local body_edit_stderr sanitized_body=""
+	local body_edit_stderr sanitized_body="" body_edit_ec=0
 
 	# Health dashboards aggregate helper output from many local repositories.
 	# Sanitize that output before the public write rather than letting one local
@@ -245,11 +245,12 @@ _update_health_issue_body_or_fail() {
 	# update when the 5000/hr GraphQL budget is exhausted, leaving the
 	# dashboard stale until the budget resets (up to 1h). GH#33.
 	body_edit_stderr=$(_gh_with_timeout write gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
-		--body "$sanitized_body" 2>&1 >/dev/null) || {
+		--body "$sanitized_body" 2>&1 >/dev/null) || body_edit_ec=$?
+	if [[ "$body_edit_ec" -ne 0 ]]; then
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
 			>>"${LOGFILE:-/dev/null}"
-		return 1
-	}
+		return "$body_edit_ec"
+	fi
 	return 0
 }
 
@@ -304,7 +305,7 @@ _refresh_health_issue_title_from_body() {
 #   $3 - cross-repo activity markdown (pre-computed by update_health_issues)
 #   $4 - cross-repo session time markdown (pre-computed by update_health_issues)
 #   $5 - cross-repo person stats markdown (pre-computed by update_health_issues)
-# Returns: 0 when refreshed/skipped, 1 when an existing dashboard update fails
+# Returns: 0 when refreshed/skipped, wrapped status when an existing update fails
 #######################################
 _update_health_issue_for_repo() {
 	local repo_slug="$1"
@@ -367,7 +368,9 @@ _update_health_issue_for_repo() {
 		"$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" \
 		"$canonical_identity" "$identity_aliases")
 
-	_update_health_issue_body_or_fail "$health_issue_number" "$repo_slug" "$body" || return 1
+	local body_update_ec=0
+	_update_health_issue_body_or_fail "$health_issue_number" "$repo_slug" "$body" || body_update_ec=$?
+	[[ "$body_update_ec" -ne 0 ]] && return "$body_update_ec"
 	_refresh_health_issue_title_from_body \
 		"$health_issue_number" "$repo_slug" "$runner_prefix" "$body" "$now_iso"
 	_record_health_issue_refresh_state "$health_issue_file" "$activity_state"
@@ -454,16 +457,19 @@ _prioritize_health_repo_entries() {
 #######################################
 _refresh_priority_health_issue() {
 	local repo_entries="$1"
-	local priority_entry="" priority_slug="" priority_path=""
+	local priority_entry="" priority_slug="" priority_path="" update_ec=0
 
 	priority_entry=$(printf '%s\n' "$repo_entries" | awk 'NR == 1 { print; exit }')
 	[[ -z "$priority_entry" ]] && return 0
 	IFS='|' read -r priority_slug priority_path <<<"$priority_entry"
-	if ! _update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" ""; then
-		echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
-		return 1
-	fi
+	# Emit the attempted slug even on failure so the best-effort caller can skip
+	# an immediate retry while continuing with the remaining repositories.
 	printf '%s\n' "$priority_slug"
+	_update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" "" || update_ec=$?
+	if [[ "$update_ec" -ne 0 ]]; then
+		echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
+		return "$update_ec"
+	fi
 	return 0
 }
 
@@ -578,10 +584,22 @@ update_health_issues() {
 
 	local refresh_start_epoch
 	refresh_start_epoch=$(date +%s)
-	local priority_slug=""
-	priority_slug=$(_refresh_priority_health_issue "$repo_entries") || return 1
+	local priority_slug="" priority_updated=0 updated=0 deferred=0 failed=0 update_ec=0
+	priority_slug=$(_refresh_priority_health_issue "$repo_entries") || update_ec=$?
+	if [[ "$update_ec" -eq 0 ]]; then
+		[[ -n "$priority_slug" ]] && priority_updated=1
+	elif [[ "$update_ec" -eq 75 || "$update_ec" -eq 124 ]]; then
+		deferred=$((deferred + 1))
+	else
+		failed=$((failed + 1))
+	fi
 	if ! _health_dashboard_optional_work_has_budget "$refresh_start_epoch"; then
 		echo "[stats] Health dashboard optional cross-repo work skipped after priority refresh exhausted its time budget" >>"$LOGFILE"
+		if [[ "$failed" -gt 0 ]]; then
+			echo "[stats] Health issues: failed $failed repo(s)" >>"$LOGFILE"
+			return 1
+		fi
+		[[ "$deferred" -gt 0 ]] && echo "[stats] Health issues: deferred $deferred repo(s)" >>"$LOGFILE"
 		return 0
 	fi
 
@@ -594,12 +612,17 @@ update_health_issues() {
 	_build_cross_repo_health_summaries "$repo_entries" \
 		cross_repo_md cross_repo_session_time_md cross_repo_person_stats_md
 
-	local updated=0
-	local failed=0
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
 		[[ "$slug" == "${priority_slug:-}" ]] && continue
-		if ! _update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md"; then
+		update_ec=0
+		_update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" || update_ec=$?
+		if [[ "$update_ec" -eq 75 || "$update_ec" -eq 124 ]]; then
+			echo "[stats] Health issue update deferred for ${slug} (rc=${update_ec})" >>"$LOGFILE"
+			deferred=$((deferred + 1))
+			continue
+		fi
+		if [[ "$update_ec" -ne 0 ]]; then
 			echo "[stats] Health issue update failed for ${slug}" >>"$LOGFILE"
 			failed=$((failed + 1))
 			continue
@@ -607,10 +630,11 @@ update_health_issues() {
 		updated=$((updated + 1))
 	done <<<"$repo_entries"
 
-	[[ -n "$priority_slug" ]] && updated=$((updated + 1))
+	[[ "$priority_updated" -eq 1 ]] && updated=$((updated + 1))
 	if [[ "$updated" -gt 0 ]]; then
 		echo "[stats] Health issues: updated $updated repo(s)" >>"$LOGFILE"
 	fi
+	[[ "$deferred" -gt 0 ]] && echo "[stats] Health issues: deferred $deferred repo(s)" >>"$LOGFILE"
 	if [[ "$failed" -gt 0 ]]; then
 		echo "[stats] Health issues: failed $failed repo(s)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -235,9 +235,14 @@ _stats_wrapper_run_work() {
 }
 
 _stats_wrapper_run_with_timeout() {
-	local start_epoch="" now="" elapsed="" child_pid=""
+	local start_epoch="" now="" elapsed="" child_pid="" gh_deadline_epoch=""
 	start_epoch=$(date +%s)
-	_stats_wrapper_run_work &
+	# Leave enough time for the outer process-tree cleanup while ensuring every
+	# nested gh wrapper—including shell-function writes—shares this invocation's
+	# aggregate budget. Without a deadline, _gh_with_timeout intentionally calls
+	# shell functions directly for zsh compatibility.
+	gh_deadline_epoch=$((start_epoch + STATS_TIMEOUT - 30))
+	AIDEVOPS_GH_DEADLINE_EPOCH="$gh_deadline_epoch" _stats_wrapper_run_work &
 	child_pid=$!
 
 	while kill -0 "$child_pid" 2>/dev/null; do

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -121,6 +121,14 @@ GH_AUDIT_LOG_FILE="$MALFORMED_LOG" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/malformed
 source "$SAFE_EDIT_HELPER"
 PROOF_LOG="${TEST_ROOT}/proof-audit.log"
 export GH_AUDIT_LOG_FILE="$PROOF_LOG"
+GH_TIMEOUT_TRACE="${TEST_ROOT}/gh-timeout-calls.log"
+_gh_with_timeout() {
+	local op_class="$1"
+	shift
+	printf '%s|%s\n' "$op_class" "$*" >>"$GH_TIMEOUT_TRACE"
+	"$@"
+	return $?
+}
 cmd_verify() {
 	local target_type="${1:-}"
 	local target_number="${2:-}"
@@ -309,6 +317,10 @@ jq -e '.capture_status == "ok" and .title_len == 21 and .body_len == 14 and .lab
 	<<<"$native_fallback_issue" >/dev/null || fail "issue audit capture did not fall back after the REST-capable wrapper failed"
 jq -e '.capture_status == "ok" and .title_len == 18 and .body_len == 14 and .labels == ["monitoring"]' \
 	<<<"$native_fallback_pr" >/dev/null || fail "PR audit capture did not fall back after the REST-capable wrapper failed"
+grep -Fqx 'read|gh issue view 8 --repo example/repo --json title,body,labels' "$GH_TIMEOUT_TRACE" ||
+	fail "native issue audit fallback bypassed _gh_with_timeout"
+grep -Fqx 'read|gh pr view 9 --repo example/repo --json title,body,labels' "$GH_TIMEOUT_TRACE" ||
+	fail "native PR audit fallback bypassed _gh_with_timeout"
 
 gh() {
 	return 1

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -241,7 +241,7 @@ MOCK_STATS_FUNCTIONS
 test_priority_dashboard_precedes_optional_cross_repo_work() {
 	local dashboard_script priority_line cache_line
 	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
-	priority_line=$(grep -nE "^[[:space:]]*priority_slug=[\$]\(_refresh_priority_health_issue \"[\$]repo_entries\"\)" "$dashboard_script" | head -1 | cut -d: -f1)
+	priority_line=$(grep -nE "^[[:space:]]*(if[[:space:]]+)?priority_slug=[\$]\(_refresh_priority_health_issue \"[\$]repo_entries\"\)" "$dashboard_script" | head -1 | cut -d: -f1)
 	cache_line=$(grep -nE '^[[:space:]]*_refresh_person_stats_cache \|\| true' "$dashboard_script" | head -1 | cut -d: -f1)
 	if [[ -n "$priority_line" && -n "$cache_line" && "$priority_line" -lt "$cache_line" ]]; then
 		print_result "priority dashboard refresh precedes optional cross-repo work" 0
@@ -249,6 +249,30 @@ test_priority_dashboard_precedes_optional_cross_repo_work() {
 	fi
 	print_result "priority dashboard refresh precedes optional cross-repo work" 1 \
 		"Expected priority update before person-stats refresh; priority_line=${priority_line:-<missing>} cache_line=${cache_line:-<missing>}"
+	return 0
+}
+
+test_priority_failure_continues_remaining_repos() {
+	local production_snippet
+	production_snippet=$(awk '
+		/^update_health_issues\(\) \{/ { in_production=1 }
+		in_production { print }
+		in_production && /^}$/ { exit }
+	' "$HEALTH_DASHBOARD_SCRIPT")
+	if printf '%s' "$production_snippet" | grep -qE 'priority_slug=[\$]\(_refresh_priority_health_issue "[\$]repo_entries"\)[[:space:]]*\|\|[[:space:]]*return 1'; then
+		print_result "priority dashboard failure does not abort remaining repos" 1 \
+			"Priority refresh still returns before the best-effort repository loop"
+		return 0
+	fi
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*priority_slug=[\$]\(_refresh_priority_health_issue "[\$]repo_entries"\)[[:space:]]*\|\|[[:space:]]*update_ec=[\$][?]' &&
+		printf '%s' "$production_snippet" | grep -qE 'update_ec" -eq 75 \|\| "[\$]update_ec" -eq 124' &&
+		printf '%s' "$production_snippet" | grep -qF "failed=\$((failed + 1))" &&
+		printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*while IFS='; then
+		print_result "priority dashboard failure does not abort remaining repos" 0
+		return 0
+	fi
+	print_result "priority dashboard failure does not abort remaining repos" 1 \
+		"Expected a counted priority failure followed by the best-effort repository loop"
 	return 0
 }
 
@@ -332,9 +356,8 @@ test_transient_dashboard_tempfail_is_deferred() {
 	return 0
 }
 
-# Test 9: the dashboard updater itself must return non-zero when the body edit
-# fails, otherwise the wrapper's direct update_health_issues call still exits 0
-# and the HEALTH-DASHBOARD-FAIL trap never fires.
+# Test 9: the dashboard updater must preserve the wrapped body-edit status so
+# callers can defer transient timeouts while propagating genuine failures.
 test_dashboard_body_edit_failure_returns_nonzero() {
 	local failure_snippet
 	failure_snippet=$(awk '
@@ -342,12 +365,12 @@ test_dashboard_body_edit_failure_returns_nonzero() {
 		in_failure { print }
 		in_failure && /^[[:space:]]*}/ { exit }
 	' "$HEALTH_DASHBOARD_SCRIPT")
-	if printf '%s' "$failure_snippet" | grep -qE '^[[:space:]]*return 1[[:space:]]*$'; then
-		print_result "dashboard body edit failures return non-zero" 0
+	if printf '%s' "$failure_snippet" | grep -qE '^[[:space:]]*return "[$]body_edit_ec"[[:space:]]*$'; then
+		print_result "dashboard body edit failures preserve non-zero status" 0
 		return 0
 	fi
-	print_result "dashboard body edit failures return non-zero" 1 \
-		"Expected _update_health_issue_for_repo body-edit failure block to return 1"
+	print_result "dashboard body edit failures preserve non-zero status" 1 \
+		"Expected the body-edit failure block to return its wrapped command status"
 	return 0
 }
 
@@ -359,6 +382,7 @@ main_test() {
 	test_health_update_precedes_quality_sweep
 	test_health_update_survives_slow_quality_sweep
 	test_priority_dashboard_precedes_optional_cross_repo_work
+	test_priority_failure_continues_remaining_repos
 	test_slow_priority_dashboard_skips_optional_cross_repo_work
 	test_dashboard_freshness_precedes_maintenance
 	test_dashboard_update_failure_not_swallowed

--- a/.agents/scripts/tests/test-stats-wrapper-timeout.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-timeout.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression tests for GH#29836: stats-wrapper.sh must enforce its hard
-# ceiling within the current scheduler invocation and preserve successor PID
-# ownership during EXIT-trap cleanup.
+# Regression tests for GH#29836 and GH#30546: stats-wrapper.sh must enforce its
+# hard ceiling within the current scheduler invocation, propagate an aggregate
+# GitHub deadline, and preserve successor PID ownership during EXIT cleanup.
 
 set -uo pipefail
 
@@ -41,7 +41,10 @@ source "$WRAPPER_SCRIPT"
 STATS_PIDFILE="\$1/stats.pid"
 STATS_LOGFILE="\$1/stats.log"
 HARNESS_TEMP_DIR="\$1"
-STATS_TIMEOUT=1
+case "$mode" in
+deadline | function-timeout) STATS_TIMEOUT=60 ;;
+*) STATS_TIMEOUT=1 ;;
+esac
 _stats_wrapper_run_work() {
 	case "$mode" in
 	timeout)
@@ -51,7 +54,19 @@ _stats_wrapper_run_work() {
 	normal)
 		return 0
 		;;
+	deadline)
+		printf '%s\n' "\${AIDEVOPS_GH_DEADLINE_EPOCH:-}" >"\$HARNESS_TEMP_DIR/gh-deadline"
+		return 0
+		;;
+	function-timeout)
+		AIDEVOPS_GH_WRITE_TIMEOUT=1 _gh_with_timeout write _stats_test_slow_function
+		return \$?
+		;;
 	esac
+	return 0
+}
+_stats_test_slow_function() {
+	sleep 30
 	return 0
 }
 main
@@ -128,10 +143,52 @@ test_cleanup_preserves_successor_pidfile() {
 	return 0
 }
 
+test_stats_child_receives_aggregate_gh_deadline() {
+	local temp_dir="" rc="" deadline="" now=""
+	temp_dir=$(run_harness deadline) || {
+		fail "deadline harness starts" "could not create harness"
+		return 0
+	}
+	rc=$(<"$temp_dir/rc")
+	deadline=$(<"$temp_dir/gh-deadline")
+	now=$(date +%s)
+	if [[ "$rc" -ne 0 ]]; then
+		fail "stats child receives aggregate GitHub deadline" "got rc=$rc"
+	elif [[ ! "$deadline" =~ ^[0-9]+$ ]]; then
+		fail "stats child receives aggregate GitHub deadline" "deadline is not numeric: $deadline"
+	elif [[ "$deadline" -le "$now" || "$deadline" -gt $((now + 35)) ]]; then
+		fail "stats child receives aggregate GitHub deadline" "deadline $deadline is outside the reserved budget"
+	else
+		pass "stats child receives aggregate GitHub deadline"
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
+test_function_write_times_out_before_outer_ceiling() {
+	local temp_dir="" rc=""
+	temp_dir=$(run_harness function-timeout) || {
+		fail "function-timeout harness starts" "could not create harness"
+		return 0
+	}
+	rc=$(<"$temp_dir/rc")
+	if [[ "$rc" -ne 124 ]]; then
+		fail "function write respects per-operation timeout" "got rc=$rc"
+	elif grep -q 'STATS-TIMEOUT' "$temp_dir/stats.log"; then
+		fail "function write respects per-operation timeout" "outer stats ceiling fired"
+	else
+		pass "function write respects per-operation timeout"
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
 main_test() {
 	test_timeout_kills_work_and_cleans_pidfile
 	test_normal_completion_cleans_pidfile
 	test_cleanup_preserves_successor_pidfile
+	test_stats_child_receives_aggregate_gh_deadline
+	test_function_write_times_out_before_outer_ceiling
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Propagate an aggregate GitHub deadline through stats refreshes, bound native audit fallbacks, and continue best-effort dashboard updates after transient per-repository timeouts.

## Files Changed

.agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/stats-health-dashboard.sh, .agents/scripts/stats-wrapper.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh, .agents/scripts/tests/test-stats-wrapper-headless-export.sh, .agents/scripts/tests/test-stats-wrapper-timeout.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local linters passed; focused stats timeout, dashboard, audit fallback, sentinel, quality sweep, characterization, self-check, and dry-run checks passed.

Resolves #30546


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.284 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 26m and 657,651 tokens on this with the user in an interactive session.